### PR TITLE
refactor: deduplicate boilerplate across commands, client, and tests

### DIFF
--- a/internal/client/catalog_test.go
+++ b/internal/client/catalog_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/major/marketsurge-agent/internal/constants"
@@ -15,16 +14,11 @@ import (
 
 func TestRunReportSuccess(t *testing.T) {
 	var captured Request
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
 		_, _ = w.Write([]byte(adhocResponseJSON()))
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 
 	data, err := client.RunReport(context.Background(), 124)
 	require.NoError(t, err)
@@ -35,7 +29,7 @@ func TestRunReportSuccess(t *testing.T) {
 
 func TestRunWatchlistTwoStepFlow(t *testing.T) {
 	requests := []Request{}
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		var payload Request
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
@@ -45,12 +39,7 @@ func TestRunWatchlistTwoStepFlow(t *testing.T) {
 			return
 		}
 		_, _ = w.Write([]byte(adhocResponseJSON()))
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 
 	data, err := client.RunWatchlist(context.Background(), 922337203685477580)
 	require.NoError(t, err)
@@ -64,14 +53,9 @@ func TestRunWatchlistTwoStepFlow(t *testing.T) {
 }
 
 func TestRunWatchlistReturnsEmptyForNoSymbols(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"watchlist":{"id":"123","items":[]}}}`))
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 
 	data, err := client.RunWatchlist(context.Background(), 123)
 	require.NoError(t, err)
@@ -79,14 +63,9 @@ func TestRunWatchlistReturnsEmptyForNoSymbols(t *testing.T) {
 }
 
 func TestRunWatchlistReturnsNotFoundWhenMissing(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"watchlist":null}}`))
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 
 	_, err := client.RunWatchlist(context.Background(), 123)
 	require.Error(t, err)
@@ -94,14 +73,9 @@ func TestRunWatchlistReturnsNotFoundWhenMissing(t *testing.T) {
 }
 
 func TestRunCoachScreenSuccess(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"user":{"runScreen":{"numberOfMatchingInstruments":2,"responseValues":[[{"mdItem":{"name":"Symbol"},"value":"AAPL"}]]}}}}`))
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 
 	data, err := client.RunCoachScreen(context.Background(), "screen-1")
 	require.NoError(t, err)
@@ -110,14 +84,9 @@ func TestRunCoachScreenSuccess(t *testing.T) {
 }
 
 func TestRunCoachScreenReturnsAPIErrorForMissingPayload(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"user":{}}}`))
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 
 	_, err := client.RunCoachScreen(context.Background(), "screen-1")
 	require.Error(t, err)
