### PR TITLE
Backport improvements from newer agent projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,9 @@ jobs:
           go-version-file: go.mod
       - run: go test -v -race -coverprofile=coverage.out ./...
       - run: go build ./cmd/marketsurge-agent/
+
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run govulncheck
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,20 +5,27 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: write
+permissions: read-all
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write # keyless cosign signing via Sigstore OIDC
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
-      - uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7
+      - name: Install cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7
         with:
           version: "~> v2"
           args: release --clean

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
     - bodyclose
     - errorlint
     - gocritic
+    - gosec
     - misspell
     - nolintlint
     - revive
@@ -48,6 +49,7 @@ linters:
         linters:
           - bodyclose
           - goconst
+          - gosec
           - unparam
 
 run:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,18 @@ archives:
   - format: tar.gz
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
+# Keyless cosign signing via Sigstore/Fulcio OIDC (no private key needed).
+# Signs the checksums file only; users verify checksums, then verify SHAs.
+signs:
+  - cmd: cosign
+    signature: "${artifact}.sigstore.json"
+    args:
+      - "sign-blob"
+      - "--bundle=${signature}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: checksum
+
 changelog:
   sort: asc
   filters:

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@ build:
 	go build -o marketsurge-agent ./cmd/marketsurge-agent/
 
 test:
-	go test -v ./...
+	go test -v -race -coverprofile=coverage.out ./...
 
 lint:
 	golangci-lint run ./...
 
 clean:
 	go clean
-	rm -f marketsurge-agent
+	rm -f marketsurge-agent coverage.out
 	rm -rf dist/

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 .PHONY: build test lint clean
 
 build:
-	/usr/local/go/bin/go build -o marketsurge-agent ./cmd/marketsurge-agent/
+	go build -o marketsurge-agent ./cmd/marketsurge-agent/
 
 test:
-	/usr/local/go/bin/go test -v ./...
+	go test -v ./...
 
 lint:
 	golangci-lint run ./...
 
 clean:
-	/usr/local/go/bin/go clean
+	go clean
 	rm -f marketsurge-agent
 	rm -rf dist/

--- a/cmd/marketsurge-agent/main.go
+++ b/cmd/marketsurge-agent/main.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 
 	"github.com/urfave/cli/v3"
@@ -61,10 +61,11 @@ func buildApp(w io.Writer) *cli.Command {
 		},
 		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
 			if cmd.Bool("verbose") {
-				log.SetOutput(os.Stderr)
-				log.SetFlags(log.LstdFlags | log.Lshortfile)
+				slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+					Level: slog.LevelDebug,
+				})))
 			} else {
-				log.SetOutput(io.Discard)
+				slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
 			}
 
 			// Skills commands don't require authentication.

--- a/cmd/marketsurge-agent/main_test.go
+++ b/cmd/marketsurge-agent/main_test.go
@@ -17,6 +17,7 @@ import (
 // TestHelpContainsAllCommands verifies that --help exits 0 and lists every
 // top-level command group.
 func TestHelpContainsAllCommands(t *testing.T) {
+	t.Parallel()
 	var jsonBuf bytes.Buffer
 	app := buildApp(&jsonBuf)
 

--- a/internal/auth/chain.go
+++ b/internal/auth/chain.go
@@ -6,7 +6,7 @@ package auth
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"os"
 
 	"github.com/major/marketsurge-agent/internal/cookies"
@@ -75,28 +75,28 @@ func resolveFromFirefoxProfiles(ctx context.Context) (string, error) {
 
 	var lastErr error
 	for _, dbPath := range dbPaths {
-		log.Printf("trying Firefox profile: %s", dbPath)
+		slog.Debug("trying Firefox profile", "path", dbPath)
 
 		cookieJar, err := cookies.ExtractCookies(ctx, dbPath)
 		if err != nil {
-			log.Printf("  cookie extraction failed: %v", err)
+			slog.Debug("cookie extraction failed", "path", dbPath, "error", err)
 			lastErr = err
 			continue
 		}
 
 		if len(cookieJar) == 0 {
-			log.Printf("  no investors.com cookies found, skipping")
+			slog.Debug("no investors.com cookies found, skipping", "path", dbPath)
 			continue
 		}
 
 		jwt, err := ExchangeJWT(ctx, cookieJar)
 		if err != nil {
-			log.Printf("  JWT exchange failed: %v", err)
+			slog.Debug("JWT exchange failed", "path", dbPath, "error", err)
 			lastErr = err
 			continue
 		}
 
-		log.Printf("  authentication successful")
+		slog.Debug("authentication successful", "path", dbPath)
 		return jwt, nil
 	}
 

--- a/internal/auth/exchange.go
+++ b/internal/auth/exchange.go
@@ -58,7 +58,7 @@ func ExchangeJWT(ctx context.Context, cookies []*http.Cookie) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, constants.MaxResponseSize))
 	if err != nil {
 		return "", errors.NewAuthenticationError(
 			fmt.Sprintf("failed to read JWT exchange response: %s", err),

--- a/internal/client/AGENTS.md
+++ b/internal/client/AGENTS.md
@@ -10,6 +10,11 @@ type Client struct {
     Endpoint   string
     HTTPClient *http.Client
 }
+
+// Functional options pattern:
+NewClient(jwt string, opts ...Option)
+WithBaseURL(url string)       // Override GraphQL endpoint
+WithHTTPClient(c *http.Client) // Override HTTP client
 ```
 
 `Execute(query string, variables map[string]interface{})` handles:

--- a/internal/client/catalog_test.go
+++ b/internal/client/catalog_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestRunReportSuccess(t *testing.T) {
+	t.Parallel()
 	var captured Request
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
@@ -28,6 +29,7 @@ func TestRunReportSuccess(t *testing.T) {
 }
 
 func TestRunWatchlistTwoStepFlow(t *testing.T) {
+	t.Parallel()
 	requests := []Request{}
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
@@ -53,6 +55,7 @@ func TestRunWatchlistTwoStepFlow(t *testing.T) {
 }
 
 func TestRunWatchlistReturnsEmptyForNoSymbols(t *testing.T) {
+	t.Parallel()
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"watchlist":{"id":"123","items":[]}}}`))
 	})
@@ -63,6 +66,7 @@ func TestRunWatchlistReturnsEmptyForNoSymbols(t *testing.T) {
 }
 
 func TestRunWatchlistReturnsNotFoundWhenMissing(t *testing.T) {
+	t.Parallel()
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"watchlist":null}}`))
 	})
@@ -73,6 +77,7 @@ func TestRunWatchlistReturnsNotFoundWhenMissing(t *testing.T) {
 }
 
 func TestRunCoachScreenSuccess(t *testing.T) {
+	t.Parallel()
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"user":{"runScreen":{"numberOfMatchingInstruments":2,"responseValues":[[{"mdItem":{"name":"Symbol"},"value":"AAPL"}]]}}}}`))
 	})
@@ -84,6 +89,7 @@ func TestRunCoachScreenSuccess(t *testing.T) {
 }
 
 func TestRunCoachScreenReturnsAPIErrorForMissingPayload(t *testing.T) {
+	t.Parallel()
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"user":{}}}`))
 	})
@@ -94,6 +100,7 @@ func TestRunCoachScreenReturnsAPIErrorForMissingPayload(t *testing.T) {
 }
 
 func TestListCatalogAggregatesAllSources(t *testing.T) {
+	t.Parallel()
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		var payload Request
@@ -118,6 +125,7 @@ func TestListCatalogAggregatesAllSources(t *testing.T) {
 }
 
 func TestListCatalogReportFilterSkipsRemoteSources(t *testing.T) {
+	t.Parallel()
 	requests := []string{}
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
@@ -136,6 +144,7 @@ func TestListCatalogReportFilterSkipsRemoteSources(t *testing.T) {
 }
 
 func TestListCatalogPartialFailure(t *testing.T) {
+	t.Parallel()
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		var payload Request
@@ -159,6 +168,7 @@ func TestListCatalogPartialFailure(t *testing.T) {
 }
 
 func TestListCatalogFiltersKind(t *testing.T) {
+	t.Parallel()
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		var payload Request
@@ -184,6 +194,7 @@ func TestListCatalogFiltersKind(t *testing.T) {
 }
 
 func TestParseAdhocScreenResultIncludesErrorValues(t *testing.T) {
+	t.Parallel()
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"marketDataAdhocScreen":{"responseValues":[],"errorValues":["bad symbol"]}}}`))
 	})
