### PR TITLE
refactor: deduplicate error dispatch and pagination logic

### DIFF
--- a/internal/commands/catalog_run.go
+++ b/internal/commands/catalog_run.go
@@ -176,7 +176,7 @@ func runCatalogEntries(
 		}
 
 		entries := applyCatalogRunFilters(result.Entries, filters)
-		return projectWatchlistEntries(paginateWatchlistEntries(entries, limit, offset), fields), len(entries), nil
+		return projectWatchlistEntries(paginateSlice(entries, limit, offset), fields), len(entries), nil
 	case models.CatalogKindWatchlist:
 		watchlistID := cmd.Int64("watchlist-id")
 		if watchlistID == 0 {
@@ -189,7 +189,7 @@ func runCatalogEntries(
 		}
 
 		entries := applyCatalogRunFilters(result.Entries, filters)
-		return projectWatchlistEntries(paginateWatchlistEntries(entries, limit, offset), fields), len(entries), nil
+		return projectWatchlistEntries(paginateSlice(entries, limit, offset), fields), len(entries), nil
 	case models.CatalogKindCoachScreen:
 		coachScreenID := cmd.String("coach-screen-id")
 		if coachScreenID == "" {
@@ -201,7 +201,7 @@ func runCatalogEntries(
 			return nil, 0, err
 		}
 
-		rows := paginateCoachScreenRows(result.Rows, limit, offset)
+		rows := paginateSlice(result.Rows, limit, offset)
 		return rows, len(result.Rows), nil
 	default:
 		return nil, 0, mserrors.NewValidationError("kind must be one of: watchlist, screen, report, coach_screen", nil)
@@ -238,36 +238,20 @@ func isSPACEntry(entry *models.WatchlistEntry) bool {
 	return strings.EqualFold(*entry.InstrumentSubType, "BLANK_CHECK")
 }
 
-// paginateWatchlistEntries slices watchlist entries using limit and offset.
-func paginateWatchlistEntries(entries []models.WatchlistEntry, limit, offset int) []models.WatchlistEntry {
-	start := clampCatalogOffset(offset, len(entries))
+// paginateSlice returns a sub-slice bounded by limit and offset.
+func paginateSlice[T any](items []T, limit, offset int) []T {
+	start := clampCatalogOffset(offset, len(items))
 	if limit < 0 {
 		limit = 0
 	}
-	end := len(entries)
+	end := len(items)
 	if limit > 0 && start+limit < end {
 		end = start + limit
 	}
 	if start > end {
 		start = end
 	}
-	return entries[start:end]
-}
-
-// paginateCoachScreenRows slices coach screen rows using limit and offset.
-func paginateCoachScreenRows(rows []map[string]*string, limit, offset int) []map[string]*string {
-	start := clampCatalogOffset(offset, len(rows))
-	if limit < 0 {
-		limit = 0
-	}
-	end := len(rows)
-	if limit > 0 && start+limit < end {
-		end = start + limit
-	}
-	if start > end {
-		start = end
-	}
-	return rows[start:end]
+	return items[start:end]
 }
 
 // clampCatalogOffset bounds the offset to the available entry count.

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -39,6 +39,12 @@ func (e *MarketSurgeError) As(target interface{}) bool {
 	return false
 }
 
+// ErrorCode returns the error classification code for JSON responses.
+func (e *MarketSurgeError) ErrorCode() string { return "GENERAL_ERROR" }
+
+// ExitCode returns the process exit code for this error type.
+func (e *MarketSurgeError) ExitCode() int { return ExitGeneral }
+
 // AuthenticationError indicates an authentication failure (cookie extraction or token expiry).
 type AuthenticationError struct {
 	MarketSurgeError
@@ -54,6 +60,12 @@ func (e *AuthenticationError) As(target interface{}) bool {
 	}
 	return false
 }
+
+// ErrorCode returns the error classification code for JSON responses.
+func (e *AuthenticationError) ErrorCode() string { return "AUTH_FAILED" }
+
+// ExitCode returns the process exit code for this error type.
+func (e *AuthenticationError) ExitCode() int { return ExitAuthFailure }
 
 // CookieExtractionError indicates failure to extract browser cookies.
 // It is a subtype of AuthenticationError.
@@ -76,6 +88,12 @@ func (e *CookieExtractionError) As(target interface{}) bool {
 	return false
 }
 
+// ErrorCode returns the error classification code for JSON responses.
+func (e *CookieExtractionError) ErrorCode() string { return "AUTH_FAILED" }
+
+// ExitCode returns the process exit code for this error type.
+func (e *CookieExtractionError) ExitCode() int { return ExitAuthFailure }
+
 // TokenExpiredError indicates that the JWT token has expired or been rejected.
 // It is a subtype of AuthenticationError.
 type TokenExpiredError struct {
@@ -97,6 +115,12 @@ func (e *TokenExpiredError) As(target interface{}) bool {
 	return false
 }
 
+// ErrorCode returns the error classification code for JSON responses.
+func (e *TokenExpiredError) ErrorCode() string { return "AUTH_FAILED" }
+
+// ExitCode returns the process exit code for this error type.
+func (e *TokenExpiredError) ExitCode() int { return ExitAuthFailure }
+
 // APIError indicates that the GraphQL API returned errors.
 type APIError struct {
 	MarketSurgeError
@@ -112,6 +136,12 @@ func (e *APIError) As(target interface{}) bool {
 	}
 	return false
 }
+
+// ErrorCode returns the error classification code for JSON responses.
+func (e *APIError) ErrorCode() string { return "API_ERROR" }
+
+// ExitCode returns the process exit code for this error type.
+func (e *APIError) ExitCode() int { return ExitAPIError }
 
 // SymbolNotFoundError indicates that the API returned empty marketData for a requested symbol.
 // It is a subtype of APIError.
@@ -134,6 +164,12 @@ func (e *SymbolNotFoundError) As(target interface{}) bool {
 	return false
 }
 
+// ErrorCode returns the error classification code for JSON responses.
+func (e *SymbolNotFoundError) ErrorCode() string { return "SYMBOL_NOT_FOUND" }
+
+// ExitCode returns the process exit code for this error type.
+func (e *SymbolNotFoundError) ExitCode() int { return ExitNotFound }
+
 // HTTPError indicates that an HTTP request returned a non-2xx error status code.
 type HTTPError struct {
 	MarketSurgeError
@@ -152,6 +188,12 @@ func (e *HTTPError) As(target interface{}) bool {
 	return false
 }
 
+// ErrorCode returns the error classification code for JSON responses.
+func (e *HTTPError) ErrorCode() string { return "HTTP_ERROR" }
+
+// ExitCode returns the process exit code for this error type.
+func (e *HTTPError) ExitCode() int { return ExitAPIError }
+
 // ValidationError indicates that input validation failed.
 type ValidationError struct {
 	MarketSurgeError
@@ -167,6 +209,12 @@ func (e *ValidationError) As(target interface{}) bool {
 	}
 	return false
 }
+
+// ErrorCode returns the error classification code for JSON responses.
+func (e *ValidationError) ErrorCode() string { return "VALIDATION_ERROR" }
+
+// ExitCode returns the process exit code for this error type.
+func (e *ValidationError) ExitCode() int { return ExitGeneral }
 
 // NewMarketSurgeError creates a new MarketSurgeError wrapping the given cause.
 func NewMarketSurgeError(message string, cause error) *MarketSurgeError {
@@ -252,54 +300,19 @@ func NewValidationError(message string, cause error) *ValidationError {
 }
 
 // ExitCodeFor determines the appropriate exit code for the given error.
-// It checks error types from most specific to least specific using errors.As().
+// Each error type implements ExitCode() to declare its own exit code.
 // Returns ExitSuccess (0) if err is nil, otherwise returns the appropriate exit code.
 func ExitCodeFor(err error) int {
 	if err == nil {
 		return ExitSuccess
 	}
 
-	// Check most specific types first
-	var symbolNotFound *SymbolNotFoundError
-	if errors.As(err, &symbolNotFound) {
-		return ExitNotFound
+	type exitCoder interface{ ExitCode() int }
+
+	var coder exitCoder
+	if errors.As(err, &coder) {
+		return coder.ExitCode()
 	}
 
-	var cookieExtraction *CookieExtractionError
-	if errors.As(err, &cookieExtraction) {
-		return ExitAuthFailure
-	}
-
-	var tokenExpired *TokenExpiredError
-	if errors.As(err, &tokenExpired) {
-		return ExitAuthFailure
-	}
-
-	var authentication *AuthenticationError
-	if errors.As(err, &authentication) {
-		return ExitAuthFailure
-	}
-
-	var httpErr *HTTPError
-	if errors.As(err, &httpErr) {
-		return ExitAPIError
-	}
-
-	var apiErr *APIError
-	if errors.As(err, &apiErr) {
-		return ExitAPIError
-	}
-
-	var validation *ValidationError
-	if errors.As(err, &validation) {
-		return ExitGeneral
-	}
-
-	var marketSurge *MarketSurgeError
-	if errors.As(err, &marketSurge) {
-		return ExitGeneral
-	}
-
-	// Default to general error for unknown error types
 	return ExitGeneral
 }

--- a/internal/output/metadata.go
+++ b/internal/output/metadata.go
@@ -5,12 +5,17 @@ import (
 	"time"
 )
 
+// utcTimestamp returns the current UTC time formatted as RFC3339.
+func utcTimestamp() string {
+	return time.Now().UTC().Format(time.RFC3339)
+}
+
 // SymbolMeta creates metadata for a symbol query response.
 // It includes the symbol and a UTC timestamp in RFC3339 format.
 func SymbolMeta(symbol string) map[string]any {
 	return map[string]any{
 		"symbol":    symbol,
-		"timestamp": time.Now().UTC().Format(time.RFC3339),
+		"timestamp": utcTimestamp(),
 	}
 }
 
@@ -22,6 +27,6 @@ func CatalogMeta(kind string, total, limit, offset int) map[string]any {
 		"total":     total,
 		"limit":     limit,
 		"offset":    offset,
-		"timestamp": time.Now().UTC().Format(time.RFC3339),
+		"timestamp": utcTimestamp(),
 	}
 }

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -86,49 +86,14 @@ func WritePartial(w io.Writer, data any, errs []string, metadata map[string]any)
 }
 
 // errorCode maps an error to its corresponding error code string.
-// It uses errors.As() to check error types from most specific to least specific.
+// Each error type implements ErrorCode() to declare its own classification code.
 func errorCode(err error) string {
-	// Check most specific types first
-	var symbolNotFound *mserr.SymbolNotFoundError
-	if errors.As(err, &symbolNotFound) {
-		return "SYMBOL_NOT_FOUND"
+	type errorCoder interface{ ErrorCode() string }
+
+	var coder errorCoder
+	if errors.As(err, &coder) {
+		return coder.ErrorCode()
 	}
 
-	var cookieExtraction *mserr.CookieExtractionError
-	if errors.As(err, &cookieExtraction) {
-		return "AUTH_FAILED"
-	}
-
-	var tokenExpired *mserr.TokenExpiredError
-	if errors.As(err, &tokenExpired) {
-		return "AUTH_FAILED"
-	}
-
-	var authentication *mserr.AuthenticationError
-	if errors.As(err, &authentication) {
-		return "AUTH_FAILED"
-	}
-
-	var httpErr *mserr.HTTPError
-	if errors.As(err, &httpErr) {
-		return "HTTP_ERROR"
-	}
-
-	var apiErr *mserr.APIError
-	if errors.As(err, &apiErr) {
-		return "API_ERROR"
-	}
-
-	var validation *mserr.ValidationError
-	if errors.As(err, &validation) {
-		return "VALIDATION_ERROR"
-	}
-
-	var marketSurge *mserr.MarketSurgeError
-	if errors.As(err, &marketSurge) {
-		return "GENERAL_ERROR"
-	}
-
-	// Default to general error for unknown error types
 	return "GENERAL_ERROR"
 }


### PR DESCRIPTION
## Summary

Continuation of the boilerplate deduplication series (follows merged PR #6).

- Replace two identical pagination functions (`paginateWatchlistEntries`, `paginateCoachScreenRows`) with a single generic `paginateSlice[T any]`
- Add `ErrorCode()` and `ExitCode()` methods to all 8 error types, then collapse both `errorCode()` and `ExitCodeFor()` from ~80 lines of sequential `errors.As` chains to ~12 lines of interface dispatch
- Extract `utcTimestamp()` helper to prevent timestamp format drift

Net: -33 lines across 4 files. All tests pass.