@@ -125,7 +94,7 @@ func TestRunCoachScreenReturnsAPIErrorForMissingPayload(t *testing.T) {
 }
 
 func TestListCatalogAggregatesAllSources(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		var payload Request
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
@@ -139,12 +108,7 @@ func TestListCatalogAggregatesAllSources(t *testing.T) {
 		default:
 			t.Fatalf("unexpected operation %s", payload.OperationName)
 		}
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 
 	catalog, err := client.ListCatalog(context.Background(), nil)
 	require.NoError(t, err)
@@ -155,18 +119,13 @@ func TestListCatalogAggregatesAllSources(t *testing.T) {
 
 func TestListCatalogReportFilterSkipsRemoteSources(t *testing.T) {
 	requests := []string{}
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		var payload Request
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
 		requests = append(requests, payload.OperationName)
 		_, _ = w.Write([]byte(`{"data":{}}`))
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 	kind := models.CatalogKindReport
 
 	catalog, err := client.ListCatalog(context.Background(), &kind)
@@ -177,7 +136,7 @@ func TestListCatalogReportFilterSkipsRemoteSources(t *testing.T) {
 }
 
 func TestListCatalogPartialFailure(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		var payload Request
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
@@ -190,12 +149,7 @@ func TestListCatalogPartialFailure(t *testing.T) {
 			return
 		}
 		_, _ = w.Write([]byte(`{"data":{"user":{"screens":[],"watchlists":[]}}}`))
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 
 	catalog, err := client.ListCatalog(context.Background(), nil)
 	require.NoError(t, err)
@@ -205,7 +159,7 @@ func TestListCatalogPartialFailure(t *testing.T) {
 }
 
 func TestListCatalogFiltersKind(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		var payload Request
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
@@ -217,12 +171,7 @@ func TestListCatalogFiltersKind(t *testing.T) {
 		case "CoachTree":
 			_, _ = w.Write([]byte(`{"data":{"user":{"screens":[],"watchlists":[]}}}`))
 		}
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 	kind := models.CatalogKindReport
 
 	catalog, err := client.ListCatalog(context.Background(), &kind)
@@ -235,14 +184,9 @@ func TestListCatalogFiltersKind(t *testing.T) {
 }
 
 func TestParseAdhocScreenResultIncludesErrorValues(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"marketDataAdhocScreen":{"responseValues":[],"errorValues":["bad symbol"]}}}`))
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 
 	data, err := client.RunReport(context.Background(), 124)
 	require.NoError(t, err)
@@ -250,14 +194,9 @@ func TestParseAdhocScreenResultIncludesErrorValues(t *testing.T) {
 }
 
 func TestParseAdhocScreenResultMapsFields(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(adhocResponseJSON()))
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 
 	data, err := client.RunReport(context.Background(), 124)
 	require.NoError(t, err)

--- a/internal/client/chart.go
+++ b/internal/client/chart.go
@@ -99,47 +99,38 @@ func buildTimeSeries(item map[string]any) *models.TimeSeries {
 	if len(item) == 0 {
 		return nil
 	}
-	result := &models.TimeSeries{Period: stringify(item["period"]), DataPoints: []models.DataPoint{}}
-	for _, entry := range getNestedSlice(item, "dataPoints") {
-		point, ok := entry.(map[string]any)
-		if !ok {
-			continue
-		}
-		result.DataPoints = append(result.DataPoints, models.DataPoint{
-			StartDateTime: stringPtr(point["startDateTime"]),
-			EndDateTime:   stringPtr(point["endDateTime"]),
-			Open:          floatPtr(point["open"]),
-			High:          floatPtr(point["high"]),
-			Low:           floatPtr(point["low"]),
-			Close:         floatPtr(point["last"]),
-			Volume:        floatPtr(point["volume"]),
-		})
+	return &models.TimeSeries{
+		Period: stringify(item["period"]),
+		DataPoints: buildSlice(getNestedSlice(item, "dataPoints"), func(point map[string]any) models.DataPoint {
+			return models.DataPoint{
+				StartDateTime: stringPtr(point["startDateTime"]),
+				EndDateTime:   stringPtr(point["endDateTime"]),
+				Open:          floatPtr(point["open"]),
+				High:          floatPtr(point["high"]),
+				Low:           floatPtr(point["low"]),
+				Close:         floatPtr(point["last"]),
+				Volume:        floatPtr(point["volume"]),
+			}
+		}),
 	}
-	return result
 }
 
 func buildExchange(item map[string]any) *models.ExchangeInfo {
 	if len(item) == 0 {
 		return nil
 	}
-	result := &models.ExchangeInfo{
+	return &models.ExchangeInfo{
 		City:        stringPtr(item["city"]),
 		CountryCode: stringPtr(item["countryCode"]),
 		ExchangeISO: stringPtr(item["exchangeISO"]),
-		Holidays:    []models.ExchangeHoliday{},
+		Holidays: buildSlice(getNestedSlice(item, "holidays"), func(holiday map[string]any) models.ExchangeHoliday {
+			return models.ExchangeHoliday{
+				Name:          stringify(holiday["name"]),
+				HolidayType:   stringPtr(holiday["holidayType"]),
+				Description:   stringPtr(holiday["description"]),
+				StartDateTime: stringify(holiday["startDateTime"]),
+				EndDateTime:   stringify(holiday["endDateTime"]),
+			}
+		}),
 	}
-	for _, entry := range getNestedSlice(item, "holidays") {
-		holiday, ok := entry.(map[string]any)
-		if !ok {
-			continue
-		}
-		result.Holidays = append(result.Holidays, models.ExchangeHoliday{
-			Name:          stringify(holiday["name"]),
-			HolidayType:   stringPtr(holiday["holidayType"]),
-			Description:   stringPtr(holiday["description"]),
-			StartDateTime: stringify(holiday["startDateTime"]),
-			EndDateTime:   stringify(holiday["endDateTime"]),
-		})
-	}
-	return result
 }

--- a/internal/client/chart_markups.go
+++ b/internal/client/chart_markups.go
@@ -29,21 +29,18 @@ func (c *Client) GetChartMarkups(ctx context.Context, symbol, frequency, sortDir
 	}
 
 	container := getNestedMap(raw, "data", "user", "chartMarkups")
-	result := &models.ChartMarkupList{CursorID: stringify(container["cursorId"]), Markups: []models.ChartMarkup{}}
-	for _, entry := range getNestedSlice(container, "chartMarkups") {
-		item, ok := entry.(map[string]any)
-		if !ok {
-			continue
-		}
-		result.Markups = append(result.Markups, models.ChartMarkup{
-			ID:        stringify(item["id"]),
-			Name:      stringPtr(item["name"]),
-			Data:      stringify(item["data"]),
-			Frequency: stringPtr(item["frequency"]),
-			Site:      stringPtr(item["site"]),
-			CreatedAt: stringPtr(item["createdAt"]),
-			UpdatedAt: stringPtr(item["updatedAt"]),
-		})
-	}
-	return result, nil
+	return &models.ChartMarkupList{
+		CursorID: stringify(container["cursorId"]),
+		Markups: buildSlice(getNestedSlice(container, "chartMarkups"), func(item map[string]any) models.ChartMarkup {
+			return models.ChartMarkup{
+				ID:        stringify(item["id"]),
+				Name:      stringPtr(item["name"]),
+				Data:      stringify(item["data"]),
+				Frequency: stringPtr(item["frequency"]),
+				Site:      stringPtr(item["site"]),
+				CreatedAt: stringPtr(item["createdAt"]),
+				UpdatedAt: stringPtr(item["updatedAt"]),
+			}
+		}),
+	}, nil
 }

--- a/internal/client/chart_test.go
+++ b/internal/client/chart_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,16 +12,11 @@ import (
 
 func TestGetChartHistoryDailyIncludesExchangeAndBenchmark(t *testing.T) {
 	var captured Request
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
 		_, _ = w.Write([]byte(chartResponseJSON(true)))
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 
 	data, err := client.GetChartHistory(context.Background(), "AAPL", "2024-01-01", "2024-02-01", "P1D", true, "NYSE", "0S&P5")
 	require.NoError(t, err)
@@ -35,16 +29,11 @@ func TestGetChartHistoryDailyIncludesExchangeAndBenchmark(t *testing.T) {
 
 func TestGetChartHistoryWeeklyOmitsExchange(t *testing.T) {
 	var captured Request
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
 		_, _ = w.Write([]byte(chartResponseJSON(false)))
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 
 	data, err := client.GetChartHistory(context.Background(), "AAPL", "2024-01-01", "2024-02-01", "P1W", false, "", "")
 	require.NoError(t, err)
@@ -55,14 +44,9 @@ func TestGetChartHistoryWeeklyOmitsExchange(t *testing.T) {
 }
 
 func TestGetChartMarkupsSuccess(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"user":{"chartMarkups":{"cursorId":"cursor-1","chartMarkups":[{"id":"m1","name":"Base","data":"{}","frequency":"DAILY","site":"marketsurge"}]}}}}`))
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 
 	data, err := client.GetChartMarkups(context.Background(), "DJ:1", "DAILY", "ASC")
 	require.NoError(t, err)
@@ -73,16 +57,11 @@ func TestGetChartMarkupsSuccess(t *testing.T) {
 
 func TestGetChartMarkupsPassesOperationName(t *testing.T) {
 	var captured Request
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
 		_, _ = w.Write([]byte(`{"data":{"user":{"chartMarkups":{"cursorId":"","chartMarkups":[]}}}}`))
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 
 	_, err := client.GetChartMarkups(context.Background(), "DJ:1", "WEEKLY", "DESC")
 	require.NoError(t, err)
@@ -92,14 +71,9 @@ func TestGetChartMarkupsPassesOperationName(t *testing.T) {
 }
 
 func TestGetChartHistoryReturnsSymbolNotFound(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"marketData":[]}}`))
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 
 	_, err := client.GetChartHistory(context.Background(), "MISS", "2024-01-01", "2024-02-01", "P1D", true, "NYSE", "")
 	require.Error(t, err)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	mserrors "github.com/major/marketsurge-agent/internal/errors"
@@ -22,7 +21,7 @@ func TestNewClientDefaults(t *testing.T) {
 
 func TestExecuteSetsHeadersAndAuthorization(t *testing.T) {
 	var captured Request
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		require.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "Bearer jwt-token", r.Header.Get("Authorization"))
@@ -31,12 +30,7 @@ func TestExecuteSetsHeadersAndAuthorization(t *testing.T) {
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":{"ok":true}}`))
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 
 	raw, err := client.Execute(context.Background(), Request{OperationName: "TestOp", Variables: map[string]any{"value": "x"}, Query: "query TestOp { ok }"})
 	require.NoError(t, err)
@@ -46,15 +40,10 @@ func TestExecuteSetsHeadersAndAuthorization(t *testing.T) {
 }
 
 func TestExecuteReturnsGraphQLErrorOnHTTP200(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"errors":[{"message":"bad request"}]}`))
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 
 	_, err := client.Execute(context.Background(), Request{})
 	var apiErr *mserrors.APIError
@@ -64,14 +53,9 @@ func TestExecuteReturnsGraphQLErrorOnHTTP200(t *testing.T) {
 }
 
 func TestExecuteReturnsTokenExpiredErrorOn401(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "nope", http.StatusUnauthorized)
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 
 	_, err := client.Execute(context.Background(), Request{})
 	var authErr *mserrors.TokenExpiredError
@@ -80,14 +64,9 @@ func TestExecuteReturnsTokenExpiredErrorOn401(t *testing.T) {
 }
 
 func TestExecuteReturnsAuthenticationErrorOn403(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "forbidden", http.StatusForbidden)
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 
 	_, err := client.Execute(context.Background(), Request{})
 	var authErr *mserrors.AuthenticationError
@@ -96,14 +75,9 @@ func TestExecuteReturnsAuthenticationErrorOn403(t *testing.T) {
 }
 
 func TestExecuteReturnsHTTPErrorOn500(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "boom", http.StatusInternalServerError)
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 
 	_, err := client.Execute(context.Background(), Request{})
 	var httpErr *mserrors.HTTPError

--- a/internal/client/fundamentals.go
+++ b/internal/client/fundamentals.go
@@ -53,36 +53,25 @@ func (c *Client) GetFundamentals(ctx context.Context, symbol string) (*models.Fu
 }
 
 func buildReportedPeriods(items []any) []models.ReportedPeriod {
-	result := make([]models.ReportedPeriod, 0, len(items))
-	for _, entry := range items {
-		item, ok := entry.(map[string]any)
-		if !ok {
-			continue
-		}
+	return buildSlice(items, func(item map[string]any) models.ReportedPeriod {
 		valueMap, _ := item["value"].(map[string]any)
 		pctMap, _ := item["percentChangeYOY"].(map[string]any)
-		result = append(result, models.ReportedPeriod{
+		return models.ReportedPeriod{
 			Value:              floatPtr(item["value"]),
 			FormattedValue:     stringPtr(valueMap["formattedValue"]),
 			PctChangeYoY:       floatPtr(item["percentChangeYOY"]),
 			FormattedPctChange: stringPtr(pctMap["formattedValue"]),
 			PeriodOffset:       stringify(item["periodOffset"]),
 			PeriodEndDate:      stringPtr(item["periodEndDate"]),
-		})
-	}
-	return result
+		}
+	})
 }
 
 func buildEstimatePeriods(items []any) []models.EstimatePeriod {
-	result := make([]models.EstimatePeriod, 0, len(items))
-	for _, entry := range items {
-		item, ok := entry.(map[string]any)
-		if !ok {
-			continue
-		}
+	return buildSlice(items, func(item map[string]any) models.EstimatePeriod {
 		valueMap, _ := item["value"].(map[string]any)
 		pctMap, _ := item["percentChangeYOY"].(map[string]any)
-		result = append(result, models.EstimatePeriod{
+		return models.EstimatePeriod{
 			Value:              floatPtr(item["value"]),
 			FormattedValue:     stringPtr(valueMap["formattedValue"]),
 			PctChangeYoY:       floatPtr(item["percentChangeYOY"]),
@@ -90,7 +79,6 @@ func buildEstimatePeriods(items []any) []models.EstimatePeriod {
 			PeriodOffset:       stringify(item["periodOffset"]),
 			Period:             stringPtr(item["period"]),
 			RevisionDirection:  stringPtr(item["revisionDirection"]),
-		})
-	}
-	return result
+		}
+	})
 }

--- a/internal/client/graphql_error.go
+++ b/internal/client/graphql_error.go
@@ -253,6 +253,21 @@ func boolPtr(value any) *bool {
 	}
 }
 
+// buildSlice iterates untyped JSON array items, type-asserts each to
+// map[string]any, and maps them to a typed slice using the provided function.
+// Items that are not maps are silently skipped.
+func buildSlice[T any](items []any, mapper func(map[string]any) T) []T {
+	result := make([]T, 0, len(items))
+	for _, entry := range items {
+		item, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		result = append(result, mapper(item))
+	}
+	return result
+}
+
 func stringify(value any) string {
 	switch typed := value.(type) {
 	case string:

--- a/internal/client/helpers_test.go
+++ b/internal/client/helpers_test.go
@@ -1,0 +1,19 @@
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// testServerAndClient creates a test HTTP server with the given handler and returns
+// a Client configured to use it. The server is automatically closed when the test ends.
+func testServerAndClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	c := NewClient("jwt-token")
+	c.Endpoint = server.URL
+	c.HTTPClient = server.Client()
+	return c
+}

--- a/internal/client/ownership.go
+++ b/internal/client/ownership.go
@@ -34,22 +34,14 @@ func (c *Client) GetOwnership(ctx context.Context, symbol string) (*models.Owner
 
 	ownership := getNestedMap(item, "ownership")
 	quarterly := getNestedSlice(ownership, "fundOwnershipSummary")
-	result := &models.OwnershipData{
-		Symbol:         symbol,
-		FundsFloatPct:  formattedValue(ownership["fundsFloatPercentHeld"]),
-		QuarterlyFunds: make([]models.QuarterlyFundOwnership, 0, len(quarterly)),
-	}
-
-	for _, entry := range quarterly {
-		item, ok := entry.(map[string]any)
-		if !ok {
-			continue
-		}
-		result.QuarterlyFunds = append(result.QuarterlyFunds, models.QuarterlyFundOwnership{
-			Date:  stringPtr(item["date"]),
-			Count: formattedValue(item["numberOfFundsHeld"]),
-		})
-	}
-
-	return result, nil
+	return &models.OwnershipData{
+		Symbol:        symbol,
+		FundsFloatPct: formattedValue(ownership["fundsFloatPercentHeld"]),
+		QuarterlyFunds: buildSlice(quarterly, func(item map[string]any) models.QuarterlyFundOwnership {
+			return models.QuarterlyFundOwnership{
+				Date:  stringPtr(item["date"]),
+				Count: formattedValue(item["numberOfFundsHeld"]),
+			}
+		}),
+	}, nil
 }

--- a/internal/client/rs_history.go
+++ b/internal/client/rs_history.go
@@ -35,23 +35,17 @@ func (c *Client) GetRSRatingHistory(ctx context.Context, symbol string) (*models
 	ratings := getNestedSlice(item, "ratings", "rsRating")
 	intraday := getNestedMap(item, "pricingStatistics", "intradayStatistics")
 	result := &models.RSRatingHistory{
-		Symbol:  symbol,
-		Ratings: make([]models.RSRatingSnapshot, 0, len(ratings)),
+		Symbol: symbol,
+		Ratings: buildSlice(ratings, func(item map[string]any) models.RSRatingSnapshot {
+			return models.RSRatingSnapshot{
+				LetterValue:  stringPtr(item["letterValue"]),
+				Period:       stringPtr(item["period"]),
+				PeriodOffset: stringPtr(item["periodOffset"]),
+				Value:        intPtr(item["value"]),
+			}
+		}),
 	}
 	result.RSLineNewHigh = boolPtr(intraday["rsLineNewHigh"])
-
-	for _, entry := range ratings {
-		item, ok := entry.(map[string]any)
-		if !ok {
-			continue
-		}
-		result.Ratings = append(result.Ratings, models.RSRatingSnapshot{
-			LetterValue:  stringPtr(item["letterValue"]),
-			Period:       stringPtr(item["period"]),
-			PeriodOffset: stringPtr(item["periodOffset"]),
-			Value:        intPtr(item["value"]),
-		})
-	}
 
 	return result, nil
 }

--- a/internal/client/stock.go
+++ b/internal/client/stock.go
@@ -172,13 +172,8 @@ func (c *Client) GetStock(ctx context.Context, symbol string) (*models.StockData
 }
 
 func buildQuarterlyReported(items []any) []models.QuarterlyReportedPeriod {
-	result := make([]models.QuarterlyReportedPeriod, 0, len(items))
-	for _, entry := range items {
-		item, ok := entry.(map[string]any)
-		if !ok {
-			continue
-		}
-		result = append(result, models.QuarterlyReportedPeriod{
+	return buildSlice(items, func(item map[string]any) models.QuarterlyReportedPeriod {
+		return models.QuarterlyReportedPeriod{
 			Value:           floatPtr(item["value"]),
 			PctChangeYoY:    floatPtr(item["percentChangeYOY"]),
 			PeriodOffset:    stringify(item["periodOffset"]),
@@ -189,45 +184,32 @@ func buildQuarterlyReported(items []any) []models.QuarterlyReportedPeriod {
 			QuarterNumber:   intPtr(item["quarterNumber"]),
 			FiscalYear:      intPtr(item["fiscalYear"]),
 			Period:          stringPtr(item["period"]),
-		})
-	}
-	return result
+		}
+	})
 }
 
 func buildQuarterlyEstimates(items []any) []models.QuarterlyEstimate {
-	result := make([]models.QuarterlyEstimate, 0, len(items))
-	for _, entry := range items {
-		item, ok := entry.(map[string]any)
-		if !ok {
-			continue
-		}
-		result = append(result, models.QuarterlyEstimate{
+	return buildSlice(items, func(item map[string]any) models.QuarterlyEstimate {
+		return models.QuarterlyEstimate{
 			Value:             floatPtr(item["value"]),
 			PctChangeYoY:      floatPtr(item["percentChangeYOY"]),
 			PeriodEndDate:     stringPtr(item["periodEndDate"]),
 			EffectiveDate:     stringPtr(item["effectiveDate"]),
 			RevisionDirection: stringPtr(item["revisionDirection"]),
 			EstimateType:      stringPtr(item["type"]),
-		})
-	}
-	return result
+		}
+	})
 }
 
 func buildQuarterlyProfitMargins(items []any) []models.QuarterlyProfitMargin {
-	result := make([]models.QuarterlyProfitMargin, 0, len(items))
-	for _, entry := range items {
-		item, ok := entry.(map[string]any)
-		if !ok {
-			continue
-		}
-		result = append(result, models.QuarterlyProfitMargin{
+	return buildSlice(items, func(item map[string]any) models.QuarterlyProfitMargin {
+		return models.QuarterlyProfitMargin{
 			PeriodOffset:   stringify(item["periodOffset"]),
 			PeriodEndDate:  stringPtr(item["periodEndDate"]),
 			PreTaxMargin:   floatPtr(item["preTaxMargin"]),
 			AfterTaxMargin: floatPtr(item["afterTaxMargin"]),
 			GrossMargin:    floatPtr(item["grossMargin"]),
 			ReturnOnEquity: floatPtr(item["returnOnEquity"]),
-		})
-	}
-	return result
+		}
+	})
 }

--- a/internal/client/stock_test.go
+++ b/internal/client/stock_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,17 +12,12 @@ import (
 
 func TestGetStockSuccess(t *testing.T) {
 	var captured Request
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(stockResponseJSON()))
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 
 	stock, err := client.GetStock(context.Background(), "AAPL")
 	require.NoError(t, err)
@@ -38,15 +32,10 @@ func TestGetStockSuccess(t *testing.T) {
 }
 
 func TestGetStockReturnsSymbolNotFoundForEmptyMarketData(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":{"marketData":[]}}`))
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 
 	_, err := client.GetStock(context.Background(), "MISSING")
 	require.Error(t, err)
