### PR TITLE
refactor: replace manual JSON navigation with gjson

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/browserutils/kooky v0.2.9
 	github.com/stretchr/testify v1.11.1
+	github.com/tidwall/gjson v1.18.0
 	github.com/urfave/cli/v3 v3.8.0
 )
 
@@ -14,6 +15,8 @@ require (
 	github.com/gonuts/binary v0.2.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.26 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	gopkg.in/ini.v1 v1.67.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,12 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/urfave/cli/v3 v3.8.0 h1:XqKPrm0q4P0q5JpoclYoCAv0/MIvH/jZ2umzuf8pNTI=
 github.com/urfave/cli/v3 v3.8.0/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
 github.com/zalando/go-keyring v0.2.7 h1:YbqBw40+g4g69UNk4WsRM/fV9YErfVWwozE2+7Bn+7g=

--- a/internal/client/catalog.go
+++ b/internal/client/catalog.go
@@ -2,8 +2,9 @@ package client
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
+
+	"github.com/tidwall/gjson"
 
 	"github.com/major/marketsurge-agent/internal/constants"
 	mserrors "github.com/major/marketsurge-agent/internal/errors"
@@ -102,18 +103,15 @@ func (c *Client) RunWatchlist(ctx context.Context, watchlistID int64) (*models.A
 		return nil, err
 	}
 
-	watchlist := getNestedMap(flaggedRaw, "data", "watchlist")
-	if len(watchlist) == 0 {
+	watchlist := gjson.GetBytes(flaggedRaw, "data.watchlist")
+	if !watchlist.Exists() || watchlist.Type == gjson.Null {
 		return nil, mserrors.NewAPIError(fmt.Sprintf("watchlist not found: %d", watchlistID), nil)
 	}
 
-	symbols := make([]string, 0, len(getNestedSlice(watchlist, "items")))
-	for _, entry := range getNestedSlice(watchlist, "items") {
-		item, ok := entry.(map[string]any)
-		if !ok {
-			continue
-		}
-		if key := stringPtr(item["dowJonesKey"]); key != nil {
+	items := watchlist.Get("items").Array()
+	symbols := make([]string, 0, len(items))
+	for _, entry := range items {
+		if key := gStr(entry.Get("dowJonesKey")); key != nil {
 			symbols = append(symbols, *key)
 		}
 	}
@@ -177,14 +175,14 @@ func (c *Client) RunCoachScreen(ctx context.Context, screenID string) (*models.S
 		return nil, err
 	}
 
-	container := getNestedMap(raw, "data", "user", "runScreen")
-	if len(container) == 0 {
+	container := gjson.GetBytes(raw, "data.user.runScreen")
+	if !container.Exists() || container.Type == gjson.Null {
 		return nil, mserrors.NewAPIError("no coach screen data returned", nil)
 	}
 
 	return &models.ScreenResult{
-		NumInstruments: intPtr(container["numberOfMatchingInstruments"]),
-		Rows:           parseRows(getNestedSlice(container, "responseValues")),
+		NumInstruments: gInt(container.Get("numberOfMatchingInstruments")),
+		Rows:           parseRows(container.Get("responseValues").Array()),
 	}, nil
 }
 
@@ -197,18 +195,15 @@ func (c *Client) listWatchlists(ctx context.Context) ([]models.CatalogEntry, err
 	if err != nil {
 		return nil, err
 	}
-	entries := make([]models.CatalogEntry, 0, len(getNestedSlice(raw, "data", "watchlists")))
-	for _, entry := range getNestedSlice(raw, "data", "watchlists") {
-		item, ok := entry.(map[string]any)
-		if !ok {
-			continue
-		}
-		name := stringify(item["name"])
+	items := gjson.GetBytes(raw, "data.watchlists").Array()
+	entries := make([]models.CatalogEntry, 0, len(items))
+	for _, item := range items {
+		name := stringify(item.Get("name"))
 		entries = append(entries, models.CatalogEntry{
 			Name:        name,
 			Kind:        models.CatalogKindWatchlist,
-			Description: stringPtr(item["description"]),
-			WatchlistID: int64Ptr(item["id"]),
+			Description: gStr(item.Get("description")),
+			WatchlistID: gInt64(item.Get("id")),
 		})
 	}
 	return entries, nil
@@ -224,16 +219,12 @@ func (c *Client) listScreens(ctx context.Context) ([]models.CatalogEntry, error)
 		return nil, err
 	}
 	entries := []models.CatalogEntry{}
-	for _, entry := range getNestedSlice(raw, "data", "user", "screens") {
-		item, ok := entry.(map[string]any)
-		if !ok {
-			continue
-		}
-		name := stringPtr(item["name"])
+	for _, item := range gjson.GetBytes(raw, "data.user.screens").Array() {
+		name := gStr(item.Get("name"))
 		if name == nil {
 			continue
 		}
-		entries = append(entries, models.CatalogEntry{Name: *name, Kind: models.CatalogKindScreen, Description: stringPtr(item["description"])})
+		entries = append(entries, models.CatalogEntry{Name: *name, Kind: models.CatalogKindScreen, Description: gStr(item.Get("description"))})
 	}
 	return entries, nil
 }
@@ -248,35 +239,31 @@ func (c *Client) listCoachEntries(ctx context.Context) ([]models.CatalogEntry, e
 		return nil, err
 	}
 	entries := []models.CatalogEntry{}
-	entries = append(entries, coachTreeEntries(getNestedSlice(raw, "data", "user", "screens"), true)...)
+	entries = append(entries, coachTreeEntries(gjson.GetBytes(raw, "data.user.screens").Array(), true)...)
 	return entries, nil
 }
 
-func coachTreeEntries(nodes []any, screen bool) []models.CatalogEntry {
+func coachTreeEntries(nodes []gjson.Result, screen bool) []models.CatalogEntry {
 	entries := []models.CatalogEntry{}
-	for _, entry := range nodes {
-		item, ok := entry.(map[string]any)
-		if !ok {
-			continue
-		}
-		if children := getNestedSlice(item, "children"); len(children) > 0 {
+	for _, item := range nodes {
+		if children := item.Get("children").Array(); len(children) > 0 {
 			entries = append(entries, coachTreeEntries(children, screen)...)
 			continue
 		}
-		name := stringify(item["name"])
+		name := stringify(item.Get("name"))
 		if name == "" {
 			continue
 		}
 		ref := getReferenceID(item)
 		if screen {
-			screenID := stringPtr(ref["screenId"])
+			screenID := gStr(ref.Get("screenId"))
 			if screenID == nil {
 				continue
 			}
 			entries = append(entries, models.CatalogEntry{Name: name, Kind: models.CatalogKindCoachScreen, CoachScreenID: screenID})
 			continue
 		}
-		watchlistID := int64Ptr(ref["watchlistId"])
+		watchlistID := gInt64(ref.Get("watchlistId"))
 		if watchlistID == nil {
 			continue
 		}
@@ -285,108 +272,73 @@ func coachTreeEntries(nodes []any, screen bool) []models.CatalogEntry {
 	return entries
 }
 
-func getReferenceID(node map[string]any) map[string]any {
-	reference, ok := node["referenceId"].(string)
-	if !ok || reference == "" {
-		return nil
+func getReferenceID(node gjson.Result) gjson.Result {
+	ref := node.Get("referenceId").String()
+	if ref == "" {
+		return gjson.Result{}
 	}
-	parsed := map[string]any{}
-	_ = json.Unmarshal([]byte(reference), &parsed)
-	return parsed
+	return gjson.Parse(ref)
 }
 
-func parseAdhocScreenResult(raw map[string]any) (*models.AdhocScreenResult, error) {
-	container := getNestedMap(raw, "data", "marketDataAdhocScreen")
-	if len(container) == 0 {
+func parseAdhocScreenResult(raw []byte) (*models.AdhocScreenResult, error) {
+	container := gjson.GetBytes(raw, "data.marketDataAdhocScreen")
+	if !container.Exists() || container.Type == gjson.Null {
 		return nil, mserrors.NewAPIError("no adhoc screen data returned", nil)
 	}
-	return &models.AdhocScreenResult{Entries: parseWatchlistEntries(getNestedSlice(container, "responseValues")), ErrorValues: stringSlice(getNestedSlice(container, "errorValues"))}, nil
+	return &models.AdhocScreenResult{
+		Entries:     parseWatchlistEntries(container.Get("responseValues").Array()),
+		ErrorValues: stringSlice(container.Get("errorValues").Array()),
+	}, nil
 }
 
-func parseWatchlistEntries(rows []any) []models.WatchlistEntry {
+func parseWatchlistEntries(rows []gjson.Result) []models.WatchlistEntry {
 	result := make([]models.WatchlistEntry, 0, len(rows))
 	for _, row := range rows {
-		columns, ok := row.([]any)
-		if !ok {
-			continue
-		}
-		mapped := map[string]any{}
-		for _, column := range columns {
-			item, ok := column.(map[string]any)
-			if !ok {
-				continue
-			}
-			name := stringify(getNestedMap(item, "mdItem")["name"])
-			mapped[name] = item["value"]
+		columns := row.Array()
+		mapped := map[string]gjson.Result{}
+		for _, col := range columns {
+			name := col.Get("mdItem.name").String()
+			mapped[name] = col.Get("value")
 		}
 		result = append(result, models.WatchlistEntry{
-			Symbol:              stringPtr(mapped["Symbol"]),
-			CompanyName:         stringPtr(mapped["CompanyName"]),
-			ListRank:            intPtr(mapped["ListRank"]),
-			Price:               floatPtr(mapped["Price"]),
-			PriceNetChange:      floatPtr(firstNonNil(mapped["PriceNetChange"], mapped["PriceNetChg"])),
-			PricePctChange:      floatPtr(mapped["PricePctChg"]),
-			PricePctOff52WHighs: floatPtr(mapped["PricePctOff52WHigh"]),
-			Volume:              intPtr(mapped["Volume"]),
-			VolumeChange:        intPtr(mapped["VolumeChange"]),
-			VolumePctChange:     floatPtr(mapped["VolumePctChg"]),
-			CompositeRating:     intPtr(mapped["CompositeRating"]),
-			EPSRating:           intPtr(mapped["EPSRating"]),
-			RSRating:            intPtr(mapped["RSRating"]),
-			AccDisRating:        stringPtr(mapped["AccDisRating"]),
-			SMRRating:           stringPtr(mapped["SMRRating"]),
-			IndustryGroupRank:   intPtr(mapped["IndustryGroupRank"]),
-			IndustryName:        stringPtr(mapped["IndustryName"]),
-			MarketCap:           floatPtr(mapped["MarketCapIntraday"]),
-			VolumeDollarAvg50D:  floatPtr(mapped["VolumeDollarAvg50D"]),
-			IPODate:             stringPtr(mapped["IPODate"]),
-			DowJonesKey:         stringPtr(mapped["DowJonesKey"]),
-			ChartingSymbol:      stringPtr(mapped["ChartingSymbol"]),
-			InstrumentType:      stringPtr(mapped["DowJonesInstrumentType"]),
-			InstrumentSubType:   stringPtr(mapped["DowJonesInstrumentSubType"]),
+			Symbol:              gStr(mapped["Symbol"]),
+			CompanyName:         gStr(mapped["CompanyName"]),
+			ListRank:            gInt(mapped["ListRank"]),
+			Price:               gFloat(mapped["Price"]),
+			PriceNetChange:      gFloat(firstExisting(mapped["PriceNetChange"], mapped["PriceNetChg"])),
+			PricePctChange:      gFloat(mapped["PricePctChg"]),
+			PricePctOff52WHighs: gFloat(mapped["PricePctOff52WHigh"]),
+			Volume:              gInt(mapped["Volume"]),
+			VolumeChange:        gInt(mapped["VolumeChange"]),
+			VolumePctChange:     gFloat(mapped["VolumePctChg"]),
+			CompositeRating:     gInt(mapped["CompositeRating"]),
+			EPSRating:           gInt(mapped["EPSRating"]),
+			RSRating:            gInt(mapped["RSRating"]),
+			AccDisRating:        gStr(mapped["AccDisRating"]),
+			SMRRating:           gStr(mapped["SMRRating"]),
+			IndustryGroupRank:   gInt(mapped["IndustryGroupRank"]),
+			IndustryName:        gStr(mapped["IndustryName"]),
+			MarketCap:           gFloat(mapped["MarketCapIntraday"]),
+			VolumeDollarAvg50D:  gFloat(mapped["VolumeDollarAvg50D"]),
+			IPODate:             gStr(mapped["IPODate"]),
+			DowJonesKey:         gStr(mapped["DowJonesKey"]),
+			ChartingSymbol:      gStr(mapped["ChartingSymbol"]),
+			InstrumentType:      gStr(mapped["DowJonesInstrumentType"]),
+			InstrumentSubType:   gStr(mapped["DowJonesInstrumentSubType"]),
 		})
 	}
 	return result
 }
 
-func parseRows(rows []any) []map[string]*string {
+func parseRows(rows []gjson.Result) []map[string]*string {
 	result := make([]map[string]*string, 0, len(rows))
 	for _, row := range rows {
-		columns, ok := row.([]any)
-		if !ok {
-			continue
-		}
+		columns := row.Array()
 		mapped := map[string]*string{}
-		for _, column := range columns {
-			item, ok := column.(map[string]any)
-			if !ok {
-				continue
-			}
-			mapped[stringify(getNestedMap(item, "mdItem")["name"])] = stringPtr(item["value"])
+		for _, col := range columns {
+			mapped[col.Get("mdItem.name").String()] = gStr(col.Get("value"))
 		}
 		result = append(result, mapped)
-	}
-	return result
-}
-
-func firstNonNil(values ...any) any {
-	for _, value := range values {
-		if value != nil {
-			return value
-		}
-	}
-	return nil
-}
-
-func stringSlice(values []any) []string {
-	if len(values) == 0 {
-		return nil
-	}
-	result := make([]string, 0, len(values))
-	for _, value := range values {
-		if text := stringify(value); text != "" {
-			result = append(result, text)
-		}
 	}
 	return result
 }

--- a/internal/client/chart.go
+++ b/internal/client/chart.go
@@ -3,6 +3,8 @@ package client
 import (
 	"context"
 
+	"github.com/tidwall/gjson"
+
 	"github.com/major/marketsurge-agent/internal/constants"
 	"github.com/major/marketsurge-agent/internal/models"
 	"github.com/major/marketsurge-agent/queries"
@@ -44,92 +46,89 @@ func (c *Client) GetChartHistory(ctx context.Context, symbol, startDate, endDate
 		return nil, err
 	}
 
-	pricing := getNestedMap(item, "pricing")
+	pricing := item.Get("pricing")
 	result := &models.ChartData{
 		Symbol:             symbol,
-		TimeSeries:         buildTimeSeries(getNestedMap(pricing, "timeSeries")),
-		Quote:              buildQuote(getNestedMap(pricing, "quote")),
-		PremarketQuote:     buildQuote(getNestedMap(pricing, "premarketQuote")),
-		PostmarketQuote:    buildQuote(getNestedMap(pricing, "postmarketQuote")),
-		CurrentMarketState: stringPtr(pricing["currentMarketState"]),
+		TimeSeries:         buildTimeSeries(pricing.Get("timeSeries")),
+		Quote:              buildQuote(pricing.Get("quote")),
+		PremarketQuote:     buildQuote(pricing.Get("premarketQuote")),
+		PostmarketQuote:    buildQuote(pricing.Get("postmarketQuote")),
+		CurrentMarketState: gStr(pricing.Get("currentMarketState")),
 	}
 
-	exchangeData := raw["data"]
-	if dataMap, ok := exchangeData.(map[string]any); ok {
-		if rawExchange, ok := dataMap["exchangeData"]; ok {
-			switch exchange := rawExchange.(type) {
-			case []any:
-				result.Exchange = buildExchange(firstMap(exchange))
-			case map[string]any:
-				result.Exchange = buildExchange(exchange)
+	exchangeData := gjson.GetBytes(raw, "data.exchangeData")
+	if exchangeData.Exists() {
+		if exchangeData.IsArray() {
+			if first := exchangeData.Get("0"); first.Exists() {
+				result.Exchange = buildExchange(first)
 			}
+		} else if exchangeData.IsObject() {
+			result.Exchange = buildExchange(exchangeData)
 		}
 	}
 
-	marketData := getNestedSlice(raw, "data", "marketData")
-	if len(marketData) > 1 {
-		if benchmarkItem, ok := marketData[1].(map[string]any); ok {
-			result.BenchmarkTimeSeries = buildTimeSeries(getNestedMap(benchmarkItem, "pricing", "timeSeries"))
-		}
+	benchmarkItem := gjson.GetBytes(raw, "data.marketData.1")
+	if benchmarkItem.Exists() {
+		result.BenchmarkTimeSeries = buildTimeSeries(benchmarkItem.Get("pricing.timeSeries"))
 	}
 
 	return result, nil
 }
 
-func buildQuote(item map[string]any) *models.Quote {
-	if len(item) == 0 {
+func buildQuote(item gjson.Result) *models.Quote {
+	if !item.Exists() {
 		return nil
 	}
 	return &models.Quote{
-		TradeDateTime:          stringPtr(item["tradeDateTime"]),
-		Timeliness:             stringPtr(item["timeliness"]),
-		QuoteType:              stringPtr(item["quoteType"]),
-		Last:                   floatPtr(item["last"]),
-		Volume:                 floatPtr(item["volume"]),
-		PercentChange:          floatPtr(item["percentChange"]),
-		NetChange:              floatPtr(item["netChange"]),
-		LastFormatted:          formattedValue(item["last"]),
-		VolumeFormatted:        formattedValue(item["volume"]),
-		PercentChangeFormatted: formattedValue(item["percentChange"]),
-		NetChangeFormatted:     formattedValue(item["netChange"]),
+		TradeDateTime:          gStr(item.Get("tradeDateTime")),
+		Timeliness:             gStr(item.Get("timeliness")),
+		QuoteType:              gStr(item.Get("quoteType")),
+		Last:                   gFloat(item.Get("last")),
+		Volume:                 gFloat(item.Get("volume")),
+		PercentChange:          gFloat(item.Get("percentChange")),
+		NetChange:              gFloat(item.Get("netChange")),
+		LastFormatted:          gStr(item.Get("last.formattedValue")),
+		VolumeFormatted:        gStr(item.Get("volume.formattedValue")),
+		PercentChangeFormatted: gStr(item.Get("percentChange.formattedValue")),
+		NetChangeFormatted:     gStr(item.Get("netChange.formattedValue")),
 	}
 }
 
-func buildTimeSeries(item map[string]any) *models.TimeSeries {
-	if len(item) == 0 {
+func buildTimeSeries(item gjson.Result) *models.TimeSeries {
+	if !item.Exists() {
 		return nil
 	}
 	return &models.TimeSeries{
-		Period: stringify(item["period"]),
-		DataPoints: buildSlice(getNestedSlice(item, "dataPoints"), func(point map[string]any) models.DataPoint {
+		Period: stringify(item.Get("period")),
+		DataPoints: buildSlice(item.Get("dataPoints").Array(), func(point gjson.Result) models.DataPoint {
 			return models.DataPoint{
-				StartDateTime: stringPtr(point["startDateTime"]),
-				EndDateTime:   stringPtr(point["endDateTime"]),
-				Open:          floatPtr(point["open"]),
-				High:          floatPtr(point["high"]),
-				Low:           floatPtr(point["low"]),
-				Close:         floatPtr(point["last"]),
-				Volume:        floatPtr(point["volume"]),
+				StartDateTime: gStr(point.Get("startDateTime")),
+				EndDateTime:   gStr(point.Get("endDateTime")),
+				Open:          gFloat(point.Get("open")),
+				High:          gFloat(point.Get("high")),
+				Low:           gFloat(point.Get("low")),
+				Close:         gFloat(point.Get("last")),
+				Volume:        gFloat(point.Get("volume")),
 			}
 		}),
 	}
 }
 
-func buildExchange(item map[string]any) *models.ExchangeInfo {
-	if len(item) == 0 {
+func buildExchange(item gjson.Result) *models.ExchangeInfo {
+	if !item.Exists() {
 		return nil
 	}
 	return &models.ExchangeInfo{
-		City:        stringPtr(item["city"]),
-		CountryCode: stringPtr(item["countryCode"]),
-		ExchangeISO: stringPtr(item["exchangeISO"]),
-		Holidays: buildSlice(getNestedSlice(item, "holidays"), func(holiday map[string]any) models.ExchangeHoliday {
+		City:        gStr(item.Get("city")),
+		CountryCode: gStr(item.Get("countryCode")),
+		ExchangeISO: gStr(item.Get("exchangeISO")),
+		Holidays: buildSlice(item.Get("holidays").Array(), func(holiday gjson.Result) models.ExchangeHoliday {
 			return models.ExchangeHoliday{
-				Name:          stringify(holiday["name"]),
-				HolidayType:   stringPtr(holiday["holidayType"]),
-				Description:   stringPtr(holiday["description"]),
-				StartDateTime: stringify(holiday["startDateTime"]),
-				EndDateTime:   stringify(holiday["endDateTime"]),
+				Name:          stringify(holiday.Get("name")),
+				HolidayType:   gStr(holiday.Get("holidayType")),
+				Description:   gStr(holiday.Get("description")),
+				StartDateTime: stringify(holiday.Get("startDateTime")),
+				EndDateTime:   stringify(holiday.Get("endDateTime")),
 			}
 		}),
 	}

--- a/internal/client/chart_markups.go
+++ b/internal/client/chart_markups.go
@@ -3,6 +3,8 @@ package client
 import (
 	"context"
 
+	"github.com/tidwall/gjson"
+
 	"github.com/major/marketsurge-agent/internal/models"
 	"github.com/major/marketsurge-agent/queries"
 )
@@ -28,18 +30,18 @@ func (c *Client) GetChartMarkups(ctx context.Context, symbol, frequency, sortDir
 		return nil, err
 	}
 
-	container := getNestedMap(raw, "data", "user", "chartMarkups")
+	container := gjson.GetBytes(raw, "data.user.chartMarkups")
 	return &models.ChartMarkupList{
-		CursorID: stringify(container["cursorId"]),
-		Markups: buildSlice(getNestedSlice(container, "chartMarkups"), func(item map[string]any) models.ChartMarkup {
+		CursorID: stringify(container.Get("cursorId")),
+		Markups: buildSlice(container.Get("chartMarkups").Array(), func(item gjson.Result) models.ChartMarkup {
 			return models.ChartMarkup{
-				ID:        stringify(item["id"]),
-				Name:      stringPtr(item["name"]),
-				Data:      stringify(item["data"]),
-				Frequency: stringPtr(item["frequency"]),
-				Site:      stringPtr(item["site"]),
-				CreatedAt: stringPtr(item["createdAt"]),
-				UpdatedAt: stringPtr(item["updatedAt"]),
+				ID:        stringify(item.Get("id")),
+				Name:      gStr(item.Get("name")),
+				Data:      stringify(item.Get("data")),
+				Frequency: gStr(item.Get("frequency")),
+				Site:      gStr(item.Get("site")),
+				CreatedAt: gStr(item.Get("createdAt")),
+				UpdatedAt: gStr(item.Get("updatedAt")),
 			}
 		}),
 	}, nil

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -41,8 +41,8 @@ func NewClient(jwt string) *Client {
 	}
 }
 
-// Execute sends a GraphQL request and returns the decoded response body.
-func (c *Client) Execute(ctx context.Context, payload Request) (map[string]any, error) {
+// Execute sends a GraphQL request and returns the raw response body.
+func (c *Client) Execute(ctx context.Context, payload Request) ([]byte, error) {
 	encodedPayload, err := json.Marshal(payload)
 	if err != nil {
 		return nil, fmt.Errorf("marshal graphql payload: %w", err)
@@ -71,16 +71,11 @@ func (c *Client) Execute(ctx context.Context, payload Request) (map[string]any, 
 		return nil, mapHTTPError(response.StatusCode, string(body), nil)
 	}
 
-	var raw map[string]any
-	if err := json.Unmarshal(body, &raw); err != nil {
-		return nil, fmt.Errorf("decode graphql response: %w", err)
+	if err := mapGraphQLError(body); err != nil {
+		return body, err
 	}
 
-	if err := mapGraphQLError(raw); err != nil {
-		return raw, err
-	}
-
-	return raw, nil
+	return body, nil
 }
 
 func (c *Client) endpoint() string {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/tidwall/gjson"
+
 	mserrors "github.com/major/marketsurge-agent/internal/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,7 +38,7 @@ func TestExecuteSetsHeadersAndAuthorization(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "TestOp", captured.OperationName)
 	assert.Equal(t, "x", captured.Variables["value"])
-	assert.Equal(t, true, getNestedMap(raw, "data")["ok"])
+	assert.True(t, gjson.GetBytes(raw, "data.ok").Bool())
 }
 
 func TestExecuteReturnsGraphQLErrorOnHTTP200(t *testing.T) {

--- a/internal/client/fundamentals.go
+++ b/internal/client/fundamentals.go
@@ -3,6 +3,8 @@ package client
 import (
 	"context"
 
+	"github.com/tidwall/gjson"
+
 	"github.com/major/marketsurge-agent/internal/constants"
 	"github.com/major/marketsurge-agent/internal/models"
 	"github.com/major/marketsurge-agent/queries"
@@ -36,49 +38,42 @@ func (c *Client) GetFundamentals(ctx context.Context, symbol string) (*models.Fu
 		return nil, err
 	}
 
-	financials := getNestedMap(item, "financials")
-	consensus := getNestedMap(financials, "consensusFinancials")
-	estimates := getNestedMap(financials, "estimates")
-	symbology := getNestedMap(item, "symbology")
-	companyName := stringPtr(firstMap(getNestedSlice(symbology, "company"))["companyName"])
+	consensus := item.Get("financials.consensusFinancials")
+	companyName := gStr(item.Get("symbology.company.0.companyName"))
 
 	return &models.FundamentalData{
 		Symbol:           symbol,
 		CompanyName:      companyName,
-		ReportedEarnings: buildReportedPeriods(getNestedSlice(consensus, "eps", "reportedEarnings")),
-		ReportedSales:    buildReportedPeriods(getNestedSlice(consensus, "sales", "reportedSales")),
-		EPSEstimates:     buildEstimatePeriods(getNestedSlice(estimates, "epsEstimates")),
-		SalesEstimates:   buildEstimatePeriods(getNestedSlice(estimates, "salesEstimates")),
+		ReportedEarnings: buildReportedPeriods(consensus.Get("eps.reportedEarnings").Array()),
+		ReportedSales:    buildReportedPeriods(consensus.Get("sales.reportedSales").Array()),
+		EPSEstimates:     buildEstimatePeriods(item.Get("financials.estimates.epsEstimates").Array()),
+		SalesEstimates:   buildEstimatePeriods(item.Get("financials.estimates.salesEstimates").Array()),
 	}, nil
 }
 
-func buildReportedPeriods(items []any) []models.ReportedPeriod {
-	return buildSlice(items, func(item map[string]any) models.ReportedPeriod {
-		valueMap, _ := item["value"].(map[string]any)
-		pctMap, _ := item["percentChangeYOY"].(map[string]any)
+func buildReportedPeriods(items []gjson.Result) []models.ReportedPeriod {
+	return buildSlice(items, func(item gjson.Result) models.ReportedPeriod {
 		return models.ReportedPeriod{
-			Value:              floatPtr(item["value"]),
-			FormattedValue:     stringPtr(valueMap["formattedValue"]),
-			PctChangeYoY:       floatPtr(item["percentChangeYOY"]),
-			FormattedPctChange: stringPtr(pctMap["formattedValue"]),
-			PeriodOffset:       stringify(item["periodOffset"]),
-			PeriodEndDate:      stringPtr(item["periodEndDate"]),
+			Value:              gFloat(item.Get("value")),
+			FormattedValue:     gStr(item.Get("value.formattedValue")),
+			PctChangeYoY:       gFloat(item.Get("percentChangeYOY")),
+			FormattedPctChange: gStr(item.Get("percentChangeYOY.formattedValue")),
+			PeriodOffset:       stringify(item.Get("periodOffset")),
+			PeriodEndDate:      gStr(item.Get("periodEndDate")),
 		}
 	})
 }
 
-func buildEstimatePeriods(items []any) []models.EstimatePeriod {
-	return buildSlice(items, func(item map[string]any) models.EstimatePeriod {
-		valueMap, _ := item["value"].(map[string]any)
-		pctMap, _ := item["percentChangeYOY"].(map[string]any)
+func buildEstimatePeriods(items []gjson.Result) []models.EstimatePeriod {
+	return buildSlice(items, func(item gjson.Result) models.EstimatePeriod {
 		return models.EstimatePeriod{
-			Value:              floatPtr(item["value"]),
-			FormattedValue:     stringPtr(valueMap["formattedValue"]),
-			PctChangeYoY:       floatPtr(item["percentChangeYOY"]),
-			FormattedPctChange: stringPtr(pctMap["formattedValue"]),
-			PeriodOffset:       stringify(item["periodOffset"]),
-			Period:             stringPtr(item["period"]),
-			RevisionDirection:  stringPtr(item["revisionDirection"]),
+			Value:              gFloat(item.Get("value")),
+			FormattedValue:     gStr(item.Get("value.formattedValue")),
+			PctChangeYoY:       gFloat(item.Get("percentChangeYOY")),
+			FormattedPctChange: gStr(item.Get("percentChangeYOY.formattedValue")),
+			PeriodOffset:       stringify(item.Get("periodOffset")),
+			Period:             gStr(item.Get("period")),
+			RevisionDirection:  gStr(item.Get("revisionDirection")),
 		}
 	})
 }

--- a/internal/client/graphql_error.go
+++ b/internal/client/graphql_error.go
@@ -1,282 +1,160 @@
 package client
 
 import (
-	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
+
+	"github.com/tidwall/gjson"
 
 	mserrors "github.com/major/marketsurge-agent/internal/errors"
 )
 
-func mapGraphQLError(raw map[string]any) error {
-	entries, ok := raw["errors"]
-	if !ok {
+// mapGraphQLError checks the raw response body for GraphQL-level errors.
+func mapGraphQLError(body []byte) error {
+	errs := gjson.GetBytes(body, "errors")
+	if !errs.Exists() {
 		return nil
 	}
 
-	errorList, ok := entries.([]any)
-	if !ok || len(errorList) == 0 {
+	items := errs.Array()
+	if len(items) == 0 {
 		return nil
 	}
 
-	messages := make([]string, 0, len(errorList))
-	for _, entry := range errorList {
-		if item, ok := entry.(map[string]any); ok {
-			if message, ok := item["message"].(string); ok && message != "" {
-				messages = append(messages, message)
-				continue
-			}
+	messages := make([]string, 0, len(items))
+	for _, item := range items {
+		if msg := item.Get("message").String(); msg != "" {
+			messages = append(messages, msg)
+		} else {
+			messages = append(messages, item.Raw)
 		}
-		messages = append(messages, stringify(entry))
 	}
 
 	return mserrors.NewAPIError("graphql errors: "+strings.Join(messages, "; "), nil)
 }
 
-func firstMarketData(raw map[string]any, symbol string) (map[string]any, error) {
-	marketData := getNestedSlice(raw, "data", "marketData")
-	if len(marketData) == 0 {
-		return nil, mserrors.NewSymbolNotFoundError(fmt.Sprintf("symbol not found: %q", symbol), nil, symbol)
+// firstMarketData returns the first element of data.marketData from a raw response.
+func firstMarketData(body []byte, symbol string) (gjson.Result, error) {
+	item := gjson.GetBytes(body, "data.marketData.0")
+	if !item.Exists() {
+		return gjson.Result{}, mserrors.NewSymbolNotFoundError(
+			fmt.Sprintf("symbol not found: %q", symbol), nil, symbol,
+		)
 	}
-
-	item, ok := marketData[0].(map[string]any)
-	if !ok {
-		return nil, fmt.Errorf("invalid marketData item for %q", symbol)
-	}
-
 	return item, nil
 }
 
-func getNestedMap(root map[string]any, keys ...string) map[string]any {
-	current := any(root)
-	for _, key := range keys {
-		mapping, ok := current.(map[string]any)
-		if !ok {
-			return nil
-		}
-		current = mapping[key]
+// gScalar extracts the scalar value from a gjson result, unwrapping {value: X}
+// wrappers used by the MarketSurge API. Returns the result unchanged if it is
+// not a wrapper object. Filters the sentinel date "0001-01-01".
+func gScalar(r gjson.Result) gjson.Result {
+	if !r.Exists() || r.Type == gjson.Null {
+		return r
 	}
-
-	mapping, _ := current.(map[string]any)
-	return mapping
-}
-
-func getNestedSlice(root map[string]any, keys ...string) []any {
-	current := any(root)
-	for _, key := range keys {
-		mapping, ok := current.(map[string]any)
-		if !ok {
-			return nil
-		}
-		current = mapping[key]
-	}
-
-	slice, _ := current.([]any)
-	return slice
-}
-
-func firstMap(items []any) map[string]any {
-	if len(items) == 0 {
-		return nil
-	}
-	mapping, _ := items[0].(map[string]any)
-	return mapping
-}
-
-func scalarValue(node any) any {
-	if mapping, ok := node.(map[string]any); ok {
-		if value, ok := mapping["value"]; ok {
-			if stringValue, ok := value.(string); ok && stringValue == "0001-01-01" {
-				return nil
+	if r.IsObject() {
+		if v := r.Get("value"); v.Exists() {
+			if v.Type == gjson.String && v.String() == "0001-01-01" {
+				return gjson.Result{}
 			}
-			return value
+			return v
 		}
 	}
-	return node
+	return r
 }
 
-func formattedValue(node any) *string {
-	mapping, ok := node.(map[string]any)
-	if !ok {
+// gStr extracts a string pointer, unwrapping {value: X} wrappers.
+func gStr(r gjson.Result) *string {
+	v := gScalar(r)
+	if !v.Exists() || v.Type == gjson.Null {
 		return nil
 	}
-	return stringPtr(mapping["formattedValue"])
+	s := v.String()
+	if s == "" {
+		return nil
+	}
+	return &s
 }
 
-func stringPtr(value any) *string {
-	if value == nil {
+// gInt extracts an int pointer, unwrapping {value: X} wrappers.
+func gInt(r gjson.Result) *int {
+	v := gScalar(r)
+	if !v.Exists() || v.Type == gjson.Null {
 		return nil
 	}
-	resolved := scalarValue(value)
-	if resolved == nil {
-		return nil
-	}
-	switch typed := resolved.(type) {
-	case string:
-		if typed == "" {
-			return nil
-		}
-		return &typed
-	default:
-		text := stringify(typed)
-		if text == "" {
-			return nil
-		}
-		return &text
-	}
+	n := int(v.Int())
+	return &n
 }
 
-func intPtr(value any) *int {
-	if value == nil {
+// gInt64 extracts an int64 pointer, unwrapping {value: X} wrappers.
+func gInt64(r gjson.Result) *int64 {
+	v := gScalar(r)
+	if !v.Exists() || v.Type == gjson.Null {
 		return nil
 	}
-	resolved := scalarValue(value)
-	switch typed := resolved.(type) {
-	case float64:
-		result := int(typed)
-		return &result
-	case int:
-		result := typed
-		return &result
-	case int64:
-		result := int(typed)
-		return &result
-	case json.Number:
-		parsed, err := typed.Int64()
-		if err != nil {
-			return nil
-		}
-		result := int(parsed)
-		return &result
-	case string:
-		if typed == "" {
-			return nil
-		}
-		parsed, err := strconv.Atoi(typed)
-		if err != nil {
-			return nil
-		}
-		return &parsed
-	default:
-		return nil
-	}
+	n := v.Int()
+	return &n
 }
 
-func int64Ptr(value any) *int64 {
-	if value == nil {
+// gFloat extracts a float64 pointer, unwrapping {value: X} wrappers.
+func gFloat(r gjson.Result) *float64 {
+	v := gScalar(r)
+	if !v.Exists() || v.Type == gjson.Null {
 		return nil
 	}
-	resolved := scalarValue(value)
-	switch typed := resolved.(type) {
-	case float64:
-		result := int64(typed)
-		return &result
-	case int64:
-		result := typed
-		return &result
-	case int:
-		result := int64(typed)
-		return &result
-	case json.Number:
-		parsed, err := typed.Int64()
-		if err != nil {
-			return nil
-		}
-		return &parsed
-	case string:
-		if typed == "" {
-			return nil
-		}
-		parsed, err := strconv.ParseInt(typed, 10, 64)
-		if err != nil {
-			return nil
-		}
-		return &parsed
-	default:
-		return nil
-	}
+	f := v.Float()
+	return &f
 }
 
-func floatPtr(value any) *float64 {
-	if value == nil {
+// gBool extracts a bool pointer, unwrapping {value: X} wrappers.
+func gBool(r gjson.Result) *bool {
+	v := gScalar(r)
+	if !v.Exists() || v.Type == gjson.Null {
 		return nil
 	}
-	resolved := scalarValue(value)
-	switch typed := resolved.(type) {
-	case float64:
-		result := typed
-		return &result
-	case int:
-		result := float64(typed)
-		return &result
-	case int64:
-		result := float64(typed)
-		return &result
-	case json.Number:
-		parsed, err := typed.Float64()
-		if err != nil {
-			return nil
-		}
-		return &parsed
-	case string:
-		if typed == "" {
-			return nil
-		}
-		parsed, err := strconv.ParseFloat(typed, 64)
-		if err != nil {
-			return nil
-		}
-		return &parsed
-	default:
-		return nil
-	}
+	b := v.Bool()
+	return &b
 }
 
-func boolPtr(value any) *bool {
-	if value == nil {
-		return nil
-	}
-	resolved := scalarValue(value)
-	switch typed := resolved.(type) {
-	case bool:
-		result := typed
-		return &result
-	case string:
-		parsed, err := strconv.ParseBool(typed)
-		if err != nil {
-			return nil
-		}
-		return &parsed
-	default:
-		return nil
-	}
-}
-
-// buildSlice iterates untyped JSON array items, type-asserts each to
-// map[string]any, and maps them to a typed slice using the provided function.
-// Items that are not maps are silently skipped.
-func buildSlice[T any](items []any, mapper func(map[string]any) T) []T {
+// buildSlice maps a gjson array to a typed slice.
+func buildSlice[T any](items []gjson.Result, fn func(gjson.Result) T) []T {
 	result := make([]T, 0, len(items))
-	for _, entry := range items {
-		item, ok := entry.(map[string]any)
-		if !ok {
-			continue
-		}
-		result = append(result, mapper(item))
+	for _, item := range items {
+		result = append(result, fn(item))
 	}
 	return result
 }
 
-func stringify(value any) string {
-	switch typed := value.(type) {
-	case string:
-		return typed
-	default:
-		encoded, err := json.Marshal(typed)
-		if err != nil {
-			return fmt.Sprintf("%v", typed)
-		}
-		return string(encoded)
+// stringify converts a gjson result to its string representation.
+func stringify(r gjson.Result) string {
+	if !r.Exists() {
+		return ""
 	}
+	if r.Type == gjson.String {
+		return r.String()
+	}
+	return r.Raw
+}
+
+// firstExisting returns the first result that exists and is not null.
+func firstExisting(results ...gjson.Result) gjson.Result {
+	for _, r := range results {
+		if r.Exists() && r.Type != gjson.Null {
+			return r
+		}
+	}
+	return gjson.Result{}
+}
+
+// stringSlice converts a gjson array to a string slice, skipping empty values.
+func stringSlice(items []gjson.Result) []string {
+	if len(items) == 0 {
+		return nil
+	}
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		if s := item.String(); s != "" {
+			result = append(result, s)
+		}
+	}
+	return result
 }

--- a/internal/client/ownership.go
+++ b/internal/client/ownership.go
@@ -3,6 +3,8 @@ package client
 import (
 	"context"
 
+	"github.com/tidwall/gjson"
+
 	"github.com/major/marketsurge-agent/internal/constants"
 	"github.com/major/marketsurge-agent/internal/models"
 	"github.com/major/marketsurge-agent/queries"
@@ -32,15 +34,14 @@ func (c *Client) GetOwnership(ctx context.Context, symbol string) (*models.Owner
 		return nil, err
 	}
 
-	ownership := getNestedMap(item, "ownership")
-	quarterly := getNestedSlice(ownership, "fundOwnershipSummary")
+	ownership := item.Get("ownership")
 	return &models.OwnershipData{
 		Symbol:        symbol,
-		FundsFloatPct: formattedValue(ownership["fundsFloatPercentHeld"]),
-		QuarterlyFunds: buildSlice(quarterly, func(item map[string]any) models.QuarterlyFundOwnership {
+		FundsFloatPct: gStr(ownership.Get("fundsFloatPercentHeld.formattedValue")),
+		QuarterlyFunds: buildSlice(ownership.Get("fundOwnershipSummary").Array(), func(entry gjson.Result) models.QuarterlyFundOwnership {
 			return models.QuarterlyFundOwnership{
-				Date:  stringPtr(item["date"]),
-				Count: formattedValue(item["numberOfFundsHeld"]),
+				Date:  gStr(entry.Get("date")),
+				Count: gStr(entry.Get("numberOfFundsHeld.formattedValue")),
 			}
 		}),
 	}, nil

--- a/internal/client/rs_history.go
+++ b/internal/client/rs_history.go
@@ -3,6 +3,8 @@ package client
 import (
 	"context"
 
+	"github.com/tidwall/gjson"
+
 	"github.com/major/marketsurge-agent/internal/constants"
 	"github.com/major/marketsurge-agent/internal/models"
 	"github.com/major/marketsurge-agent/queries"
@@ -32,20 +34,18 @@ func (c *Client) GetRSRatingHistory(ctx context.Context, symbol string) (*models
 		return nil, err
 	}
 
-	ratings := getNestedSlice(item, "ratings", "rsRating")
-	intraday := getNestedMap(item, "pricingStatistics", "intradayStatistics")
 	result := &models.RSRatingHistory{
 		Symbol: symbol,
-		Ratings: buildSlice(ratings, func(item map[string]any) models.RSRatingSnapshot {
+		Ratings: buildSlice(item.Get("ratings.rsRating").Array(), func(entry gjson.Result) models.RSRatingSnapshot {
 			return models.RSRatingSnapshot{
-				LetterValue:  stringPtr(item["letterValue"]),
-				Period:       stringPtr(item["period"]),
-				PeriodOffset: stringPtr(item["periodOffset"]),
-				Value:        intPtr(item["value"]),
+				LetterValue:  gStr(entry.Get("letterValue")),
+				Period:       gStr(entry.Get("period")),
+				PeriodOffset: gStr(entry.Get("periodOffset")),
+				Value:        gInt(entry.Get("value")),
 			}
 		}),
 	}
-	result.RSLineNewHigh = boolPtr(intraday["rsLineNewHigh"])
+	result.RSLineNewHigh = gBool(item.Get("pricingStatistics.intradayStatistics.rsLineNewHigh"))
 
 	return result, nil
 }

--- a/internal/client/stock.go
+++ b/internal/client/stock.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/tidwall/gjson"
+
 	"github.com/major/marketsurge-agent/internal/constants"
 	"github.com/major/marketsurge-agent/internal/models"
 	"github.com/major/marketsurge-agent/queries"
@@ -42,174 +44,162 @@ func (c *Client) GetStock(ctx context.Context, symbol string) (*models.StockData
 		return nil, err
 	}
 
-	ratings := getNestedMap(item, "ratings")
-	pricingStatistics := getNestedMap(item, "pricingStatistics")
-	pricingEOD := getNestedMap(pricingStatistics, "endOfDayStatistics")
-	pricingIntraday := getNestedMap(pricingStatistics, "intradayStatistics")
-	financials := getNestedMap(item, "financials")
-	consensus := getNestedMap(financials, "consensusFinancials")
-	epsConsensus := getNestedMap(consensus, "eps")
-	salesConsensus := getNestedMap(consensus, "sales")
-	industry := getNestedMap(item, "industry")
-	ownership := getNestedMap(item, "ownership")
-	fundamentals := getNestedMap(item, "fundamentals")
-	corporateActions := getNestedMap(item, "corporateActions")
-	symbology := getNestedMap(item, "symbology")
-	company := firstMap(getNestedSlice(symbology, "company"))
-	instrument := firstMap(getNestedSlice(symbology, "instrument"))
-	compRating := firstMap(getNestedSlice(ratings, "compRating"))
-	epsRating := firstMap(getNestedSlice(ratings, "epsRating"))
-	rsRating := firstMap(getNestedSlice(ratings, "rsRating"))
-	smrRating := firstMap(getNestedSlice(ratings, "smrRating"))
-	adRating := firstMap(getNestedSlice(ratings, "adRating"))
-	groupRank := firstMap(getNestedSlice(industry, "groupRanks"))
-	groupRS := firstMap(getNestedSlice(industry, "groupRS"))
-	profitMargin := firstMap(getNestedSlice(financials, "profitMarginValues"))
-	epsGrowth := firstMap(getNestedSlice(epsConsensus, "growthRate"))
-	salesGrowth := firstMap(getNestedSlice(salesConsensus, "growthRate"))
-	atr21d := firstMap(getNestedSlice(pricingEOD, "averageTrueRangePercent"))
+	ratings := item.Get("ratings")
+	pricingEOD := item.Get("pricingStatistics.endOfDayStatistics")
+	pricingIntraday := item.Get("pricingStatistics.intradayStatistics")
+	financials := item.Get("financials")
+	epsConsensus := financials.Get("consensusFinancials.eps")
+	salesConsensus := financials.Get("consensusFinancials.sales")
+	industry := item.Get("industry")
+	ownership := item.Get("ownership")
+	fundmtls := item.Get("fundamentals")
+	corporateActions := item.Get("corporateActions")
+	company := item.Get("symbology.company.0")
+	instrument := item.Get("symbology.instrument.0")
+	profitMargin := financials.Get("profitMarginValues.0")
+	atr := pricingEOD.Get("averageTrueRangePercent.0")
 
 	return &models.StockData{
 		Symbol: symbol,
 		Ratings: &models.Ratings{
-			Composite: intPtr(compRating["value"]),
-			EPS:       intPtr(epsRating["value"]),
-			RS:        intPtr(rsRating["value"]),
-			SMR:       stringPtr(smrRating["letterValue"]),
-			AD:        stringPtr(adRating["letterValue"]),
+			Composite: gInt(ratings.Get("compRating.0.value")),
+			EPS:       gInt(ratings.Get("epsRating.0.value")),
+			RS:        gInt(ratings.Get("rsRating.0.value")),
+			SMR:       gStr(ratings.Get("smrRating.0.letterValue")),
+			AD:        gStr(ratings.Get("adRating.0.letterValue")),
 		},
 		Company: &models.Company{
-			Name:                  stringPtr(company["companyName"]),
-			Industry:              stringPtr(industry["name"]),
-			Sector:                stringPtr(industry["sector"]),
-			IndustryGroupRank:     intPtr(groupRank["value"]),
-			IndustryGroupRS:       intPtr(groupRS["value"]),
-			IndustryGroupRSLetter: stringPtr(groupRS["letterValue"]),
-			Description:           stringPtr(company["businessDescription"]),
-			Website:               stringPtr(company["url"]),
-			Address:               stringPtr(company["address"]),
-			Address2:              stringPtr(company["address2"]),
-			Phone:                 stringPtr(company["phone"]),
-			IPODate:               stringPtr(instrument["ipoDate"]),
-			IPOPrice:              floatPtr(instrument["ipoPrice"]),
-			IPOPriceFormatted:     formattedValue(instrument["ipoPrice"]),
-			City:                  stringPtr(company["city"]),
-			Country:               stringPtr(company["country"]),
-			StateProvince:         stringPtr(company["stateProvince"]),
-			InstrumentSubType:     stringPtr(instrument["subType"]),
+			Name:                  gStr(company.Get("companyName")),
+			Industry:              gStr(industry.Get("name")),
+			Sector:                gStr(industry.Get("sector")),
+			IndustryGroupRank:     gInt(industry.Get("groupRanks.0.value")),
+			IndustryGroupRS:       gInt(industry.Get("groupRS.0.value")),
+			IndustryGroupRSLetter: gStr(industry.Get("groupRS.0.letterValue")),
+			Description:           gStr(company.Get("businessDescription")),
+			Website:               gStr(company.Get("url")),
+			Address:               gStr(company.Get("address")),
+			Address2:              gStr(company.Get("address2")),
+			Phone:                 gStr(company.Get("phone")),
+			IPODate:               gStr(instrument.Get("ipoDate")),
+			IPOPrice:              gFloat(instrument.Get("ipoPrice")),
+			IPOPriceFormatted:     gStr(instrument.Get("ipoPrice.formattedValue")),
+			City:                  gStr(company.Get("city")),
+			Country:               gStr(company.Get("country")),
+			StateProvince:         gStr(company.Get("stateProvince")),
+			InstrumentSubType:     gStr(instrument.Get("subType")),
 		},
 		Pricing: &models.Pricing{
-			MarketCap:                            floatPtr(pricingEOD["marketCapitalization"]),
-			MarketCapFormatted:                   formattedValue(pricingEOD["marketCapitalization"]),
-			AvgDollarVolume50D:                   floatPtr(pricingEOD["avgDollarVolume50Day"]),
-			AvgDollarVolume50DFormatted:          formattedValue(pricingEOD["avgDollarVolume50Day"]),
-			UpDownVolumeRatio:                    floatPtr(pricingEOD["upDownVolumeRatio"]),
-			UpDownVolumeRatioFormatted:           formattedValue(pricingEOD["upDownVolumeRatio"]),
-			ATRPercent21D:                        floatPtr(atr21d),
-			ATRPercent21DFormatted:               formattedValue(atr21d),
-			DividendYield:                        floatPtr(pricingIntraday["yield"]),
-			DividendYieldFormatted:               formattedValue(pricingIntraday["yield"]),
-			PriceToCashFlowRatio:                 floatPtr(pricingIntraday["priceToCashFlowRatio"]),
-			PriceToCashFlowRatioFormatted:        formattedValue(pricingIntraday["priceToCashFlowRatio"]),
-			ForwardPriceToEarningsRatio:          floatPtr(pricingIntraday["forwardPriceToEarningsRatio"]),
-			ForwardPriceToEarningsRatioFormatted: formattedValue(pricingIntraday["forwardPriceToEarningsRatio"]),
-			PriceToSalesRatio:                    floatPtr(pricingIntraday["priceToSalesRatio"]),
-			PriceToSalesRatioFormatted:           formattedValue(pricingIntraday["priceToSalesRatio"]),
-			PriceToEarningsRatio:                 floatPtr(pricingIntraday["priceToEarningsRatio"]),
-			PriceToEarningsRatioFormatted:        formattedValue(pricingIntraday["priceToEarningsRatio"]),
-			PEVsSP500:                            floatPtr(pricingIntraday["priceToEarningsVsSP500"]),
-			PEVsSP500Formatted:                   formattedValue(pricingIntraday["priceToEarningsVsSP500"]),
-			Alpha:                                floatPtr(pricingEOD["alpha"]),
-			AlphaFormatted:                       formattedValue(pricingEOD["alpha"]),
-			Beta:                                 floatPtr(pricingEOD["beta"]),
-			BetaFormatted:                        formattedValue(pricingEOD["beta"]),
-			PricingStartDate:                     stringPtr(pricingEOD["pricingStartDate"]),
-			PricingEndDate:                       stringPtr(pricingEOD["pricingEndDate"]),
+			MarketCap:                            gFloat(pricingEOD.Get("marketCapitalization")),
+			MarketCapFormatted:                   gStr(pricingEOD.Get("marketCapitalization.formattedValue")),
+			AvgDollarVolume50D:                   gFloat(pricingEOD.Get("avgDollarVolume50Day")),
+			AvgDollarVolume50DFormatted:          gStr(pricingEOD.Get("avgDollarVolume50Day.formattedValue")),
+			UpDownVolumeRatio:                    gFloat(pricingEOD.Get("upDownVolumeRatio")),
+			UpDownVolumeRatioFormatted:           gStr(pricingEOD.Get("upDownVolumeRatio.formattedValue")),
+			ATRPercent21D:                        gFloat(atr),
+			ATRPercent21DFormatted:               gStr(atr.Get("formattedValue")),
+			DividendYield:                        gFloat(pricingIntraday.Get("yield")),
+			DividendYieldFormatted:               gStr(pricingIntraday.Get("yield.formattedValue")),
+			PriceToCashFlowRatio:                 gFloat(pricingIntraday.Get("priceToCashFlowRatio")),
+			PriceToCashFlowRatioFormatted:        gStr(pricingIntraday.Get("priceToCashFlowRatio.formattedValue")),
+			ForwardPriceToEarningsRatio:          gFloat(pricingIntraday.Get("forwardPriceToEarningsRatio")),
+			ForwardPriceToEarningsRatioFormatted: gStr(pricingIntraday.Get("forwardPriceToEarningsRatio.formattedValue")),
+			PriceToSalesRatio:                    gFloat(pricingIntraday.Get("priceToSalesRatio")),
+			PriceToSalesRatioFormatted:           gStr(pricingIntraday.Get("priceToSalesRatio.formattedValue")),
+			PriceToEarningsRatio:                 gFloat(pricingIntraday.Get("priceToEarningsRatio")),
+			PriceToEarningsRatioFormatted:        gStr(pricingIntraday.Get("priceToEarningsRatio.formattedValue")),
+			PEVsSP500:                            gFloat(pricingIntraday.Get("priceToEarningsVsSP500")),
+			PEVsSP500Formatted:                   gStr(pricingIntraday.Get("priceToEarningsVsSP500.formattedValue")),
+			Alpha:                                gFloat(pricingEOD.Get("alpha")),
+			AlphaFormatted:                       gStr(pricingEOD.Get("alpha.formattedValue")),
+			Beta:                                 gFloat(pricingEOD.Get("beta")),
+			BetaFormatted:                        gStr(pricingEOD.Get("beta.formattedValue")),
+			PricingStartDate:                     gStr(pricingEOD.Get("pricingStartDate")),
+			PricingEndDate:                       gStr(pricingEOD.Get("pricingEndDate")),
 		},
 		Financials: &models.Financials{
-			EPSDueDate:                stringPtr(financials["epsDueDate"]),
-			EPSDueDateStatus:          stringPtr(financials["epsDueDateStatus"]),
-			EPSLastReportedDate:       stringPtr(financials["epsLastReportedDate"]),
-			EPSGrowthRate:             floatPtr(epsGrowth),
-			SalesGrowthRate3Y:         floatPtr(salesGrowth),
-			PreTaxMargin:              floatPtr(profitMargin["preTaxMargin"]),
-			AfterTaxMargin:            floatPtr(profitMargin["afterTaxMargin"]),
-			GrossMargin:               floatPtr(profitMargin["grossMargin"]),
-			ReturnOnEquity:            floatPtr(profitMargin["returnOnEquity"]),
-			EarningsStability:         intPtr(epsConsensus["earningsStability"]),
-			CashFlowPerShare:          floatPtr(pricingIntraday["cashFlowPerShareLastYear"]),
-			CashFlowPerShareFormatted: formattedValue(pricingIntraday["cashFlowPerShareLastYear"]),
+			EPSDueDate:                gStr(financials.Get("epsDueDate")),
+			EPSDueDateStatus:          gStr(financials.Get("epsDueDateStatus")),
+			EPSLastReportedDate:       gStr(financials.Get("epsLastReportedDate")),
+			EPSGrowthRate:             gFloat(epsConsensus.Get("growthRate.0")),
+			SalesGrowthRate3Y:         gFloat(salesConsensus.Get("growthRate.0")),
+			PreTaxMargin:              gFloat(profitMargin.Get("preTaxMargin")),
+			AfterTaxMargin:            gFloat(profitMargin.Get("afterTaxMargin")),
+			GrossMargin:               gFloat(profitMargin.Get("grossMargin")),
+			ReturnOnEquity:            gFloat(profitMargin.Get("returnOnEquity")),
+			EarningsStability:         gInt(epsConsensus.Get("earningsStability")),
+			CashFlowPerShare:          gFloat(pricingIntraday.Get("cashFlowPerShareLastYear")),
+			CashFlowPerShareFormatted: gStr(pricingIntraday.Get("cashFlowPerShareLastYear.formattedValue")),
 		},
 		CorporateActions: &models.CorporateActions{
-			NextExDividendDate: stringPtr(corporateActions["dividendNextReportedExDate"]),
+			NextExDividendDate: gStr(corporateActions.Get("dividendNextReportedExDate")),
 		},
 		Industry: &models.Industry{
-			Name:           stringPtr(industry["name"]),
-			Sector:         stringPtr(industry["sector"]),
-			Code:           stringPtr(industry["indCode"]),
-			NumberOfStocks: intPtr(industry["numberOfStocksInGroup"]),
+			Name:           gStr(industry.Get("name")),
+			Sector:         gStr(industry.Get("sector")),
+			Code:           gStr(industry.Get("indCode")),
+			NumberOfStocks: gInt(industry.Get("numberOfStocksInGroup")),
 		},
 		Ownership: &models.BasicOwnership{
-			FundsFloatPct:          floatPtr(ownership["fundsFloatPercentHeld"]),
-			FundsFloatPctFormatted: formattedValue(ownership["fundsFloatPercentHeld"]),
+			FundsFloatPct:          gFloat(ownership.Get("fundsFloatPercentHeld")),
+			FundsFloatPctFormatted: gStr(ownership.Get("fundsFloatPercentHeld.formattedValue")),
 		},
 		Fundamentals: &models.Fundamentals{
-			RAndDPercentLastQtr:          floatPtr(fundamentals["researchAndDevelopmentPercentLastQtr"]),
-			RAndDPercentLastQtrFormatted: formattedValue(fundamentals["researchAndDevelopmentPercentLastQtr"]),
-			DebtPercentFormatted:         formattedValue(fundamentals["debtPercent"]),
-			NewCEODate:                   stringPtr(fundamentals["newCEODate"]),
+			RAndDPercentLastQtr:          gFloat(fundmtls.Get("researchAndDevelopmentPercentLastQtr")),
+			RAndDPercentLastQtrFormatted: gStr(fundmtls.Get("researchAndDevelopmentPercentLastQtr.formattedValue")),
+			DebtPercentFormatted:         gStr(fundmtls.Get("debtPercent.formattedValue")),
+			NewCEODate:                   gStr(fundmtls.Get("newCEODate")),
 		},
 		QuarterlyFinancials: &models.QuarterlyFinancials{
-			ReportedEarnings: buildQuarterlyReported(getNestedSlice(epsConsensus, "reportedEarnings")),
-			ReportedSales:    buildQuarterlyReported(getNestedSlice(salesConsensus, "reportedSales")),
-			EPSEstimates:     buildQuarterlyEstimates(getNestedSlice(financials, "estimates", "epsEstimates")),
-			SalesEstimates:   buildQuarterlyEstimates(getNestedSlice(financials, "estimates", "salesEstimates")),
-			ProfitMargins:    buildQuarterlyProfitMargins(getNestedSlice(financials, "profitMarginValues")),
+			ReportedEarnings: buildQuarterlyReported(epsConsensus.Get("reportedEarnings").Array()),
+			ReportedSales:    buildQuarterlyReported(salesConsensus.Get("reportedSales").Array()),
+			EPSEstimates:     buildQuarterlyEstimates(financials.Get("estimates.epsEstimates").Array()),
+			SalesEstimates:   buildQuarterlyEstimates(financials.Get("estimates.salesEstimates").Array()),
+			ProfitMargins:    buildQuarterlyProfitMargins(financials.Get("profitMarginValues").Array()),
 		},
 		Patterns:   []models.Pattern{},
 		TightAreas: []models.TightArea{},
 	}, nil
 }
 
-func buildQuarterlyReported(items []any) []models.QuarterlyReportedPeriod {
-	return buildSlice(items, func(item map[string]any) models.QuarterlyReportedPeriod {
+func buildQuarterlyReported(items []gjson.Result) []models.QuarterlyReportedPeriod {
+	return buildSlice(items, func(item gjson.Result) models.QuarterlyReportedPeriod {
 		return models.QuarterlyReportedPeriod{
-			Value:           floatPtr(item["value"]),
-			PctChangeYoY:    floatPtr(item["percentChangeYOY"]),
-			PeriodOffset:    stringify(item["periodOffset"]),
-			PeriodEndDate:   stringPtr(item["periodEndDate"]),
-			EffectiveDate:   stringPtr(item["effectiveDate"]),
-			PercentSurprise: floatPtr(item["percentSurprise"]),
-			SurpriseAmount:  floatPtr(item["surpriseAmount"]),
-			QuarterNumber:   intPtr(item["quarterNumber"]),
-			FiscalYear:      intPtr(item["fiscalYear"]),
-			Period:          stringPtr(item["period"]),
+			Value:           gFloat(item.Get("value")),
+			PctChangeYoY:    gFloat(item.Get("percentChangeYOY")),
+			PeriodOffset:    stringify(item.Get("periodOffset")),
+			PeriodEndDate:   gStr(item.Get("periodEndDate")),
+			EffectiveDate:   gStr(item.Get("effectiveDate")),
+			PercentSurprise: gFloat(item.Get("percentSurprise")),
+			SurpriseAmount:  gFloat(item.Get("surpriseAmount")),
+			QuarterNumber:   gInt(item.Get("quarterNumber")),
+			FiscalYear:      gInt(item.Get("fiscalYear")),
+			Period:          gStr(item.Get("period")),
 		}
 	})
 }
 
-func buildQuarterlyEstimates(items []any) []models.QuarterlyEstimate {
-	return buildSlice(items, func(item map[string]any) models.QuarterlyEstimate {
+func buildQuarterlyEstimates(items []gjson.Result) []models.QuarterlyEstimate {
+	return buildSlice(items, func(item gjson.Result) models.QuarterlyEstimate {
 		return models.QuarterlyEstimate{
-			Value:             floatPtr(item["value"]),
-			PctChangeYoY:      floatPtr(item["percentChangeYOY"]),
-			PeriodEndDate:     stringPtr(item["periodEndDate"]),
-			EffectiveDate:     stringPtr(item["effectiveDate"]),
-			RevisionDirection: stringPtr(item["revisionDirection"]),
-			EstimateType:      stringPtr(item["type"]),
+			Value:             gFloat(item.Get("value")),
+			PctChangeYoY:      gFloat(item.Get("percentChangeYOY")),
+			PeriodEndDate:     gStr(item.Get("periodEndDate")),
+			EffectiveDate:     gStr(item.Get("effectiveDate")),
+			RevisionDirection: gStr(item.Get("revisionDirection")),
+			EstimateType:      gStr(item.Get("type")),
 		}
 	})
 }
 
-func buildQuarterlyProfitMargins(items []any) []models.QuarterlyProfitMargin {
-	return buildSlice(items, func(item map[string]any) models.QuarterlyProfitMargin {
+func buildQuarterlyProfitMargins(items []gjson.Result) []models.QuarterlyProfitMargin {
+	return buildSlice(items, func(item gjson.Result) models.QuarterlyProfitMargin {
 		return models.QuarterlyProfitMargin{
-			PeriodOffset:   stringify(item["periodOffset"]),
-			PeriodEndDate:  stringPtr(item["periodEndDate"]),
-			PreTaxMargin:   floatPtr(item["preTaxMargin"]),
-			AfterTaxMargin: floatPtr(item["afterTaxMargin"]),
-			GrossMargin:    floatPtr(item["grossMargin"]),
-			ReturnOnEquity: floatPtr(item["returnOnEquity"]),
+			PeriodOffset:   stringify(item.Get("periodOffset")),
+			PeriodEndDate:  gStr(item.Get("periodEndDate")),
+			PreTaxMargin:   gFloat(item.Get("preTaxMargin")),
+			AfterTaxMargin: gFloat(item.Get("afterTaxMargin")),
+			GrossMargin:    gFloat(item.Get("grossMargin")),
+			ReturnOnEquity: gFloat(item.Get("returnOnEquity")),
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- Replace hand-rolled type converters (`stringPtr`, `intPtr`, `floatPtr`, `boolPtr`, etc.) and nested map walkers (`getNestedMap`, `getNestedSlice`, `firstMap`, `scalarValue`, `formattedValue`) with [gjson](https://github.com/tidwall/gjson) dot-path queries
- `Execute()` now returns raw `[]byte` instead of `map[string]any`, removing the intermediate unmarshal step
- Net reduction of ~177 lines across 12 files (413 added, 590 removed)

## What changed

**graphql_error.go** - Complete rewrite. All old helpers deleted, replaced with thin gjson wrappers (`gStr`, `gInt`, `gFloat`, `gBool`, `gScalar`). `gScalar` handles the API's `{value: X}` wrapper pattern and sentinel date filtering in one place.

**client.go** - `Execute()` returns `[]byte` instead of `map[string]any`. Skips `json.Unmarshal` entirely since gjson operates on raw bytes.

**API methods** (stock, fundamentals, ownership, rs_history, chart, chart_markups, catalog) - All migrated from map index chains to gjson path queries. No functional changes.

**client_test.go** - Updated to use `gjson.GetBytes` for the one test that accessed raw response data.

## Testing

All 28 client package tests pass. `go vet` clean. The one pre-existing failure (`TestUnknownCommandReturnsError` in `cmd/marketsurge-agent`) is unrelated and fails on `main` as well.