### PR TITLE
fix: handle unknown commands and fix flaky auth test

### DIFF
--- a/cmd/marketsurge-agent/main.go
+++ b/cmd/marketsurge-agent/main.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -78,6 +79,10 @@ func buildApp(w io.Writer) *cli.Command {
 
 			*apiClient = *client.NewClient(jwt)
 			return ctx, nil
+		},
+		CommandNotFound: func(_ context.Context, _ *cli.Command, name string) {
+			err := errors.NewValidationError(fmt.Sprintf("unknown command %q", name), nil)
+			_ = output.WriteError(w, err)
 		},
 		Commands: []*cli.Command{
 			{

--- a/cmd/marketsurge-agent/main_test.go
+++ b/cmd/marketsurge-agent/main_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
 
 	"github.com/major/marketsurge-agent/internal/output"
 )
@@ -35,25 +36,33 @@ func TestHelpContainsAllCommands(t *testing.T) {
 }
 
 // TestUnknownCommandReturnsError verifies that an unrecognized subcommand
-// produces a non-nil error from Run.
+// produces a JSON error envelope via the CommandNotFound handler.
 func TestUnknownCommandReturnsError(t *testing.T) {
 	var buf bytes.Buffer
 	app := buildApp(&buf)
 	app.Writer = io.Discard
 
-	err := app.Run(context.Background(), []string{"marketsurge-agent", "nonexistent"})
-	assert.Error(t, err)
+	_ = app.Run(context.Background(), []string{"marketsurge-agent", "nonexistent"})
+
+	var envelope output.ErrorEnvelope
+	err := json.NewDecoder(&buf).Decode(&envelope)
+	require.NoError(t, err, "unknown command should produce valid JSON error envelope")
+	assert.Equal(t, "VALIDATION_ERROR", envelope.Error.Code)
+	assert.Contains(t, envelope.Error.Message, "nonexistent")
 }
 
 // TestErrorOutputIsValidJSON verifies that error responses are valid JSON
 // with the expected envelope structure.
 func TestErrorOutputIsValidJSON(t *testing.T) {
-	// Force auth failure by clearing all JWT sources.
+	// Force auth failure by clearing all JWT sources. HOME must point at a
+	// temp directory so Firefox cookie auto-discovery finds no profiles.
 	t.Setenv("MARKETSURGE_JWT", "")
+	t.Setenv("HOME", t.TempDir())
 
 	var jsonBuf bytes.Buffer
 	app := buildApp(&jsonBuf)
 	app.Writer = io.Discard
+	app.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
 
 	// Running a real command without auth triggers an AuthenticationError
 	// from the Before handler.

--- a/cmd/marketsurge-agent/main_test.go
+++ b/cmd/marketsurge-agent/main_test.go
@@ -38,9 +38,14 @@ func TestHelpContainsAllCommands(t *testing.T) {
 // TestUnknownCommandReturnsError verifies that an unrecognized subcommand
 // produces a JSON error envelope via the CommandNotFound handler.
 func TestUnknownCommandReturnsError(t *testing.T) {
+	// Provide a dummy JWT so the Before hook succeeds (it runs before
+	// command routing, even for unknown commands).
+	t.Setenv("MARKETSURGE_JWT", "test-token")
+
 	var buf bytes.Buffer
 	app := buildApp(&buf)
 	app.Writer = io.Discard
+	app.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
 
 	_ = app.Run(context.Background(), []string{"marketsurge-agent", "nonexistent"})
 


### PR DESCRIPTION
## Summary

- Add `CommandNotFound` handler to `buildApp()` that writes a JSON error envelope for unrecognized subcommands, matching the output contract
- Fix `TestUnknownCommandReturnsError` to verify the JSON envelope instead of relying on `Run()` returning an error (urfave/cli v3 returns nil for unknown commands)
- Fix `TestErrorOutputIsValidJSON` by isolating Firefox cookie auto-discovery (`HOME` to temp dir) and suppressing `ExitErrHandler` to prevent `os.Exit()` during tests