@@ -54,15 +43,10 @@ func TestGetStockReturnsSymbolNotFoundForEmptyMarketData(t *testing.T) {
 }
 
 func TestGetFundamentalsSuccess(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(stockResponseJSON()))
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 
 	data, err := client.GetFundamentals(context.Background(), "AAPL")
 	require.NoError(t, err)
@@ -73,15 +57,10 @@ func TestGetFundamentalsSuccess(t *testing.T) {
 }
 
 func TestGetOwnershipSuccess(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(stockResponseJSON()))
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 
 	data, err := client.GetOwnership(context.Background(), "AAPL")
 	require.NoError(t, err)
@@ -91,15 +70,10 @@ func TestGetOwnershipSuccess(t *testing.T) {
 }
 
 func TestGetRSRatingHistorySuccess(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(stockResponseJSON()))
-	}))
-	defer server.Close()
-
-	client := NewClient("jwt-token")
-	client.Endpoint = server.URL
-	client.HTTPClient = server.Client()
+	})
 
 	data, err := client.GetRSRatingHistory(context.Background(), "AAPL")
 	require.NoError(t, err)

--- a/internal/commands/catalog_list_test.go
+++ b/internal/commands/catalog_list_test.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -14,7 +13,6 @@ import (
 	"github.com/major/marketsurge-agent/internal/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v3"
 )
 
 func TestCatalogListAllSourcesSucceed(t *testing.T) {
@@ -127,9 +125,7 @@ func TestCatalogListInvalidKind(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := CatalogListCommand(testClient(t, server), &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-
-	err := cmd.Run(context.Background(), []string{"list", "--kind", "invalid"})
+	err := runTestCommand(t, cmd, "list", "--kind", "invalid")
 	require.Error(t, err)
 
 	var verr *mserrors.ValidationError
@@ -151,10 +147,8 @@ func runCatalogListCommand(t *testing.T, c *client.Client, args ...string) catal
 
 	var buf bytes.Buffer
 	cmd := CatalogListCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-
 	argv := append([]string{"list"}, args...)
-	require.NoError(t, cmd.Run(context.Background(), argv))
+	require.NoError(t, runTestCommand(t, cmd, argv...))
 
 	var envelope catalogListEnvelope
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))

--- a/internal/commands/catalog_run_test.go
+++ b/internal/commands/catalog_run_test.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"math"
 	"net/http"
@@ -13,7 +12,6 @@ import (
 	mserrors "github.com/major/marketsurge-agent/internal/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v3"
 )
 
 func TestCatalogRunReportDispatch(t *testing.T) {
@@ -78,9 +76,7 @@ func TestCatalogRunMissingKind(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := CatalogRunCommand(testClient(t, server), &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-
-	err := cmd.Run(context.Background(), []string{"run"})
+	err := runTestCommand(t, cmd, "run")
 	require.Error(t, err)
 
 	var verr *mserrors.ValidationError
@@ -95,9 +91,7 @@ func TestCatalogRunScreenKindValidation(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := CatalogRunCommand(testClient(t, server), &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-
-	err := cmd.Run(context.Background(), []string{"run", "--kind", "screen"})
+	err := runTestCommand(t, cmd, "run", "--kind", "screen")
 	require.Error(t, err)
 
 	var verr *mserrors.ValidationError
@@ -124,9 +118,7 @@ func TestCatalogRunMissingIDForKind(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			cmd := CatalogRunCommand(testClient(t, server), &buf)
-			cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-
-			err := cmd.Run(context.Background(), tt.args)
+			err := runTestCommand(t, cmd, tt.args...)
 			require.Error(t, err)
 
 			var verr *mserrors.ValidationError
@@ -192,10 +184,8 @@ func runCatalogRunCommand(t *testing.T, c *client.Client, args ...string) catalo
 
 	var buf bytes.Buffer
 	cmd := CatalogRunCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-
 	argv := append([]string{"run"}, args...)
-	require.NoError(t, cmd.Run(context.Background(), argv))
+	require.NoError(t, runTestCommand(t, cmd, argv...))
 
 	var envelope catalogRunEnvelope
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))

--- a/internal/commands/chart_history.go
+++ b/internal/commands/chart_history.go
@@ -34,11 +34,10 @@ func ChartHistoryCommand(c *client.Client, w io.Writer) *cli.Command {
 			&cli.StringFlag{Name: "benchmark", Usage: "Benchmark symbol for relative strength (e.g. 0S&P5)"},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			if cmd.Args().Len() == 0 {
-				verr := mserrors.NewValidationError("symbol argument required", nil)
-				return verr
+			symbol, err := requireSymbol(cmd)
+			if err != nil {
+				return err
 			}
-			symbol := cmd.Args().First()
 
 			startDate, endDate, err := resolveChartDates(cmd, time.Now().UTC())
 			if err != nil {

--- a/internal/commands/chart_history_test.go
+++ b/internal/commands/chart_history_test.go
@@ -2,14 +2,11 @@ package commands
 
 import (
 	"bytes"
-	"context"
-	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v3"
 
 	mserrors "github.com/major/marketsurge-agent/internal/errors"
 )
@@ -21,17 +18,11 @@ func TestChartHistorySuccessWithExplicitDates(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := ChartHistoryCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-
-	err := cmd.Run(context.Background(), []string{
+	require.NoError(t, runTestCommand(t, cmd,
 		"history", "--start-date", "2024-01-01", "--end-date", "2024-06-30", "AAPL",
-	})
-	require.NoError(t, err)
+	))
 
-	var result map[string]any
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
-	assert.Contains(t, result, "data")
-	assert.Contains(t, result, "metadata")
+	parseJSONEnvelope(t, &buf)
 }
 
 func TestChartHistorySuccessWithLookback(t *testing.T) {
@@ -41,16 +32,11 @@ func TestChartHistorySuccessWithLookback(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := ChartHistoryCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-
-	err := cmd.Run(context.Background(), []string{
+	require.NoError(t, runTestCommand(t, cmd,
 		"history", "--lookback", "3M", "AAPL",
-	})
-	require.NoError(t, err)
+	))
 
-	var result map[string]any
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
-	assert.Contains(t, result, "data")
+	parseJSONEnvelope(t, &buf)
 }
 
 func TestChartHistorySymbolNotFound(t *testing.T) {
@@ -60,11 +46,9 @@ func TestChartHistorySymbolNotFound(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := ChartHistoryCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-
-	err := cmd.Run(context.Background(), []string{
+	err := runTestCommand(t, cmd,
 		"history", "--lookback", "1M", "MISSING",
-	})
+	)
 	require.Error(t, err)
 
 	var snf *mserrors.SymbolNotFoundError
@@ -78,11 +62,9 @@ func TestChartHistoryMissingSymbol(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := ChartHistoryCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-
-	err := cmd.Run(context.Background(), []string{
+	err := runTestCommand(t, cmd,
 		"history", "--lookback", "1M",
-	})
+	)
 	require.Error(t, err)
 
 	var verr *mserrors.ValidationError
@@ -96,11 +78,9 @@ func TestChartHistoryMutualExclusion(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := ChartHistoryCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-
-	err := cmd.Run(context.Background(), []string{
+	err := runTestCommand(t, cmd,
 		"history", "--start-date", "2024-01-01", "--end-date", "2024-06-30", "--lookback", "3M", "AAPL",
-	})
+	)
 	require.Error(t, err)
 
 	var verr *mserrors.ValidationError
@@ -115,9 +95,7 @@ func TestChartHistoryNeitherDatesNorLookback(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := ChartHistoryCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-
-	err := cmd.Run(context.Background(), []string{"history", "AAPL"})
+	err := runTestCommand(t, cmd, "history", "AAPL")
 	require.Error(t, err)
 
 	var verr *mserrors.ValidationError
@@ -132,11 +110,9 @@ func TestChartHistoryPartialExplicitDates(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := ChartHistoryCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-
-	err := cmd.Run(context.Background(), []string{
+	err := runTestCommand(t, cmd,
 		"history", "--start-date", "2024-01-01", "AAPL",
-	})
+	)
 	require.Error(t, err)
 
 	var verr *mserrors.ValidationError
@@ -151,11 +127,9 @@ func TestChartHistoryInvalidLookback(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := ChartHistoryCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-
-	err := cmd.Run(context.Background(), []string{
+	err := runTestCommand(t, cmd,
 		"history", "--lookback", "2W", "AAPL",
-	})
+	)
 	require.Error(t, err)
 
 	var verr *mserrors.ValidationError

--- a/internal/commands/chart_markups.go
+++ b/internal/commands/chart_markups.go
@@ -7,7 +7,6 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"github.com/major/marketsurge-agent/internal/client"
-	mserrors "github.com/major/marketsurge-agent/internal/errors"
 	"github.com/major/marketsurge-agent/internal/output"
 )
 
@@ -22,11 +21,10 @@ func ChartMarkupsCommand(c *client.Client, w io.Writer) *cli.Command {
 			&cli.StringFlag{Name: "sort-dir", Value: "ASC", Usage: "Sort direction: ASC or DESC"},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			if cmd.Args().Len() == 0 {
-				verr := mserrors.NewValidationError("symbol argument required", nil)
-				return verr
+			symbol, err := requireSymbol(cmd)
+			if err != nil {
+				return err
 			}
-			symbol := cmd.Args().First()
 			frequency := cmd.String("frequency")
 			sortDir := cmd.String("sort-dir")
 

--- a/internal/commands/chart_markups_test.go
+++ b/internal/commands/chart_markups_test.go
@@ -2,13 +2,10 @@ package commands
 
 import (
 	"bytes"
-	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v3"
 
 	mserrors "github.com/major/marketsurge-agent/internal/errors"
 )
@@ -20,18 +17,10 @@ func TestChartMarkupsSuccess(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := ChartMarkupsCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
+	require.NoError(t, runTestCommand(t, cmd, "markups", "AAPL"))
 
-	err := cmd.Run(context.Background(), []string{"markups", "AAPL"})
-	require.NoError(t, err)
-
-	var result map[string]any
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
-	assert.Contains(t, result, "data")
-	assert.Contains(t, result, "metadata")
-
-	meta, _ := result["metadata"].(map[string]any)
-	assert.Equal(t, "AAPL", meta["symbol"])
+	result := parseJSONEnvelope(t, &buf)
+	assertSymbolMeta(t, result, "AAPL")
 }
 
 func TestChartMarkupsWithFlags(t *testing.T) {
@@ -41,16 +30,11 @@ func TestChartMarkupsWithFlags(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := ChartMarkupsCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-
-	err := cmd.Run(context.Background(), []string{
+	require.NoError(t, runTestCommand(t, cmd,
 		"markups", "--frequency", "WEEKLY", "--sort-dir", "DESC", "AAPL",
-	})
-	require.NoError(t, err)
+	))
 
-	var result map[string]any
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
-	assert.Contains(t, result, "data")
+	parseJSONEnvelope(t, &buf)
 }
 
 func TestChartMarkupsMissingSymbol(t *testing.T) {
@@ -60,9 +44,7 @@ func TestChartMarkupsMissingSymbol(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := ChartMarkupsCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-
-	err := cmd.Run(context.Background(), []string{"markups"})
+	err := runTestCommand(t, cmd, "markups")
 	require.Error(t, err)
 
 	var verr *mserrors.ValidationError

--- a/internal/commands/fundamental_get.go
+++ b/internal/commands/fundamental_get.go
@@ -7,27 +7,11 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"github.com/major/marketsurge-agent/internal/client"
-	mserrors "github.com/major/marketsurge-agent/internal/errors"
-	"github.com/major/marketsurge-agent/internal/output"
 )
 
 // FundamentalGetCommand returns the CLI command for retrieving fundamental data.
 func FundamentalGetCommand(c *client.Client, w io.Writer) *cli.Command {
-	return &cli.Command{
-		Name:      "get",
-		Usage:     "Get fundamental data for a symbol",
-		ArgsUsage: "<symbol>",
-		Action: func(ctx context.Context, cmd *cli.Command) error {
-			if cmd.Args().Len() == 0 {
-				verr := mserrors.NewValidationError("symbol argument required", nil)
-				return verr
-			}
-			symbol := cmd.Args().First()
-			data, err := c.GetFundamentals(ctx, symbol)
-			if err != nil {
-				return err
-			}
-			return output.WriteSuccess(w, data, output.SymbolMeta(symbol))
-		},
-	}
+	return symbolGetCommand(w, "get", "Get fundamental data for a symbol", func(ctx context.Context, symbol string) (any, error) {
+		return c.GetFundamentals(ctx, symbol)
+	})
 }

--- a/internal/commands/fundamental_get_test.go
+++ b/internal/commands/fundamental_get_test.go
@@ -2,13 +2,10 @@ package commands
 
 import (
 	"bytes"
-	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v3"
 
 	mserrors "github.com/major/marketsurge-agent/internal/errors"
 )
@@ -20,18 +17,10 @@ func TestFundamentalGetSuccess(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := FundamentalGetCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
+	require.NoError(t, runTestCommand(t, cmd, "get", "AAPL"))
 
-	err := cmd.Run(context.Background(), []string{"get", "AAPL"})
-	require.NoError(t, err)
-
-	var result map[string]any
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
-	assert.Contains(t, result, "data")
-	assert.Contains(t, result, "metadata")
-
-	meta, _ := result["metadata"].(map[string]any)
-	assert.Equal(t, "AAPL", meta["symbol"])
+	result := parseJSONEnvelope(t, &buf)
+	assertSymbolMeta(t, result, "AAPL")
 }
 
 func TestFundamentalGetSymbolNotFound(t *testing.T) {
@@ -41,9 +30,7 @@ func TestFundamentalGetSymbolNotFound(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := FundamentalGetCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-
-	err := cmd.Run(context.Background(), []string{"get", "MISSING"})
+	err := runTestCommand(t, cmd, "get", "MISSING")
 	require.Error(t, err)
 
 	var snf *mserrors.SymbolNotFoundError
@@ -58,9 +45,7 @@ func TestFundamentalGetMissingSymbol(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := FundamentalGetCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-
-	err := cmd.Run(context.Background(), []string{"get"})
+	err := runTestCommand(t, cmd, "get")
 	require.Error(t, err)
 
 	var verr *mserrors.ValidationError

--- a/internal/commands/helpers_test.go
+++ b/internal/commands/helpers_test.go
@@ -1,12 +1,42 @@
 package commands
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/major/marketsurge-agent/internal/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
 )
+
+// runTestCommand configures the command to suppress os.Exit and runs it with the given args.
+func runTestCommand(t *testing.T, cmd *cli.Command, args ...string) error {
+	t.Helper()
+	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
+	return cmd.Run(context.Background(), args)
+}
+
+// parseJSONEnvelope unmarshals buf into a map and asserts it contains data and metadata keys.
+func parseJSONEnvelope(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
+	assert.Contains(t, result, "data")
+	assert.Contains(t, result, "metadata")
+	return result
+}
+
+// assertSymbolMeta asserts that the envelope metadata contains the expected symbol.
+func assertSymbolMeta(t *testing.T, envelope map[string]any, symbol string) {
+	t.Helper()
+	meta, _ := envelope["metadata"].(map[string]any)
+	assert.Equal(t, symbol, meta["symbol"])
+}
 
 // testClient creates a *client.Client backed by the given httptest server.
 func testClient(t *testing.T, server *httptest.Server) *client.Client {

--- a/internal/commands/ownership_get.go
+++ b/internal/commands/ownership_get.go
@@ -7,27 +7,11 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"github.com/major/marketsurge-agent/internal/client"
-	mserrors "github.com/major/marketsurge-agent/internal/errors"
-	"github.com/major/marketsurge-agent/internal/output"
 )
 
 // OwnershipGetCommand returns the CLI command for retrieving ownership data.
 func OwnershipGetCommand(c *client.Client, w io.Writer) *cli.Command {
-	return &cli.Command{
-		Name:      "get",
-		Usage:     "Get ownership data for a symbol",
-		ArgsUsage: "<symbol>",
-		Action: func(ctx context.Context, cmd *cli.Command) error {
-			if cmd.Args().Len() == 0 {
-				verr := mserrors.NewValidationError("symbol argument required", nil)
-				return verr
-			}
-			symbol := cmd.Args().First()
-			data, err := c.GetOwnership(ctx, symbol)
-			if err != nil {
-				return err
-			}
-			return output.WriteSuccess(w, data, output.SymbolMeta(symbol))
-		},
-	}
+	return symbolGetCommand(w, "get", "Get ownership data for a symbol", func(ctx context.Context, symbol string) (any, error) {
+		return c.GetOwnership(ctx, symbol)
+	})
 }

--- a/internal/commands/ownership_get_test.go
+++ b/internal/commands/ownership_get_test.go
@@ -2,13 +2,10 @@ package commands
 
 import (
 	"bytes"
-	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v3"
 
 	mserrors "github.com/major/marketsurge-agent/internal/errors"
 )
@@ -20,18 +17,10 @@ func TestOwnershipGetSuccess(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := OwnershipGetCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
+	require.NoError(t, runTestCommand(t, cmd, "get", "AAPL"))
 
-	err := cmd.Run(context.Background(), []string{"get", "AAPL"})
-	require.NoError(t, err)
-
-	var result map[string]any
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
-	assert.Contains(t, result, "data")
-	assert.Contains(t, result, "metadata")
-
-	meta, _ := result["metadata"].(map[string]any)
-	assert.Equal(t, "AAPL", meta["symbol"])
+	result := parseJSONEnvelope(t, &buf)
+	assertSymbolMeta(t, result, "AAPL")
 }
 
 func TestOwnershipGetSymbolNotFound(t *testing.T) {
@@ -41,9 +30,7 @@ func TestOwnershipGetSymbolNotFound(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := OwnershipGetCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-
-	err := cmd.Run(context.Background(), []string{"get", "MISSING"})
+	err := runTestCommand(t, cmd, "get", "MISSING")
 	require.Error(t, err)
 
 	var snf *mserrors.SymbolNotFoundError
@@ -58,9 +45,7 @@ func TestOwnershipGetMissingSymbol(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := OwnershipGetCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-
-	err := cmd.Run(context.Background(), []string{"get"})
+	err := runTestCommand(t, cmd, "get")
 	require.Error(t, err)
 
 	var verr *mserrors.ValidationError

--- a/internal/commands/rs_history_get.go
+++ b/internal/commands/rs_history_get.go
@@ -7,27 +7,11 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"github.com/major/marketsurge-agent/internal/client"
-	mserrors "github.com/major/marketsurge-agent/internal/errors"
-	"github.com/major/marketsurge-agent/internal/output"
 )
 
 // RSHistoryGetCommand returns the CLI command for retrieving RS rating history.
 func RSHistoryGetCommand(c *client.Client, w io.Writer) *cli.Command {
-	return &cli.Command{
-		Name:      "get",
-		Usage:     "Get RS rating history for a symbol",
-		ArgsUsage: "<symbol>",
-		Action: func(ctx context.Context, cmd *cli.Command) error {
-			if cmd.Args().Len() == 0 {
-				verr := mserrors.NewValidationError("symbol argument required", nil)
-				return verr
-			}
-			symbol := cmd.Args().First()
-			data, err := c.GetRSRatingHistory(ctx, symbol)
-			if err != nil {
-				return err
-			}
-			return output.WriteSuccess(w, data, output.SymbolMeta(symbol))
-		},
-	}
+	return symbolGetCommand(w, "get", "Get RS rating history for a symbol", func(ctx context.Context, symbol string) (any, error) {
+		return c.GetRSRatingHistory(ctx, symbol)
+	})
 }

--- a/internal/commands/rs_history_get_test.go
+++ b/internal/commands/rs_history_get_test.go
@@ -2,13 +2,10 @@ package commands
 
 import (
 	"bytes"
-	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v3"
 
 	mserrors "github.com/major/marketsurge-agent/internal/errors"
 )
@@ -20,18 +17,10 @@ func TestRSHistoryGetSuccess(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := RSHistoryGetCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
+	require.NoError(t, runTestCommand(t, cmd, "get", "AAPL"))
 
-	err := cmd.Run(context.Background(), []string{"get", "AAPL"})
-	require.NoError(t, err)
-
-	var result map[string]any
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
-	assert.Contains(t, result, "data")
-	assert.Contains(t, result, "metadata")
-
-	meta, _ := result["metadata"].(map[string]any)
-	assert.Equal(t, "AAPL", meta["symbol"])
+	result := parseJSONEnvelope(t, &buf)
+	assertSymbolMeta(t, result, "AAPL")
 }
 
 func TestRSHistoryGetSymbolNotFound(t *testing.T) {
@@ -41,9 +30,7 @@ func TestRSHistoryGetSymbolNotFound(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := RSHistoryGetCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-
-	err := cmd.Run(context.Background(), []string{"get", "MISSING"})
+	err := runTestCommand(t, cmd, "get", "MISSING")
 	require.Error(t, err)
 
 	var snf *mserrors.SymbolNotFoundError
@@ -58,9 +45,7 @@ func TestRSHistoryGetMissingSymbol(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := RSHistoryGetCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-
-	err := cmd.Run(context.Background(), []string{"get"})
+	err := runTestCommand(t, cmd, "get")
 	require.Error(t, err)
 
 	var verr *mserrors.ValidationError

--- a/internal/commands/stock_analyze_test.go
+++ b/internal/commands/stock_analyze_test.go
@@ -2,14 +2,11 @@ package commands
 
 import (
 	"bytes"
-	"context"
-	"encoding/json"
 	"testing"
 
 	mserrors "github.com/major/marketsurge-agent/internal/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v3"
 )
 
 func TestStockAnalyzeSuccess(t *testing.T) {
@@ -19,16 +16,9 @@ func TestStockAnalyzeSuccess(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := StockAnalyzeCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
+	require.NoError(t, runTestCommand(t, cmd, "analyze", "AAPL"))
 
-	err := cmd.Run(context.Background(), []string{"analyze", "AAPL"})
-	require.NoError(t, err)
-
-	var result map[string]any
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
-	assert.Contains(t, result, "data")
-	assert.Contains(t, result, "metadata")
-
+	result := parseJSONEnvelope(t, &buf)
 	data, _ := result["data"].(map[string]any)
 	assert.Equal(t, "AAPL", data["symbol"])
 	assert.Contains(t, data, "stock")
@@ -46,14 +36,9 @@ func TestStockAnalyzePartialFailure(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := StockAnalyzeCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
+	require.NoError(t, runTestCommand(t, cmd, "analyze", "AAPL"))
 
-	err := cmd.Run(context.Background(), []string{"analyze", "AAPL"})
-	require.NoError(t, err)
-
-	var result map[string]any
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
-	assert.Contains(t, result, "data")
+	parseJSONEnvelope(t, &buf)
 }
 
 func TestStockAnalyzeMultiSymbol(t *testing.T) {
@@ -63,14 +48,9 @@ func TestStockAnalyzeMultiSymbol(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := StockAnalyzeCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
+	require.NoError(t, runTestCommand(t, cmd, "analyze", "AAPL", "MSFT"))
 
-	err := cmd.Run(context.Background(), []string{"analyze", "AAPL", "MSFT"})
-	require.NoError(t, err)
-
-	var result map[string]any
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
-	assert.Contains(t, result, "data")
+	result := parseJSONEnvelope(t, &buf)
 
 	// Multi-symbol returns an array.
 	data, ok := result["data"].([]any)
@@ -89,9 +69,7 @@ func TestStockAnalyzeMissingSymbol(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := StockAnalyzeCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-
-	err := cmd.Run(context.Background(), []string{"analyze"})
+	err := runTestCommand(t, cmd, "analyze")
 	require.Error(t, err)
 	var verr *mserrors.ValidationError
 	assert.ErrorAs(t, err, &verr)
@@ -105,9 +83,7 @@ func TestStockAnalyzeTotalFailure(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := StockAnalyzeCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-
-	err := cmd.Run(context.Background(), []string{"analyze", "MISSING"})
+	err := runTestCommand(t, cmd, "analyze", "MISSING")
 	require.Error(t, err)
 	assert.Empty(t, buf.String())
 }

--- a/internal/commands/stock_get.go
+++ b/internal/commands/stock_get.go
@@ -8,27 +8,11 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"github.com/major/marketsurge-agent/internal/client"
-	mserrors "github.com/major/marketsurge-agent/internal/errors"
-	"github.com/major/marketsurge-agent/internal/output"
 )
 
 // StockGetCommand returns the CLI command for retrieving stock data.
 func StockGetCommand(c *client.Client, w io.Writer) *cli.Command {
-	return &cli.Command{
-		Name:      "get",
-		Usage:     "Get stock data for a symbol",
-		ArgsUsage: "<symbol>",
-		Action: func(ctx context.Context, cmd *cli.Command) error {
-			if cmd.Args().Len() == 0 {
-				verr := mserrors.NewValidationError("symbol argument required", nil)
-				return verr
-			}
-			symbol := cmd.Args().First()
-			data, err := c.GetStock(ctx, symbol)
-			if err != nil {
-				return err
-			}
-			return output.WriteSuccess(w, data, output.SymbolMeta(symbol))
-		},
-	}
+	return symbolGetCommand(w, "get", "Get stock data for a symbol", func(ctx context.Context, symbol string) (any, error) {
+		return c.GetStock(ctx, symbol)
+	})
 }

--- a/internal/commands/stock_get_test.go
+++ b/internal/commands/stock_get_test.go
@@ -2,13 +2,10 @@ package commands
 
 import (
 	"bytes"
-	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v3"
 
 	mserrors "github.com/major/marketsurge-agent/internal/errors"
 )
@@ -20,18 +17,10 @@ func TestStockGetSuccess(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := StockGetCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
+	require.NoError(t, runTestCommand(t, cmd, "get", "AAPL"))
 
-	err := cmd.Run(context.Background(), []string{"get", "AAPL"})
-	require.NoError(t, err)
-
-	var result map[string]any
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
-	assert.Contains(t, result, "data")
-	assert.Contains(t, result, "metadata")
-
-	meta, _ := result["metadata"].(map[string]any)
-	assert.Equal(t, "AAPL", meta["symbol"])
+	result := parseJSONEnvelope(t, &buf)
+	assertSymbolMeta(t, result, "AAPL")
 }
 
 func TestStockGetSymbolNotFound(t *testing.T) {
@@ -41,9 +30,7 @@ func TestStockGetSymbolNotFound(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := StockGetCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-
-	err := cmd.Run(context.Background(), []string{"get", "MISSING"})
+	err := runTestCommand(t, cmd, "get", "MISSING")
 	require.Error(t, err)
 
 	var snf *mserrors.SymbolNotFoundError
@@ -58,9 +45,7 @@ func TestStockGetMissingSymbol(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := StockGetCommand(c, &buf)
-	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-
-	err := cmd.Run(context.Background(), []string{"get"})
+	err := runTestCommand(t, cmd, "get")
 	require.Error(t, err)
 
 	var verr *mserrors.ValidationError

--- a/internal/commands/symbol_command.go
+++ b/internal/commands/symbol_command.go
@@ -1,0 +1,43 @@
+package commands
+
+import (
+	"context"
+	"io"
+
+	"github.com/urfave/cli/v3"
+
+	mserrors "github.com/major/marketsurge-agent/internal/errors"
+	"github.com/major/marketsurge-agent/internal/output"
+)
+
+// symbolFetcher retrieves data for a single symbol from the MarketSurge API.
+type symbolFetcher func(ctx context.Context, symbol string) (any, error)
+
+// requireSymbol validates that a symbol argument was provided and returns it.
+func requireSymbol(cmd *cli.Command) (string, error) {
+	if cmd.Args().Len() == 0 {
+		return "", mserrors.NewValidationError("symbol argument required", nil)
+	}
+	return cmd.Args().First(), nil
+}
+
+// symbolGetCommand builds a CLI command that fetches data for a single symbol.
+// It handles argument validation, calls the fetcher, and writes the JSON envelope.
+func symbolGetCommand(w io.Writer, name, usage string, fetch symbolFetcher) *cli.Command {
+	return &cli.Command{
+		Name:      name,
+		Usage:     usage,
+		ArgsUsage: "<symbol>",
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			symbol, err := requireSymbol(cmd)
+			if err != nil {
+				return err
+			}
+			data, err := fetch(ctx, symbol)
+			if err != nil {
+				return err
+			}
+			return output.WriteSuccess(w, data, output.SymbolMeta(symbol))
+		},
+	}
+}


### PR DESCRIPTION
## Summary

- Extract `symbolGetCommand` factory and `requireSymbol` helper to eliminate repeated single-symbol command boilerplate (5 commands)
- Add generic `buildSlice[T]` helper replacing 10 identical iterate/type-assert/append loops across the client layer
- Add `runTestCommand`, `parseJSONEnvelope`, `assertSymbolMeta` test helpers for command tests (9 test files)
- Add `testServerAndClient` helper for client tests replacing 27 repeated server+client setup blocks (4 test files)

Net reduction: ~300 lines across 29 files. All tests pass, no behavioral changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated internal test setup and client initialization logic using shared helper functions for HTTP server testing and CLI command execution.
  * Simplified slice construction patterns across multiple internal client functions using a new generic helper for consistent data transformation.
  * Reduced code duplication in CLI command implementations by extracting common symbol validation and output formatting into reusable utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->