@@ -194,6 +205,7 @@ func TestParseAdhocScreenResultIncludesErrorValues(t *testing.T) {
 }
 
 func TestParseAdhocScreenResultMapsFields(t *testing.T) {
+	t.Parallel()
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(adhocResponseJSON()))
 	})

--- a/internal/client/chart_test.go
+++ b/internal/client/chart_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestGetChartHistoryDailyIncludesExchangeAndBenchmark(t *testing.T) {
+	t.Parallel()
 	var captured Request
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
@@ -28,6 +29,7 @@ func TestGetChartHistoryDailyIncludesExchangeAndBenchmark(t *testing.T) {
 }
 
 func TestGetChartHistoryWeeklyOmitsExchange(t *testing.T) {
+	t.Parallel()
 	var captured Request
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
@@ -44,6 +46,7 @@ func TestGetChartHistoryWeeklyOmitsExchange(t *testing.T) {
 }
 
 func TestGetChartMarkupsSuccess(t *testing.T) {
+	t.Parallel()
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"user":{"chartMarkups":{"cursorId":"cursor-1","chartMarkups":[{"id":"m1","name":"Base","data":"{}","frequency":"DAILY","site":"marketsurge"}]}}}}`))
 	})
@@ -56,6 +59,7 @@ func TestGetChartMarkupsSuccess(t *testing.T) {
 }
 
 func TestGetChartMarkupsPassesOperationName(t *testing.T) {
+	t.Parallel()
 	var captured Request
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
@@ -71,6 +75,7 @@ func TestGetChartMarkupsPassesOperationName(t *testing.T) {
 }
 
 func TestGetChartHistoryReturnsSymbolNotFound(t *testing.T) {
+	t.Parallel()
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"marketData":[]}}`))
 	})

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -62,7 +62,7 @@ func (c *Client) Execute(ctx context.Context, payload Request) (map[string]any, 
 	}
 	defer response.Body.Close()
 
-	body, err := io.ReadAll(response.Body)
+	body, err := io.ReadAll(io.LimitReader(response.Body, constants.MaxResponseSize))
 	if err != nil {
 		return nil, fmt.Errorf("read graphql response: %w", err)
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 
 	"github.com/major/marketsurge-agent/internal/constants"
@@ -91,6 +92,20 @@ func (c *Client) Execute(ctx context.Context, payload Request) (map[string]any, 
 
 	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
 		return nil, mapHTTPError(response.StatusCode, string(body), nil)
+	}
+
+	// Validate Content-Type before attempting JSON decode. Without this,
+	// an HTML error page from a proxy or maintenance window produces a
+	// cryptic json.Unmarshal error instead of a clear diagnostic.
+	if ct := response.Header.Get("Content-Type"); ct != "" {
+		mediaType, _, err := mime.ParseMediaType(ct)
+		if err == nil && mediaType != "application/json" {
+			preview := string(body)
+			if len(preview) > 200 {
+				preview = preview[:200] + "..."
+			}
+			return nil, fmt.Errorf("unexpected Content-Type %q (expected application/json): %s", ct, preview)
+		}
 	}
 
 	var raw map[string]any

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -30,15 +30,37 @@ type Client struct {
 	HTTPClient *http.Client
 }
 
+// Option configures a Client.
+type Option func(*Client)
+
+// WithBaseURL sets the GraphQL endpoint URL.
+func WithBaseURL(url string) Option {
+	return func(c *Client) {
+		c.Endpoint = url
+	}
+}
+
+// WithHTTPClient sets the HTTP client used for requests.
+func WithHTTPClient(httpClient *http.Client) Option {
+	return func(c *Client) {
+		c.HTTPClient = httpClient
+	}
+}
+
 // NewClient constructs a GraphQL client with the default endpoint and timeout.
-func NewClient(jwt string) *Client {
-	return &Client{
+// Use With* options to override defaults.
+func NewClient(jwt string, opts ...Option) *Client {
+	c := &Client{
 		JWT:      jwt,
 		Endpoint: constants.GraphQLEndpoint,
 		HTTPClient: &http.Client{
 			Timeout: constants.HTTPTimeout,
 		},
 	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
 // Execute sends a GraphQL request and returns the decoded response body.

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestNewClientDefaults(t *testing.T) {
+	t.Parallel()
 	client := NewClient("jwt-token")
 
 	require.NotNil(t, client.HTTPClient)
@@ -20,6 +21,7 @@ func TestNewClientDefaults(t *testing.T) {
 }
 
 func TestExecuteSetsHeadersAndAuthorization(t *testing.T) {
+	t.Parallel()
 	var captured Request
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
@@ -40,6 +42,7 @@ func TestExecuteSetsHeadersAndAuthorization(t *testing.T) {
 }
 
 func TestExecuteReturnsGraphQLErrorOnHTTP200(t *testing.T) {
+	t.Parallel()
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"errors":[{"message":"bad request"}]}`))
@@ -53,6 +56,7 @@ func TestExecuteReturnsGraphQLErrorOnHTTP200(t *testing.T) {
 }
 
 func TestExecuteReturnsTokenExpiredErrorOn401(t *testing.T) {
+	t.Parallel()
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "nope", http.StatusUnauthorized)
 	})
@@ -64,6 +68,7 @@ func TestExecuteReturnsTokenExpiredErrorOn401(t *testing.T) {
 }
 
 func TestExecuteReturnsAuthenticationErrorOn403(t *testing.T) {
+	t.Parallel()
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "forbidden", http.StatusForbidden)
 	})
@@ -75,6 +80,7 @@ func TestExecuteReturnsAuthenticationErrorOn403(t *testing.T) {
 }
 
 func TestExecuteReturnsHTTPErrorOn500(t *testing.T) {
+	t.Parallel()
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "boom", http.StatusInternalServerError)
 	})

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -102,3 +102,28 @@ func TestExecuteReturnsHTTPErrorOn500(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, httpErr.StatusCode)
 	assert.Contains(t, httpErr.Body, "boom")
 }
+
+func TestExecuteRejectsUnexpectedContentType(t *testing.T) {
+	t.Parallel()
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte("<html><body>Service Unavailable</body></html>"))
+	})
+
+	_, err := client.Execute(context.Background(), Request{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected Content-Type")
+	assert.Contains(t, err.Error(), "text/html")
+}
+
+func TestExecuteAcceptsJSONWithCharset(t *testing.T) {
+	t.Parallel()
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		_, _ = w.Write([]byte(`{"data":{"ok":true}}`))
+	})
+
+	raw, err := client.Execute(context.Background(), Request{})
+	require.NoError(t, err)
+	assert.Equal(t, true, getNestedMap(raw, "data")["ok"])
+}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -20,6 +20,16 @@ func TestNewClientDefaults(t *testing.T) {
 	assert.NotEmpty(t, client.Endpoint)
 }
 
+func TestNewClientWithOptions(t *testing.T) {
+	t.Parallel()
+	custom := &http.Client{}
+	c := NewClient("jwt-token", WithBaseURL("https://example.com"), WithHTTPClient(custom))
+
+	assert.Equal(t, "https://example.com", c.Endpoint)
+	assert.Same(t, custom, c.HTTPClient)
+	assert.Equal(t, "jwt-token", c.JWT)
+}
+
 func TestExecuteSetsHeadersAndAuthorization(t *testing.T) {
 	t.Parallel()
 	var captured Request

--- a/internal/client/helpers_test.go
+++ b/internal/client/helpers_test.go
@@ -8,9 +8,16 @@ import (
 
 // testServerAndClient creates a test HTTP server with the given handler and returns
 // a Client configured to use it. The server is automatically closed when the test ends.
+// testServerAndClient creates a test HTTP server with the given handler and returns
+// a Client configured to use it. The server is automatically closed when the test ends.
+// A default Content-Type of application/json is set on responses; handlers can override it.
 func testServerAndClient(t *testing.T, handler http.HandlerFunc) *Client {
 	t.Helper()
-	server := httptest.NewServer(handler)
+	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		handler(w, r)
+	})
+	server := httptest.NewServer(wrapped)
 	t.Cleanup(server.Close)
 	return NewClient("jwt-token", WithBaseURL(server.URL), WithHTTPClient(server.Client()))
 }

--- a/internal/client/helpers_test.go
+++ b/internal/client/helpers_test.go
@@ -12,8 +12,5 @@ func testServerAndClient(t *testing.T, handler http.HandlerFunc) *Client {
 	t.Helper()
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
-	c := NewClient("jwt-token")
-	c.Endpoint = server.URL
-	c.HTTPClient = server.Client()
-	return c
+	return NewClient("jwt-token", WithBaseURL(server.URL), WithHTTPClient(server.Client()))
 }

--- a/internal/client/stock_test.go
+++ b/internal/client/stock_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestGetStockSuccess(t *testing.T) {
+	t.Parallel()
 	var captured Request
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
@@ -32,6 +33,7 @@ func TestGetStockSuccess(t *testing.T) {
 }
 
 func TestGetStockReturnsSymbolNotFoundForEmptyMarketData(t *testing.T) {
+	t.Parallel()
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":{"marketData":[]}}`))
@@ -43,6 +45,7 @@ func TestGetStockReturnsSymbolNotFoundForEmptyMarketData(t *testing.T) {
 }
 
 func TestGetFundamentalsSuccess(t *testing.T) {
+	t.Parallel()
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(stockResponseJSON()))
@@ -57,6 +60,7 @@ func TestGetFundamentalsSuccess(t *testing.T) {
 }
 
 func TestGetOwnershipSuccess(t *testing.T) {
+	t.Parallel()
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(stockResponseJSON()))
@@ -70,6 +74,7 @@ func TestGetOwnershipSuccess(t *testing.T) {
 }
 
 func TestGetRSRatingHistorySuccess(t *testing.T) {
+	t.Parallel()
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(stockResponseJSON()))

--- a/internal/commands/catalog_list_test.go
+++ b/internal/commands/catalog_list_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestCatalogListAllSourcesSucceed(t *testing.T) {
+	t.Parallel()
 	server := newCatalogServer(t, func(op string, w http.ResponseWriter) {
 		switch op {
 		case "GetAllWatchlistNames":
@@ -42,6 +43,7 @@ func TestCatalogListAllSourcesSucceed(t *testing.T) {
 }
 
 func TestCatalogListPartialFailure(t *testing.T) {
+	t.Parallel()
 	server := newCatalogServer(t, func(op string, w http.ResponseWriter) {
 		switch op {
 		case "GetAllWatchlistNames":
@@ -69,6 +71,7 @@ func TestCatalogListPartialFailure(t *testing.T) {
 }
 
 func TestCatalogListKindFilter(t *testing.T) {
+	t.Parallel()
 	server := newCatalogServer(t, func(op string, w http.ResponseWriter) {
 		switch op {
 		case "GetAllWatchlistNames":
@@ -93,6 +96,7 @@ func TestCatalogListKindFilter(t *testing.T) {
 }
 
 func TestCatalogListAllAPISourcesFailStillReturnsReports(t *testing.T) {
+	t.Parallel()
 	server := newCatalogServer(t, func(op string, w http.ResponseWriter) {
 		switch op {
 		case "GetAllWatchlistNames":
@@ -120,6 +124,7 @@ func TestCatalogListAllAPISourcesFailStillReturnsReports(t *testing.T) {
 }
 
 func TestCatalogListInvalidKind(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(`{}`)
 	defer server.Close()
 

--- a/internal/commands/catalog_run_test.go
+++ b/internal/commands/catalog_run_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestCatalogRunReportDispatch(t *testing.T) {
+	t.Parallel()
 	server, requests := newCatalogRunServer(t)
 	defer server.Close()
 
@@ -35,6 +36,7 @@ func TestCatalogRunReportDispatch(t *testing.T) {
 }
 
 func TestCatalogRunWatchlistDispatch(t *testing.T) {
+	t.Parallel()
 	server, requests := newCatalogRunServer(t)
 	defer server.Close()
 
@@ -54,6 +56,7 @@ func TestCatalogRunWatchlistDispatch(t *testing.T) {
 }
 
 func TestCatalogRunCoachScreenDispatch(t *testing.T) {
+	t.Parallel()
 	server, requests := newCatalogRunServer(t)
 	defer server.Close()
 
@@ -71,6 +74,7 @@ func TestCatalogRunCoachScreenDispatch(t *testing.T) {
 }
 
 func TestCatalogRunMissingKind(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(`{}`)
 	defer server.Close()
 
@@ -86,6 +90,7 @@ func TestCatalogRunMissingKind(t *testing.T) {
 }
 
 func TestCatalogRunScreenKindValidation(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(`{}`)
 	defer server.Close()
 
@@ -101,6 +106,7 @@ func TestCatalogRunScreenKindValidation(t *testing.T) {
 }
 
 func TestCatalogRunMissingIDForKind(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(`{}`)
 	defer server.Close()
 
@@ -116,7 +122,8 @@ func TestCatalogRunMissingIDForKind(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var buf bytes.Buffer
+	t.Parallel()
+	var buf bytes.Buffer
 			cmd := CatalogRunCommand(testClient(t, server), &buf)
 			err := runTestCommand(t, cmd, tt.args...)
 			require.Error(t, err)
@@ -125,11 +132,12 @@ func TestCatalogRunMissingIDForKind(t *testing.T) {
 			assert.ErrorAs(t, err, &verr)
 			assert.Contains(t, err.Error(), tt.message)
 			assert.Empty(t, buf.String())
-		})
+})
 	}
 }
 
 func TestCatalogRunPagination(t *testing.T) {
+	t.Parallel()
 	server, _ := newCatalogRunServer(t)
 	defer server.Close()
 
@@ -150,6 +158,7 @@ func TestCatalogRunPagination(t *testing.T) {
 }
 
 func TestCatalogRunWatchlistID64Bit(t *testing.T) {
+	t.Parallel()
 	server, requests := newCatalogRunServer(t)
 	defer server.Close()
 

--- a/internal/commands/chart_history_test.go
+++ b/internal/commands/chart_history_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestChartHistorySuccessWithExplicitDates(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(chartResponseFixture())
 	defer server.Close()
 	c := testClient(t, server)
@@ -26,6 +27,7 @@ func TestChartHistorySuccessWithExplicitDates(t *testing.T) {
 }
 
 func TestChartHistorySuccessWithLookback(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(chartResponseFixture())
 	defer server.Close()
 	c := testClient(t, server)
@@ -40,6 +42,7 @@ func TestChartHistorySuccessWithLookback(t *testing.T) {
 }
 
 func TestChartHistorySymbolNotFound(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(emptyMarketDataFixture())
 	defer server.Close()
 	c := testClient(t, server)
@@ -56,6 +59,7 @@ func TestChartHistorySymbolNotFound(t *testing.T) {
 }
 
 func TestChartHistoryMissingSymbol(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(`{}`)
 	defer server.Close()
 	c := testClient(t, server)
@@ -72,6 +76,7 @@ func TestChartHistoryMissingSymbol(t *testing.T) {
 }
 
 func TestChartHistoryMutualExclusion(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(`{}`)
 	defer server.Close()
 	c := testClient(t, server)
@@ -89,6 +94,7 @@ func TestChartHistoryMutualExclusion(t *testing.T) {
 }
 
 func TestChartHistoryNeitherDatesNorLookback(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(`{}`)
 	defer server.Close()
 	c := testClient(t, server)
@@ -104,6 +110,7 @@ func TestChartHistoryNeitherDatesNorLookback(t *testing.T) {
 }
 
 func TestChartHistoryPartialExplicitDates(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(`{}`)
 	defer server.Close()
 	c := testClient(t, server)
@@ -121,6 +128,7 @@ func TestChartHistoryPartialExplicitDates(t *testing.T) {
 }
 
 func TestChartHistoryInvalidLookback(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(`{}`)
 	defer server.Close()
 	c := testClient(t, server)
@@ -155,13 +163,15 @@ func TestResolveLookback(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.lookback, func(t *testing.T) {
-			result := resolveLookback(tt.lookback, now)
+	t.Parallel()
+	result := resolveLookback(tt.lookback, now)
 			assert.Equal(t, tt.expected, result)
-		})
+})
 	}
 }
 
 func TestMapPeriod(t *testing.T) {
+	t.Parallel()
 	period, daily := mapPeriod("daily")
 	assert.Equal(t, "P1D", period)
 	assert.True(t, daily)

--- a/internal/commands/chart_markups_test.go
+++ b/internal/commands/chart_markups_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestChartMarkupsSuccess(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(chartMarkupsFixture())
 	defer server.Close()
 	c := testClient(t, server)
@@ -24,6 +25,7 @@ func TestChartMarkupsSuccess(t *testing.T) {
 }
 
 func TestChartMarkupsWithFlags(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(chartMarkupsFixture())
 	defer server.Close()
 	c := testClient(t, server)
@@ -38,6 +40,7 @@ func TestChartMarkupsWithFlags(t *testing.T) {
 }
 
 func TestChartMarkupsMissingSymbol(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(`{}`)
 	defer server.Close()
 	c := testClient(t, server)

--- a/internal/commands/fundamental_get_test.go
+++ b/internal/commands/fundamental_get_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestFundamentalGetSuccess(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(stockResponseFixture())
 	defer server.Close()
 	c := testClient(t, server)
@@ -24,6 +25,7 @@ func TestFundamentalGetSuccess(t *testing.T) {
 }
 
 func TestFundamentalGetSymbolNotFound(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(emptyMarketDataFixture())
 	defer server.Close()
 	c := testClient(t, server)
@@ -39,6 +41,7 @@ func TestFundamentalGetSymbolNotFound(t *testing.T) {
 }
 
 func TestFundamentalGetMissingSymbol(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(`{}`)
 	defer server.Close()
 	c := testClient(t, server)

--- a/internal/commands/helpers_test.go
+++ b/internal/commands/helpers_test.go
@@ -41,10 +41,7 @@ func assertSymbolMeta(t *testing.T, envelope map[string]any, symbol string) {
 // testClient creates a *client.Client backed by the given httptest server.
 func testClient(t *testing.T, server *httptest.Server) *client.Client {
 	t.Helper()
-	c := client.NewClient("test-jwt")
-	c.Endpoint = server.URL
-	c.HTTPClient = server.Client()
-	return c
+	return client.NewClient("test-jwt", client.WithBaseURL(server.URL), client.WithHTTPClient(server.Client()))
 }
 
 // jsonServer returns an httptest.Server that always responds with the given JSON body.

--- a/internal/commands/ownership_get_test.go
+++ b/internal/commands/ownership_get_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestOwnershipGetSuccess(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(stockResponseFixture())
 	defer server.Close()
 	c := testClient(t, server)
@@ -24,6 +25,7 @@ func TestOwnershipGetSuccess(t *testing.T) {
 }
 
 func TestOwnershipGetSymbolNotFound(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(emptyMarketDataFixture())
 	defer server.Close()
 	c := testClient(t, server)
@@ -39,6 +41,7 @@ func TestOwnershipGetSymbolNotFound(t *testing.T) {
 }
 
 func TestOwnershipGetMissingSymbol(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(`{}`)
 	defer server.Close()
 	c := testClient(t, server)

--- a/internal/commands/rs_history_get_test.go
+++ b/internal/commands/rs_history_get_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestRSHistoryGetSuccess(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(stockResponseFixture())
 	defer server.Close()
 	c := testClient(t, server)
@@ -24,6 +25,7 @@ func TestRSHistoryGetSuccess(t *testing.T) {
 }
 
 func TestRSHistoryGetSymbolNotFound(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(emptyMarketDataFixture())
 	defer server.Close()
 	c := testClient(t, server)
@@ -39,6 +41,7 @@ func TestRSHistoryGetSymbolNotFound(t *testing.T) {
 }
 
 func TestRSHistoryGetMissingSymbol(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(`{}`)
 	defer server.Close()
 	c := testClient(t, server)

--- a/internal/commands/skills_generate.go
+++ b/internal/commands/skills_generate.go
@@ -31,7 +31,7 @@ func SkillsGenerateCommand(w io.Writer) *cli.Command {
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			outputDir := cmd.String("output-dir")
 
-			if err := os.MkdirAll(outputDir, 0o755); err != nil {
+			if err := os.MkdirAll(outputDir, 0o750); err != nil {
 				return err
 			}
 
@@ -44,7 +44,7 @@ func SkillsGenerateCommand(w io.Writer) *cli.Command {
 				}
 
 				filename := filepath.Join(outputDir, group+".md")
-				if err := os.WriteFile(filename, []byte(content), 0o644); err != nil {
+				if err := os.WriteFile(filename, []byte(content), 0o644); err != nil { //nolint:gosec // generated docs are world-readable
 					return err
 				}
 				generatedFiles = append(generatedFiles, filename)

--- a/internal/commands/skills_generate_test.go
+++ b/internal/commands/skills_generate_test.go
@@ -22,8 +22,10 @@ type skillsGenerateEnvelope struct {
 }
 
 func TestSkillsGenerateCommand(t *testing.T) {
+	t.Parallel()
 	t.Run("generates skill files to default directory", func(t *testing.T) {
-		tmpDir := t.TempDir()
+	t.Parallel()
+	tmpDir := t.TempDir()
 		outputDir := filepath.Join(tmpDir, "skills")
 
 		var buf bytes.Buffer
@@ -74,10 +76,11 @@ func TestSkillsGenerateCommand(t *testing.T) {
 				t.Errorf("Skill file was not created: %s", fpath)
 			}
 		}
-	})
+})
 
 	t.Run("generates files with expected content", func(t *testing.T) {
-		tmpDir := t.TempDir()
+	t.Parallel()
+	tmpDir := t.TempDir()
 		outputDir := filepath.Join(tmpDir, "skills")
 
 		var buf bytes.Buffer
@@ -138,10 +141,11 @@ func TestSkillsGenerateCommand(t *testing.T) {
 		}
 
 		t.Logf("stock.md content length: %d bytes", len(contentStr))
-	})
+})
 
 	t.Run("uses custom output directory", func(t *testing.T) {
-		tmpDir := t.TempDir()
+	t.Parallel()
+	tmpDir := t.TempDir()
 		customDir := filepath.Join(tmpDir, "custom", "skills")
 
 		var buf bytes.Buffer
@@ -171,10 +175,11 @@ func TestSkillsGenerateCommand(t *testing.T) {
 		if _, err := os.Stat(stockFile); os.IsNotExist(err) {
 			t.Errorf("Skill file was not created in custom directory: %s", stockFile)
 		}
-	})
+})
 
 	t.Run("generates all command groups", func(t *testing.T) {
-		tmpDir := t.TempDir()
+	t.Parallel()
+	tmpDir := t.TempDir()
 		outputDir := filepath.Join(tmpDir, "skills")
 
 		var buf bytes.Buffer
@@ -212,10 +217,11 @@ func TestSkillsGenerateCommand(t *testing.T) {
 				t.Errorf("Skill file for group '%s' is empty", group)
 			}
 		}
-	})
+})
 
 	t.Run("outputs success message", func(t *testing.T) {
-		tmpDir := t.TempDir()
+	t.Parallel()
+	tmpDir := t.TempDir()
 		outputDir := filepath.Join(tmpDir, "skills")
 
 		var buf bytes.Buffer
@@ -236,7 +242,7 @@ func TestSkillsGenerateCommand(t *testing.T) {
 		assert.Equal(t, outputDir, envelope.Data.OutputDir)
 		assert.Len(t, envelope.Data.GeneratedFiles, 6)
 		assert.NotEmpty(t, envelope.Metadata["timestamp"])
-	})
+})
 }
 
 func decodeSkillsGenerateEnvelope(t *testing.T, data []byte) skillsGenerateEnvelope {

--- a/internal/commands/stock_analyze_test.go
+++ b/internal/commands/stock_analyze_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestStockAnalyzeSuccess(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(stockResponseFixture())
 	defer server.Close()
 	c := testClient(t, server)
@@ -42,6 +43,7 @@ func TestStockAnalyzePartialFailure(t *testing.T) {
 }
 
 func TestStockAnalyzeMultiSymbol(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(stockResponseFixture())
 	defer server.Close()
 	c := testClient(t, server)
@@ -63,6 +65,7 @@ func TestStockAnalyzeMultiSymbol(t *testing.T) {
 }
 
 func TestStockAnalyzeMissingSymbol(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(`{}`)
 	defer server.Close()
 	c := testClient(t, server)
@@ -77,6 +80,7 @@ func TestStockAnalyzeMissingSymbol(t *testing.T) {
 }
 
 func TestStockAnalyzeTotalFailure(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(emptyMarketDataFixture())
 	defer server.Close()
 	c := testClient(t, server)

--- a/internal/commands/stock_get_test.go
+++ b/internal/commands/stock_get_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestStockGetSuccess(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(stockResponseFixture())
 	defer server.Close()
 	c := testClient(t, server)
@@ -24,6 +25,7 @@ func TestStockGetSuccess(t *testing.T) {
 }
 
 func TestStockGetSymbolNotFound(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(emptyMarketDataFixture())
 	defer server.Close()
 	c := testClient(t, server)
@@ -39,6 +41,7 @@ func TestStockGetSymbolNotFound(t *testing.T) {
 }
 
 func TestStockGetMissingSymbol(t *testing.T) {
+	t.Parallel()
 	server := jsonServer(`{}`)
 	defer server.Close()
 	c := testClient(t, server)

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -18,6 +18,7 @@ const (
 	CookieDomain       = "investors.com"
 	SymbolDialectType  = "CHARTING"
 	HTTPTimeout        = 30 * time.Second
+	MaxResponseSize    = 10 * 1024 * 1024 // 10 MB
 )
 
 // GraphQLHeaders returns the HTTP headers required for GraphQL requests.

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -9,7 +9,7 @@ import (
 const (
 	GraphQLEndpoint    = "https://shared-data.dowjones.io/gateway/graphql"
 	JWTExchangeURL     = "https://www.investors.com/client"
-	DylanToken         = "x4ckyhshg90pdq6bwf6n1voijs7r3fdk"
+	DylanToken         = "x4ckyhshg90pdq6bwf6n1voijs7r3fdk" //nolint:gosec // public API exchange token, not a secret
 	UserAgent          = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:149.0) Gecko/20100101 Firefox/149.0"
 	OriginURL          = "https://marketsurge.investors.com"
 	RefererURL         = "https://marketsurge.investors.com/"

--- a/internal/constants/constants_test.go
+++ b/internal/constants/constants_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestGraphQLHeaders(t *testing.T) {
+	t.Parallel()
 	headers := GraphQLHeaders()
 
 	tests := []struct {
@@ -41,15 +42,17 @@ func TestGraphQLHeaders(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := headers.Get(tt.key)
+	t.Parallel()
+	got := headers.Get(tt.key)
 			if got != tt.expected {
 				t.Errorf("header %q = %q, want %q", tt.key, got, tt.expected)
 			}
-		})
+})
 	}
 }
 
 func TestJWTExchangeHeaders(t *testing.T) {
+	t.Parallel()
 	headers := JWTExchangeHeaders()
 
 	tests := []struct {
@@ -76,15 +79,17 @@ func TestJWTExchangeHeaders(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := headers.Get(tt.key)
+	t.Parallel()
+	got := headers.Get(tt.key)
 			if got != tt.expected {
 				t.Errorf("header %q = %q, want %q", tt.key, got, tt.expected)
 			}
-		})
+})
 	}
 }
 
 func TestPredefinedReports(t *testing.T) {
+	t.Parallel()
 	if len(PredefinedReports) != 57 {
 		t.Errorf("PredefinedReports length = %d, want 57", len(PredefinedReports))
 	}
@@ -100,6 +105,7 @@ func TestPredefinedReports(t *testing.T) {
 }
 
 func TestWatchlistColumns(t *testing.T) {
+	t.Parallel()
 	if len(WatchlistColumns) != 23 {
 		t.Errorf("WatchlistColumns length = %d, want 23", len(WatchlistColumns))
 	}

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -7,6 +7,7 @@ import (
 
 // TestExitCodeForSymbolNotFound verifies SymbolNotFoundError maps to ExitNotFound.
 func TestExitCodeForSymbolNotFound(t *testing.T) {
+	t.Parallel()
 	err := NewSymbolNotFoundError("symbol INVALID not found", nil, "INVALID")
 	code := ExitCodeFor(err)
 	if code != ExitNotFound {
@@ -16,6 +17,7 @@ func TestExitCodeForSymbolNotFound(t *testing.T) {
 
 // TestExitCodeForSymbolNotFoundWrapped verifies wrapped SymbolNotFoundError still maps correctly.
 func TestExitCodeForSymbolNotFoundWrapped(t *testing.T) {
+	t.Parallel()
 	underlying := errors.New("api returned empty data")
 	err := NewSymbolNotFoundError("symbol INVALID not found", underlying, "INVALID")
 	code := ExitCodeFor(err)
@@ -26,6 +28,7 @@ func TestExitCodeForSymbolNotFoundWrapped(t *testing.T) {
 
 // TestExitCodeForCookieExtractionError verifies CookieExtractionError maps to ExitAuthFailure.
 func TestExitCodeForCookieExtractionError(t *testing.T) {
+	t.Parallel()
 	err := NewCookieExtractionError("failed to extract cookies", nil, "Firefox")
 	code := ExitCodeFor(err)
 	if code != ExitAuthFailure {
@@ -35,6 +38,7 @@ func TestExitCodeForCookieExtractionError(t *testing.T) {
 
 // TestExitCodeForCookieExtractionErrorWrapped verifies wrapped CookieExtractionError maps correctly.
 func TestExitCodeForCookieExtractionErrorWrapped(t *testing.T) {
+	t.Parallel()
 	underlying := errors.New("rookiepy failed")
 	err := NewCookieExtractionError("failed to extract cookies", underlying, "Chrome")
 	code := ExitCodeFor(err)
@@ -45,6 +49,7 @@ func TestExitCodeForCookieExtractionErrorWrapped(t *testing.T) {
 
 // TestExitCodeForTokenExpiredError verifies TokenExpiredError maps to ExitAuthFailure.
 func TestExitCodeForTokenExpiredError(t *testing.T) {
+	t.Parallel()
 	err := NewTokenExpiredError("token expired", nil, 401)
 	code := ExitCodeFor(err)
 	if code != ExitAuthFailure {
@@ -54,6 +59,7 @@ func TestExitCodeForTokenExpiredError(t *testing.T) {
 
 // TestExitCodeForTokenExpiredErrorWrapped verifies wrapped TokenExpiredError maps correctly.
 func TestExitCodeForTokenExpiredErrorWrapped(t *testing.T) {
+	t.Parallel()
 	underlying := errors.New("http 401 unauthorized")
 	err := NewTokenExpiredError("token expired", underlying, 401)
 	code := ExitCodeFor(err)
@@ -64,6 +70,7 @@ func TestExitCodeForTokenExpiredErrorWrapped(t *testing.T) {
 
 // TestExitCodeForAuthenticationError verifies AuthenticationError maps to ExitAuthFailure.
 func TestExitCodeForAuthenticationError(t *testing.T) {
+	t.Parallel()
 	err := NewAuthenticationError("authentication failed", nil)
 	code := ExitCodeFor(err)
 	if code != ExitAuthFailure {
@@ -73,6 +80,7 @@ func TestExitCodeForAuthenticationError(t *testing.T) {
 
 // TestExitCodeForAuthenticationErrorWrapped verifies wrapped AuthenticationError maps correctly.
 func TestExitCodeForAuthenticationErrorWrapped(t *testing.T) {
+	t.Parallel()
 	underlying := errors.New("invalid credentials")
 	err := NewAuthenticationError("authentication failed", underlying)
 	code := ExitCodeFor(err)
@@ -83,6 +91,7 @@ func TestExitCodeForAuthenticationErrorWrapped(t *testing.T) {
 
 // TestExitCodeForAPIError verifies APIError maps to ExitAPIError.
 func TestExitCodeForAPIError(t *testing.T) {
+	t.Parallel()
 	err := NewAPIError("graphql api error", nil)
 	code := ExitCodeFor(err)
 	if code != ExitAPIError {
@@ -92,6 +101,7 @@ func TestExitCodeForAPIError(t *testing.T) {
 
 // TestExitCodeForAPIErrorWrapped verifies wrapped APIError maps correctly.
 func TestExitCodeForAPIErrorWrapped(t *testing.T) {
+	t.Parallel()
 	underlying := errors.New("graphql returned errors")
 	err := NewAPIError("graphql api error", underlying)
 	code := ExitCodeFor(err)
@@ -102,6 +112,7 @@ func TestExitCodeForAPIErrorWrapped(t *testing.T) {
 
 // TestExitCodeForHTTPError verifies HTTPError maps to ExitAPIError.
 func TestExitCodeForHTTPError(t *testing.T) {
+	t.Parallel()
 	err := NewHTTPError("http 500 error", nil, 500, "Internal Server Error")
 	code := ExitCodeFor(err)
 	if code != ExitAPIError {
@@ -111,6 +122,7 @@ func TestExitCodeForHTTPError(t *testing.T) {
 
 // TestExitCodeForHTTPErrorWrapped verifies wrapped HTTPError maps correctly.
 func TestExitCodeForHTTPErrorWrapped(t *testing.T) {
+	t.Parallel()
 	underlying := errors.New("connection failed")
 	err := NewHTTPError("http 502 error", underlying, 502, "Bad Gateway")
 	code := ExitCodeFor(err)
@@ -121,6 +133,7 @@ func TestExitCodeForHTTPErrorWrapped(t *testing.T) {
 
 // TestExitCodeForValidationError verifies ValidationError maps to ExitGeneral.
 func TestExitCodeForValidationError(t *testing.T) {
+	t.Parallel()
 	err := NewValidationError("invalid input", nil)
 	code := ExitCodeFor(err)
 	if code != ExitGeneral {
@@ -130,6 +143,7 @@ func TestExitCodeForValidationError(t *testing.T) {
 
 // TestExitCodeForValidationErrorWrapped verifies wrapped ValidationError maps correctly.
 func TestExitCodeForValidationErrorWrapped(t *testing.T) {
+	t.Parallel()
 	underlying := errors.New("symbol is empty")
 	err := NewValidationError("invalid input", underlying)
 	code := ExitCodeFor(err)
@@ -140,6 +154,7 @@ func TestExitCodeForValidationErrorWrapped(t *testing.T) {
 
 // TestExitCodeForMarketSurgeError verifies MarketSurgeError maps to ExitGeneral.
 func TestExitCodeForMarketSurgeError(t *testing.T) {
+	t.Parallel()
 	err := NewMarketSurgeError("generic error", nil)
 	code := ExitCodeFor(err)
 	if code != ExitGeneral {
@@ -149,6 +164,7 @@ func TestExitCodeForMarketSurgeError(t *testing.T) {
 
 // TestExitCodeForMarketSurgeErrorWrapped verifies wrapped MarketSurgeError maps correctly.
 func TestExitCodeForMarketSurgeErrorWrapped(t *testing.T) {
+	t.Parallel()
 	underlying := errors.New("something went wrong")
 	err := NewMarketSurgeError("generic error", underlying)
 	code := ExitCodeFor(err)
@@ -159,6 +175,7 @@ func TestExitCodeForMarketSurgeErrorWrapped(t *testing.T) {
 
 // TestExitCodeForStandardError verifies standard errors.New() maps to ExitGeneral.
 func TestExitCodeForStandardError(t *testing.T) {
+	t.Parallel()
 	err := errors.New("standard error")
 	code := ExitCodeFor(err)
 	if code != ExitGeneral {
@@ -168,6 +185,7 @@ func TestExitCodeForStandardError(t *testing.T) {
 
 // TestExitCodeForNilError verifies nil error maps to ExitSuccess.
 func TestExitCodeForNilError(t *testing.T) {
+	t.Parallel()
 	code := ExitCodeFor(nil)
 	if code != ExitSuccess {
 		t.Errorf("ExitCodeFor(nil) = %d, want %d", code, ExitSuccess)
@@ -176,6 +194,7 @@ func TestExitCodeForNilError(t *testing.T) {
 
 // TestErrorChainPreservation verifies that error chains are preserved through wrapping.
 func TestErrorChainPreservation(t *testing.T) {
+	t.Parallel()
 	underlying := errors.New("root cause")
 	err := NewCookieExtractionError("cookie extraction failed", underlying, "Firefox")
 
@@ -192,6 +211,7 @@ func TestErrorChainPreservation(t *testing.T) {
 
 // TestErrorChainTraversal verifies that errors.As() can traverse the error chain.
 func TestErrorChainTraversal(t *testing.T) {
+	t.Parallel()
 	underlying := errors.New("root cause")
 	err := NewCookieExtractionError("cookie extraction failed", underlying, "Firefox")
 
@@ -216,6 +236,7 @@ func TestErrorChainTraversal(t *testing.T) {
 
 // TestSymbolNotFoundErrorAttributes verifies SymbolNotFoundError stores the symbol.
 func TestSymbolNotFoundErrorAttributes(t *testing.T) {
+	t.Parallel()
 	symbol := "INVALID"
 	err := NewSymbolNotFoundError("symbol not found", nil, symbol)
 	if err.Symbol != symbol {
@@ -225,6 +246,7 @@ func TestSymbolNotFoundErrorAttributes(t *testing.T) {
 
 // TestCookieExtractionErrorAttributes verifies CookieExtractionError stores the browser.
 func TestCookieExtractionErrorAttributes(t *testing.T) {
+	t.Parallel()
 	browser := "Firefox"
 	err := NewCookieExtractionError("cookie extraction failed", nil, browser)
 	if err.Browser != browser {
@@ -234,6 +256,7 @@ func TestCookieExtractionErrorAttributes(t *testing.T) {
 
 // TestTokenExpiredErrorAttributes verifies TokenExpiredError stores the status code.
 func TestTokenExpiredErrorAttributes(t *testing.T) {
+	t.Parallel()
 	statusCode := 401
 	err := NewTokenExpiredError("token expired", nil, statusCode)
 	if err.StatusCode != statusCode {
@@ -243,6 +266,7 @@ func TestTokenExpiredErrorAttributes(t *testing.T) {
 
 // TestHTTPErrorAttributes verifies HTTPError stores status code and body.
 func TestHTTPErrorAttributes(t *testing.T) {
+	t.Parallel()
 	statusCode := 500
 	body := "Internal Server Error"
 	err := NewHTTPError("http error", nil, statusCode, body)
@@ -256,6 +280,7 @@ func TestHTTPErrorAttributes(t *testing.T) {
 
 // TestErrorMessagePreservation verifies that error messages are preserved.
 func TestErrorMessagePreservation(t *testing.T) {
+	t.Parallel()
 	message := "test error message"
 	err := NewMarketSurgeError(message, nil)
 	if err.Error() != message {
@@ -265,6 +290,7 @@ func TestErrorMessagePreservation(t *testing.T) {
 
 // TestCookieExtractionIsAuthenticationError verifies CookieExtractionError is also AuthenticationError.
 func TestCookieExtractionIsAuthenticationError(t *testing.T) {
+	t.Parallel()
 	err := NewCookieExtractionError("cookie extraction failed", nil, "Firefox")
 	var authErr *AuthenticationError
 	if !errors.As(err, &authErr) {
@@ -274,6 +300,7 @@ func TestCookieExtractionIsAuthenticationError(t *testing.T) {
 
 // TestTokenExpiredIsAuthenticationError verifies TokenExpiredError is also AuthenticationError.
 func TestTokenExpiredIsAuthenticationError(t *testing.T) {
+	t.Parallel()
 	err := NewTokenExpiredError("token expired", nil, 401)
 	var authErr *AuthenticationError
 	if !errors.As(err, &authErr) {
@@ -283,6 +310,7 @@ func TestTokenExpiredIsAuthenticationError(t *testing.T) {
 
 // TestSymbolNotFoundIsAPIError verifies SymbolNotFoundError is also APIError.
 func TestSymbolNotFoundIsAPIError(t *testing.T) {
+	t.Parallel()
 	err := NewSymbolNotFoundError("symbol not found", nil, "INVALID")
 	var apiErr *APIError
 	if !errors.As(err, &apiErr) {
@@ -293,6 +321,7 @@ func TestSymbolNotFoundIsAPIError(t *testing.T) {
 // TestExitCodePriority verifies that more specific error types take priority.
 // SymbolNotFoundError should map to ExitNotFound, not ExitAPIError.
 func TestExitCodePriority(t *testing.T) {
+	t.Parallel()
 	err := NewSymbolNotFoundError("symbol not found", nil, "INVALID")
 	code := ExitCodeFor(err)
 	if code != ExitNotFound {

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -76,6 +76,7 @@ func TestNilPointerFieldsOmitted(t *testing.T) {
 }
 
 func TestCatalogKindConstants(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		kind     CatalogKind
 		expected string
@@ -88,12 +89,14 @@ func TestCatalogKindConstants(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(string(tt.kind), func(t *testing.T) {
-			assert.Equal(t, tt.expected, string(tt.kind))
-		})
+	t.Parallel()
+	assert.Equal(t, tt.expected, string(tt.kind))
+})
 	}
 }
 
 func TestCatalogEntryMarshalUnmarshal(t *testing.T) {
+	t.Parallel()
 	reportID := 124
 	entry := CatalogEntry{
 		Name:     "Bases Forming",
@@ -114,6 +117,7 @@ func TestCatalogEntryMarshalUnmarshal(t *testing.T) {
 }
 
 func TestCatalogKindInJSON(t *testing.T) {
+	t.Parallel()
 	jsonStr := `{"name":"Test","kind":"watchlist"}`
 	var entry CatalogEntry
 	err := json.Unmarshal([]byte(jsonStr), &entry)
@@ -123,6 +127,7 @@ func TestCatalogKindInJSON(t *testing.T) {
 }
 
 func TestFundamentalDataMarshalUnmarshal(t *testing.T) {
+	t.Parallel()
 	fundamental := FundamentalData{
 		Symbol:           "NVDA",
 		ReportedEarnings: []ReportedPeriod{},
@@ -142,6 +147,7 @@ func TestFundamentalDataMarshalUnmarshal(t *testing.T) {
 }
 
 func TestChartDataMarshalUnmarshal(t *testing.T) {
+	t.Parallel()
 	chart := ChartData{
 		Symbol:     "MSFT",
 		TimeSeries: nil,
@@ -159,6 +165,7 @@ func TestChartDataMarshalUnmarshal(t *testing.T) {
 }
 
 func TestRSRatingHistoryMarshalUnmarshal(t *testing.T) {
+	t.Parallel()
 	rsTrue := true
 	rsHistory := RSRatingHistory{
 		Symbol:        "GOOGL",
@@ -178,6 +185,7 @@ func TestRSRatingHistoryMarshalUnmarshal(t *testing.T) {
 }
 
 func TestOwnershipDataMarshalUnmarshal(t *testing.T) {
+	t.Parallel()
 	ownership := OwnershipData{
 		Symbol:         "META",
 		FundsFloatPct:  nil,
@@ -195,6 +203,7 @@ func TestOwnershipDataMarshalUnmarshal(t *testing.T) {
 }
 
 func TestCatalogMarshalUnmarshal(t *testing.T) {
+	t.Parallel()
 	catalog := Catalog{
 		Entries: []CatalogEntry{
 			{
@@ -217,6 +226,7 @@ func TestCatalogMarshalUnmarshal(t *testing.T) {
 }
 
 func TestQuarterlyFinancialsMarshalUnmarshal(t *testing.T) {
+	t.Parallel()
 	quarterly := QuarterlyFinancials{
 		ReportedEarnings: []QuarterlyReportedPeriod{},
 		ReportedSales:    []QuarterlyReportedPeriod{},
@@ -236,6 +246,7 @@ func TestQuarterlyFinancialsMarshalUnmarshal(t *testing.T) {
 }
 
 func TestChartMarkupMarshalUnmarshal(t *testing.T) {
+	t.Parallel()
 	markup := ChartMarkup{
 		ID:   "markup-123",
 		Name: nil,
@@ -254,6 +265,7 @@ func TestChartMarkupMarshalUnmarshal(t *testing.T) {
 }
 
 func TestPricingWithComplexFields(t *testing.T) {
+	t.Parallel()
 	pricing := Pricing{
 		BlueDotDailyDates: []string{"2024-01-01", "2024-01-02"},
 		BlueDotWeeklyDates: []string{},
@@ -273,6 +285,7 @@ func TestPricingWithComplexFields(t *testing.T) {
 }
 
 func TestCatalogResultMarshalUnmarshal(t *testing.T) {
+	t.Parallel()
 	total := 42
 	result := CatalogResult{
 		Kind:             CatalogKindReport,
@@ -294,6 +307,7 @@ func TestCatalogResultMarshalUnmarshal(t *testing.T) {
 }
 
 func TestTimeSeriesMarshalUnmarshal(t *testing.T) {
+	t.Parallel()
 	timeSeries := TimeSeries{
 		Period:     "DAILY",
 		DataPoints: []DataPoint{},
@@ -310,6 +324,7 @@ func TestTimeSeriesMarshalUnmarshal(t *testing.T) {
 }
 
 func TestQuoteMarshalUnmarshal(t *testing.T) {
+	t.Parallel()
 	last := 150.50
 	volume := 1000000.0
 	quote := Quote{

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestWriteSuccess(t *testing.T) {
+	t.Parallel()
 	buf := &bytes.Buffer{}
 	data := map[string]any{"symbol": "AAPL", "price": "150.00"}
 	metadata := map[string]any{"timestamp": "2026-04-21T10:00:00Z"}
@@ -29,6 +30,7 @@ func TestWriteSuccess(t *testing.T) {
 }
 
 func TestWriteSuccessWithNilMetadata(t *testing.T) {
+	t.Parallel()
 	buf := &bytes.Buffer{}
 	data := map[string]any{"test": "value"}
 
@@ -44,6 +46,7 @@ func TestWriteSuccessWithNilMetadata(t *testing.T) {
 }
 
 func TestWriteErrorSymbolNotFound(t *testing.T) {
+	t.Parallel()
 	buf := &bytes.Buffer{}
 	err := mserr.NewSymbolNotFoundError("symbol not found", errors.New("api returned empty"), "INVALID")
 
@@ -60,6 +63,7 @@ func TestWriteErrorSymbolNotFound(t *testing.T) {
 }
 
 func TestWriteErrorAuthenticationError(t *testing.T) {
+	t.Parallel()
 	buf := &bytes.Buffer{}
 	err := mserr.NewAuthenticationError("auth failed", errors.New("invalid token"))
 
@@ -75,6 +79,7 @@ func TestWriteErrorAuthenticationError(t *testing.T) {
 }
 
 func TestWriteErrorCookieExtractionError(t *testing.T) {
+	t.Parallel()
 	buf := &bytes.Buffer{}
 	err := mserr.NewCookieExtractionError("cookie extraction failed", errors.New("db error"), "firefox")
 
@@ -89,6 +94,7 @@ func TestWriteErrorCookieExtractionError(t *testing.T) {
 }
 
 func TestWriteErrorTokenExpiredError(t *testing.T) {
+	t.Parallel()
 	buf := &bytes.Buffer{}
 	err := mserr.NewTokenExpiredError("token expired", errors.New("401 response"), 401)
 
@@ -103,6 +109,7 @@ func TestWriteErrorTokenExpiredError(t *testing.T) {
 }
 
 func TestWriteErrorAPIError(t *testing.T) {
+	t.Parallel()
 	buf := &bytes.Buffer{}
 	err := mserr.NewAPIError("api error", errors.New("graphql error"))
 
@@ -117,6 +124,7 @@ func TestWriteErrorAPIError(t *testing.T) {
 }
 
 func TestWriteErrorHTTPError(t *testing.T) {
+	t.Parallel()
 	buf := &bytes.Buffer{}
 	err := mserr.NewHTTPError("http error", errors.New("500 response"), 500, "Internal Server Error")
 
@@ -131,6 +139,7 @@ func TestWriteErrorHTTPError(t *testing.T) {
 }
 
 func TestWriteErrorValidationError(t *testing.T) {
+	t.Parallel()
 	buf := &bytes.Buffer{}
 	err := mserr.NewValidationError("validation failed", errors.New("invalid input"))
 
@@ -145,6 +154,7 @@ func TestWriteErrorValidationError(t *testing.T) {
 }
 
 func TestWriteErrorGenericError(t *testing.T) {
+	t.Parallel()
 	buf := &bytes.Buffer{}
 	err := errors.New("unknown error")
 
@@ -159,6 +169,7 @@ func TestWriteErrorGenericError(t *testing.T) {
 }
 
 func TestWritePartial(t *testing.T) {
+	t.Parallel()
 	buf := &bytes.Buffer{}
 	data := map[string]any{"partial": "data"}
 	errs := []string{"error 1", "error 2"}
@@ -177,6 +188,7 @@ func TestWritePartial(t *testing.T) {
 }
 
 func TestWritePartialWithEmptyErrors(t *testing.T) {
+	t.Parallel()
 	buf := &bytes.Buffer{}
 	data := map[string]any{"test": "data"}
 	metadata := map[string]any{"timestamp": "2026-04-21T10:00:00Z"}
@@ -194,6 +206,7 @@ func TestWritePartialWithEmptyErrors(t *testing.T) {
 }
 
 func TestJSONEscapeHTMLDisabled(t *testing.T) {
+	t.Parallel()
 	buf := &bytes.Buffer{}
 	data := map[string]string{"url": "https://example.com?foo=bar&baz=qux"}
 	metadata := map[string]any{}
@@ -207,6 +220,7 @@ func TestJSONEscapeHTMLDisabled(t *testing.T) {
 }
 
 func TestSymbolMeta(t *testing.T) {
+	t.Parallel()
 	meta := SymbolMeta("AAPL")
 
 	assert.Equal(t, "AAPL", meta["symbol"])
@@ -219,6 +233,7 @@ func TestSymbolMeta(t *testing.T) {
 }
 
 func TestCatalogMeta(t *testing.T) {
+	t.Parallel()
 	meta := CatalogMeta("reports", 47, 10, 0)
 
 	assert.Equal(t, "reports", meta["kind"])

--- a/queries/queries_test.go
+++ b/queries/queries_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestLoadAllQueries(t *testing.T) {
+	t.Parallel()
 	queries := []string{
 		"other_market_data.graphql",
 		"fundamentals.graphql",
@@ -23,18 +24,20 @@ func TestLoadAllQueries(t *testing.T) {
 
 	for _, query := range queries {
 		t.Run(query, func(t *testing.T) {
-			content, err := Load(query)
+	t.Parallel()
+	content, err := Load(query)
 			if err != nil {
 				t.Fatalf("failed to load %s: %v", query, err)
 			}
 			if content == "" {
 				t.Fatalf("query %s is empty", query)
 			}
-		})
+})
 	}
 }
 
 func TestLoadUnknownQuery(t *testing.T) {
+	t.Parallel()
 	_, err := Load("nonexistent.graphql")
 	if err == nil {
 		t.Fatal("expected error for nonexistent query, got nil")


### PR DESCRIPTION
## Summary

Backports 10 improvements identified by comparing marketsurge-agent against schwab-agent and volumeleaders-agent, bringing this project in line with conventions established in the newer codebases.

## Changes

**Code quality:**
- Replace `log.Printf` with `log/slog` structured logging in auth chain
- Add functional options pattern (`WithBaseURL`, `WithHTTPClient`) to `NewClient()`
- Validate `Content-Type` header before JSON decode in GraphQL client
- Bound response body reads with `io.LimitReader` (10 MB cap)

**Build and test:**
- Use PATH-resolved `go` binary instead of hardcoded `/usr/local/go/bin/go`
- Add `-race` and `-coverprofile` to Makefile test target
- Enable `t.Parallel()` across all safe test functions (145 functions)
- Enable `gosec` linter

**CI/CD:**
- Add `govulncheck` job to catch known dependency CVEs
- Add Sigstore cosign keyless signing to release workflow