### PR TITLE
build(go): target Go 1.26

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - gocritic
     - gosec
     - misspell
+    - modernize
     - nolintlint
     - revive
     - unconvert

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,8 @@ Follow `fundamental_get.go` (33 lines) as the canonical simple command template.
 
 ## Build
 
+Requires Go 1.26+.
+
 ```bash
 make build     # Build binary
 make test      # go test -v -race -coverprofile
@@ -119,7 +121,7 @@ make lint      # golangci-lint run
 make clean     # Remove binary + coverage
 ```
 
-Linting uses [golangci-lint](https://golangci-lint.run/) v2 with config in `.golangci.yml`. The standard linter set is enabled plus `bodyclose`, `errorlint`, `gocritic`, `misspell`, `nolintlint`, `revive`, `unconvert`, and `unparam`.
+Linting uses [golangci-lint](https://golangci-lint.run/) v2 with config in `.golangci.yml`. The standard linter set is enabled plus `bodyclose`, `errorlint`, `gocritic`, `misspell`, `modernize`, `nolintlint`, `revive`, `unconvert`, and `unparam`.
 
 CI pipeline: `golangci-lint` (separate job) + `go test -v -race` -> `go build`
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ marketsurge-agent skills generate
 
 ## Development
 
-Requires Go 1.25+.
+Requires Go 1.26+.
 
 ```bash
 make build     # Build binary

--- a/cmd/marketsurge-agent/main_test.go
+++ b/cmd/marketsurge-agent/main_test.go
@@ -24,7 +24,7 @@ func TestHelpContainsAllCommands(t *testing.T) {
 	var helpBuf bytes.Buffer
 	app.Writer = &helpBuf
 
-	err := app.Run(context.Background(), []string{"marketsurge-agent", "--help"})
+	err := app.Run(t.Context(), []string{"marketsurge-agent", "--help"})
 	require.NoError(t, err)
 
 	helpText := helpBuf.String()
@@ -48,7 +48,7 @@ func TestUnknownCommandReturnsError(t *testing.T) {
 	app.Writer = io.Discard
 	app.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
 
-	_ = app.Run(context.Background(), []string{"marketsurge-agent", "nonexistent"})
+	_ = app.Run(t.Context(), []string{"marketsurge-agent", "nonexistent"})
 
 	var envelope output.ErrorEnvelope
 	err := json.NewDecoder(&buf).Decode(&envelope)
@@ -72,7 +72,7 @@ func TestErrorOutputIsValidJSON(t *testing.T) {
 
 	// Running a real command without auth triggers an AuthenticationError
 	// from the Before handler.
-	err := app.Run(context.Background(), []string{"marketsurge-agent", "stock", "get", "AAPL"})
+	err := app.Run(t.Context(), []string{"marketsurge-agent", "stock", "get", "AAPL"})
 	require.Error(t, err)
 
 	// Simulate main()'s error handler writing JSON to stdout.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/major/marketsurge-agent
 
-go 1.25.0
+go 1.26
 
 require (
 	github.com/browserutils/kooky v0.2.9

--- a/internal/client/catalog_test.go
+++ b/internal/client/catalog_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -21,7 +20,7 @@ func TestRunReportSuccess(t *testing.T) {
 		_, _ = w.Write([]byte(adhocResponseJSON()))
 	})
 
-	data, err := client.RunReport(context.Background(), 124)
+	data, err := client.RunReport(t.Context(), 124)
 	require.NoError(t, err)
 	assert.Equal(t, "MarketDataAdhocScreen", captured.OperationName)
 	assert.Len(t, data.Entries, 1)
@@ -43,7 +42,7 @@ func TestRunWatchlistTwoStepFlow(t *testing.T) {
 		_, _ = w.Write([]byte(adhocResponseJSON()))
 	})
 
-	data, err := client.RunWatchlist(context.Background(), 922337203685477580)
+	data, err := client.RunWatchlist(t.Context(), 922337203685477580)
 	require.NoError(t, err)
 	require.Len(t, requests, 2)
 	assert.Equal(t, "FlaggedSymbols", requests[0].OperationName)
@@ -60,7 +59,7 @@ func TestRunWatchlistReturnsEmptyForNoSymbols(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":{"watchlist":{"id":"123","items":[]}}}`))
 	})
 
-	data, err := client.RunWatchlist(context.Background(), 123)
+	data, err := client.RunWatchlist(t.Context(), 123)
 	require.NoError(t, err)
 	assert.Empty(t, data.Entries)
 }
@@ -71,7 +70,7 @@ func TestRunWatchlistReturnsNotFoundWhenMissing(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":{"watchlist":null}}`))
 	})
 
-	_, err := client.RunWatchlist(context.Background(), 123)
+	_, err := client.RunWatchlist(t.Context(), 123)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "watchlist not found")
 }
@@ -82,7 +81,7 @@ func TestRunCoachScreenSuccess(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":{"user":{"runScreen":{"numberOfMatchingInstruments":2,"responseValues":[[{"mdItem":{"name":"Symbol"},"value":"AAPL"}]]}}}}`))
 	})
 
-	data, err := client.RunCoachScreen(context.Background(), "screen-1")
+	data, err := client.RunCoachScreen(t.Context(), "screen-1")
 	require.NoError(t, err)
 	assert.Equal(t, 2, *data.NumInstruments)
 	assert.Equal(t, "AAPL", *data.Rows[0]["Symbol"])
@@ -94,7 +93,7 @@ func TestRunCoachScreenReturnsAPIErrorForMissingPayload(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":{"user":{}}}`))
 	})
 
-	_, err := client.RunCoachScreen(context.Background(), "screen-1")
+	_, err := client.RunCoachScreen(t.Context(), "screen-1")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no coach screen data returned")
 }
@@ -117,7 +116,7 @@ func TestListCatalogAggregatesAllSources(t *testing.T) {
 		}
 	})
 
-	catalog, err := client.ListCatalog(context.Background(), nil)
+	catalog, err := client.ListCatalog(t.Context(), nil)
 	require.NoError(t, err)
 	assert.Empty(t, catalog.Errors)
 	assert.GreaterOrEqual(t, len(catalog.Entries), 4)
@@ -136,7 +135,7 @@ func TestListCatalogReportFilterSkipsRemoteSources(t *testing.T) {
 	})
 	kind := models.CatalogKindReport
 
-	catalog, err := client.ListCatalog(context.Background(), &kind)
+	catalog, err := client.ListCatalog(t.Context(), &kind)
 	require.NoError(t, err)
 	assert.Empty(t, requests)
 	assert.Len(t, catalog.Errors, 0)
@@ -160,7 +159,7 @@ func TestListCatalogPartialFailure(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":{"user":{"screens":[],"watchlists":[]}}}`))
 	})
 
-	catalog, err := client.ListCatalog(context.Background(), nil)
+	catalog, err := client.ListCatalog(t.Context(), nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, catalog.Errors)
 	assert.Contains(t, catalog.Errors[0], "screens failed")
@@ -184,7 +183,7 @@ func TestListCatalogFiltersKind(t *testing.T) {
 	})
 	kind := models.CatalogKindReport
 
-	catalog, err := client.ListCatalog(context.Background(), &kind)
+	catalog, err := client.ListCatalog(t.Context(), &kind)
 	require.NoError(t, err)
 	require.NotEmpty(t, catalog.Entries)
 	for _, entry := range catalog.Entries {
@@ -199,7 +198,7 @@ func TestParseAdhocScreenResultIncludesErrorValues(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":{"marketDataAdhocScreen":{"responseValues":[],"errorValues":["bad symbol"]}}}`))
 	})
 
-	data, err := client.RunReport(context.Background(), 124)
+	data, err := client.RunReport(t.Context(), 124)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"bad symbol"}, data.ErrorValues)
 }
@@ -210,7 +209,7 @@ func TestParseAdhocScreenResultMapsFields(t *testing.T) {
 		_, _ = w.Write([]byte(adhocResponseJSON()))
 	})
 
-	data, err := client.RunReport(context.Background(), 124)
+	data, err := client.RunReport(t.Context(), 124)
 	require.NoError(t, err)
 	require.Len(t, data.Entries, 1)
 	assert.Equal(t, 99, *data.Entries[0].CompositeRating)

--- a/internal/client/catalog_test.go
+++ b/internal/client/catalog_test.go
@@ -121,7 +121,7 @@ func TestListCatalogAggregatesAllSources(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, catalog.Errors)
 	assert.GreaterOrEqual(t, len(catalog.Entries), 4)
-	assert.Contains(t, catalog.Entries, models.CatalogEntry{Name: "Saved Screen", Kind: models.CatalogKindScreen, Description: strptr("screen desc")})
+	assert.Contains(t, catalog.Entries, models.CatalogEntry{Name: "Saved Screen", Kind: models.CatalogKindScreen, Description: new("screen desc")})
 }
 
 func TestListCatalogReportFilterSkipsRemoteSources(t *testing.T) {
@@ -222,10 +222,6 @@ func TestParseAdhocScreenResultMapsFields(t *testing.T) {
 
 func adhocResponseJSON() string {
 	return `{"data":{"marketDataAdhocScreen":{"responseValues":[[{"mdItem":{"name":"Symbol"},"value":"AAPL"},{"mdItem":{"name":"CompanyName"},"value":"Apple Inc."},{"mdItem":{"name":"ListRank"},"value":"1"},{"mdItem":{"name":"Price"},"value":"101.5"},{"mdItem":{"name":"PriceNetChg"},"value":"1.0"},{"mdItem":{"name":"PricePctChg"},"value":"0.9"},{"mdItem":{"name":"PricePctOff52WHigh"},"value":"5.0"},{"mdItem":{"name":"VolumeAvg50Day"},"value":"1000"},{"mdItem":{"name":"VolumePctChgVs50DAvgVolume"},"value":"10.0"},{"mdItem":{"name":"CompositeRating"},"value":"99"},{"mdItem":{"name":"EPSRating"},"value":"95"},{"mdItem":{"name":"RSRating"},"value":"94"},{"mdItem":{"name":"AccDisRating"},"value":"A"},{"mdItem":{"name":"SMRRating"},"value":"A"},{"mdItem":{"name":"IndustryGroupRank"},"value":"3"},{"mdItem":{"name":"IndustryName"},"value":"Technology"},{"mdItem":{"name":"MarketCapIntraday"},"value":"1000"},{"mdItem":{"name":"VolumeDollarAvg50D"},"value":"500"},{"mdItem":{"name":"IPODate"},"value":"1980-12-12"},{"mdItem":{"name":"DowJonesKey"},"value":"DJ:1"},{"mdItem":{"name":"ChartingSymbol"},"value":"AAPL"},{"mdItem":{"name":"DowJonesInstrumentType"},"value":"EQUITY"},{"mdItem":{"name":"DowJonesInstrumentSubType"},"value":"COMMON"}]],"errorValues":[]}}}`
-}
-
-func strptr(value string) *string {
-	return &value
 }
 
 func modelsToReportEntries() []models.CatalogEntry {

--- a/internal/client/chart_test.go
+++ b/internal/client/chart_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -19,7 +18,7 @@ func TestGetChartHistoryDailyIncludesExchangeAndBenchmark(t *testing.T) {
 		_, _ = w.Write([]byte(chartResponseJSON(true)))
 	})
 
-	data, err := client.GetChartHistory(context.Background(), "AAPL", "2024-01-01", "2024-02-01", "P1D", true, "NYSE", "0S&P5")
+	data, err := client.GetChartHistory(t.Context(), "AAPL", "2024-01-01", "2024-02-01", "P1D", true, "NYSE", "0S&P5")
 	require.NoError(t, err)
 	assert.Equal(t, "NYSE", captured.Variables["exchangeName"])
 	assert.Len(t, captured.Variables["symbols"], 2)
@@ -37,7 +36,7 @@ func TestGetChartHistoryWeeklyOmitsExchange(t *testing.T) {
 		_, _ = w.Write([]byte(chartResponseJSON(false)))
 	})
 
-	data, err := client.GetChartHistory(context.Background(), "AAPL", "2024-01-01", "2024-02-01", "P1W", false, "", "")
+	data, err := client.GetChartHistory(t.Context(), "AAPL", "2024-01-01", "2024-02-01", "P1W", false, "", "")
 	require.NoError(t, err)
 	assert.Nil(t, captured.Variables["exchangeName"])
 	assert.Nil(t, data.BenchmarkTimeSeries)
@@ -51,7 +50,7 @@ func TestGetChartMarkupsSuccess(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":{"user":{"chartMarkups":{"cursorId":"cursor-1","chartMarkups":[{"id":"m1","name":"Base","data":"{}","frequency":"DAILY","site":"marketsurge"}]}}}}`))
 	})
 
-	data, err := client.GetChartMarkups(context.Background(), "DJ:1", "DAILY", "ASC")
+	data, err := client.GetChartMarkups(t.Context(), "DJ:1", "DAILY", "ASC")
 	require.NoError(t, err)
 	assert.Equal(t, "cursor-1", data.CursorID)
 	assert.Len(t, data.Markups, 1)
@@ -67,7 +66,7 @@ func TestGetChartMarkupsPassesOperationName(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":{"user":{"chartMarkups":{"cursorId":"","chartMarkups":[]}}}}`))
 	})
 
-	_, err := client.GetChartMarkups(context.Background(), "DJ:1", "WEEKLY", "DESC")
+	_, err := client.GetChartMarkups(t.Context(), "DJ:1", "WEEKLY", "DESC")
 	require.NoError(t, err)
 	assert.Equal(t, "FetchChartMarkups", captured.OperationName)
 	assert.Equal(t, "WEEKLY", captured.Variables["frequency"])
@@ -80,7 +79,7 @@ func TestGetChartHistoryReturnsSymbolNotFound(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":{"marketData":[]}}`))
 	})
 
-	_, err := client.GetChartHistory(context.Background(), "MISS", "2024-01-01", "2024-02-01", "P1D", true, "NYSE", "")
+	_, err := client.GetChartHistory(t.Context(), "MISS", "2024-01-01", "2024-02-01", "P1D", true, "NYSE", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "symbol not found")
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -44,7 +43,7 @@ func TestExecuteSetsHeadersAndAuthorization(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":{"ok":true}}`))
 	})
 
-	raw, err := client.Execute(context.Background(), Request{OperationName: "TestOp", Variables: map[string]any{"value": "x"}, Query: "query TestOp { ok }"})
+	raw, err := client.Execute(t.Context(), Request{OperationName: "TestOp", Variables: map[string]any{"value": "x"}, Query: "query TestOp { ok }"})
 	require.NoError(t, err)
 	assert.Equal(t, "TestOp", captured.OperationName)
 	assert.Equal(t, "x", captured.Variables["value"])
@@ -58,7 +57,7 @@ func TestExecuteReturnsGraphQLErrorOnHTTP200(t *testing.T) {
 		_, _ = w.Write([]byte(`{"errors":[{"message":"bad request"}]}`))
 	})
 
-	_, err := client.Execute(context.Background(), Request{})
+	_, err := client.Execute(t.Context(), Request{})
 	var apiErr *mserrors.APIError
 	require.Error(t, err)
 	assert.ErrorAs(t, err, &apiErr)
@@ -71,7 +70,7 @@ func TestExecuteReturnsTokenExpiredErrorOn401(t *testing.T) {
 		http.Error(w, "nope", http.StatusUnauthorized)
 	})
 
-	_, err := client.Execute(context.Background(), Request{})
+	_, err := client.Execute(t.Context(), Request{})
 	var authErr *mserrors.TokenExpiredError
 	require.Error(t, err)
 	assert.ErrorAs(t, err, &authErr)
@@ -83,7 +82,7 @@ func TestExecuteReturnsAuthenticationErrorOn403(t *testing.T) {
 		http.Error(w, "forbidden", http.StatusForbidden)
 	})
 
-	_, err := client.Execute(context.Background(), Request{})
+	_, err := client.Execute(t.Context(), Request{})
 	var authErr *mserrors.AuthenticationError
 	require.Error(t, err)
 	assert.ErrorAs(t, err, &authErr)
@@ -95,7 +94,7 @@ func TestExecuteReturnsHTTPErrorOn500(t *testing.T) {
 		http.Error(w, "boom", http.StatusInternalServerError)
 	})
 
-	_, err := client.Execute(context.Background(), Request{})
+	_, err := client.Execute(t.Context(), Request{})
 	var httpErr *mserrors.HTTPError
 	require.Error(t, err)
 	assert.ErrorAs(t, err, &httpErr)
@@ -110,7 +109,7 @@ func TestExecuteRejectsUnexpectedContentType(t *testing.T) {
 		_, _ = w.Write([]byte("<html><body>Service Unavailable</body></html>"))
 	})
 
-	_, err := client.Execute(context.Background(), Request{})
+	_, err := client.Execute(t.Context(), Request{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unexpected Content-Type")
 	assert.Contains(t, err.Error(), "text/html")
@@ -123,7 +122,7 @@ func TestExecuteAcceptsJSONWithCharset(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":{"ok":true}}`))
 	})
 
-	raw, err := client.Execute(context.Background(), Request{})
+	raw, err := client.Execute(t.Context(), Request{})
 	require.NoError(t, err)
 	assert.Equal(t, true, getNestedMap(raw, "data")["ok"])
 }

--- a/internal/client/stock_test.go
+++ b/internal/client/stock_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -20,7 +19,7 @@ func TestGetStockSuccess(t *testing.T) {
 		_, _ = w.Write([]byte(stockResponseJSON()))
 	})
 
-	stock, err := client.GetStock(context.Background(), "AAPL")
+	stock, err := client.GetStock(t.Context(), "AAPL")
 	require.NoError(t, err)
 	require.NotNil(t, stock)
 	assert.Equal(t, "OtherMarketData", captured.OperationName)
@@ -39,7 +38,7 @@ func TestGetStockReturnsSymbolNotFoundForEmptyMarketData(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":{"marketData":[]}}`))
 	})
 
-	_, err := client.GetStock(context.Background(), "MISSING")
+	_, err := client.GetStock(t.Context(), "MISSING")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "symbol not found")
 }
@@ -51,7 +50,7 @@ func TestGetFundamentalsSuccess(t *testing.T) {
 		_, _ = w.Write([]byte(stockResponseJSON()))
 	})
 
-	data, err := client.GetFundamentals(context.Background(), "AAPL")
+	data, err := client.GetFundamentals(t.Context(), "AAPL")
 	require.NoError(t, err)
 	assert.Equal(t, "AAPL", data.Symbol)
 	assert.Equal(t, "Apple Inc.", *data.CompanyName)
@@ -66,7 +65,7 @@ func TestGetOwnershipSuccess(t *testing.T) {
 		_, _ = w.Write([]byte(stockResponseJSON()))
 	})
 
-	data, err := client.GetOwnership(context.Background(), "AAPL")
+	data, err := client.GetOwnership(t.Context(), "AAPL")
 	require.NoError(t, err)
 	assert.Equal(t, "65%", *data.FundsFloatPct)
 	assert.Len(t, data.QuarterlyFunds, 1)
@@ -80,7 +79,7 @@ func TestGetRSRatingHistorySuccess(t *testing.T) {
 		_, _ = w.Write([]byte(stockResponseJSON()))
 	})
 
-	data, err := client.GetRSRatingHistory(context.Background(), "AAPL")
+	data, err := client.GetRSRatingHistory(t.Context(), "AAPL")
 	require.NoError(t, err)
 	assert.Equal(t, "AAPL", data.Symbol)
 	assert.True(t, *data.RSLineNewHigh)

--- a/internal/commands/catalog_run.go
+++ b/internal/commands/catalog_run.go
@@ -256,13 +256,7 @@ func paginateSlice[T any](items []T, limit, offset int) []T {
 
 // clampCatalogOffset bounds the offset to the available entry count.
 func clampCatalogOffset(offset, length int) int {
-	if offset < 0 {
-		return 0
-	}
-	if offset > length {
-		return length
-	}
-	return offset
+	return max(0, min(offset, length))
 }
 
 // projectWatchlistEntries narrows output entries to the requested fields when present.

--- a/internal/commands/catalog_run_test.go
+++ b/internal/commands/catalog_run_test.go
@@ -157,6 +157,118 @@ func TestCatalogRunPagination(t *testing.T) {
 	assert.Equal(t, "MSFT", envelope.Data.Entries[0]["symbol"])
 }
 
+func TestClampCatalogOffset(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		offset   int
+		length   int
+		expected int
+	}{
+		{name: "zero offset", offset: 0, length: 10, expected: 0},
+		{name: "positive offset within bounds", offset: 5, length: 10, expected: 5},
+		{name: "negative offset clamps to zero", offset: -1, length: 10, expected: 0},
+		{name: "large negative offset clamps to zero", offset: -100, length: 10, expected: 0},
+		{name: "offset equals length", offset: 10, length: 10, expected: 10},
+		{name: "offset exceeds length", offset: 15, length: 10, expected: 10},
+		{name: "large offset clamps to length", offset: 1000, length: 10, expected: 10},
+		{name: "zero length", offset: 0, length: 0, expected: 0},
+		{name: "negative offset with zero length", offset: -5, length: 0, expected: 0},
+		{name: "positive offset with zero length", offset: 5, length: 0, expected: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := clampCatalogOffset(tt.offset, tt.length)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestPaginateSlice(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		items    []string
+		limit    int
+		offset   int
+		expected []string
+	}{
+		{
+			name:     "no pagination",
+			items:    []string{"a", "b", "c"},
+			limit:    0,
+			offset:   0,
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "limit within bounds",
+			items:    []string{"a", "b", "c", "d"},
+			limit:    2,
+			offset:   0,
+			expected: []string{"a", "b"},
+		},
+		{
+			name:     "offset and limit",
+			items:    []string{"a", "b", "c", "d"},
+			limit:    2,
+			offset:   1,
+			expected: []string{"b", "c"},
+		},
+		{
+			name:     "negative offset clamps to zero",
+			items:    []string{"a", "b", "c"},
+			limit:    2,
+			offset:   -5,
+			expected: []string{"a", "b"},
+		},
+		{
+			name:     "offset beyond length",
+			items:    []string{"a", "b", "c"},
+			limit:    2,
+			offset:   10,
+			expected: []string{},
+		},
+		{
+			name:     "negative limit returns full slice from offset",
+			items:    []string{"a", "b", "c"},
+			limit:    -1,
+			offset:   0,
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "empty slice",
+			items:    []string{},
+			limit:    10,
+			offset:   0,
+			expected: []string{},
+		},
+		{
+			name:     "offset at end of slice",
+			items:    []string{"a", "b", "c"},
+			limit:    10,
+			offset:   3,
+			expected: []string{},
+		},
+		{
+			name:     "limit exceeds remaining items",
+			items:    []string{"a", "b", "c"},
+			limit:    10,
+			offset:   1,
+			expected: []string{"b", "c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := paginateSlice(tt.items, tt.limit, tt.offset)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
 func TestCatalogRunWatchlistID64Bit(t *testing.T) {
 	t.Parallel()
 	server, requests := newCatalogRunServer(t)

--- a/internal/commands/helpers_test.go
+++ b/internal/commands/helpers_test.go
@@ -18,7 +18,7 @@ import (
 func runTestCommand(t *testing.T, cmd *cli.Command, args ...string) error {
 	t.Helper()
 	cmd.ExitErrHandler = func(_ context.Context, _ *cli.Command, _ error) {}
-	return cmd.Run(context.Background(), args)
+	return cmd.Run(t.Context(), args)
 }
 
 // parseJSONEnvelope unmarshals buf into a map and asserts it contains data and metadata keys.

--- a/internal/commands/skills_generate_test.go
+++ b/internal/commands/skills_generate_test.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -32,7 +31,7 @@ func TestSkillsGenerateCommand(t *testing.T) {
 		cmd := SkillsGenerateCommand(&buf)
 
 		// Create a CLI context with the output-dir flag
-		ctx := context.Background()
+		ctx := t.Context()
 		cliCmd := &cli.Command{
 			Name: "test",
 			Flags: []cli.Flag{
@@ -86,7 +85,7 @@ func TestSkillsGenerateCommand(t *testing.T) {
 		var buf bytes.Buffer
 		cmd := SkillsGenerateCommand(&buf)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		err := cmd.Action(ctx, &cli.Command{
 			Flags: []cli.Flag{
 				&cli.StringFlag{
@@ -151,7 +150,7 @@ func TestSkillsGenerateCommand(t *testing.T) {
 		var buf bytes.Buffer
 		cmd := SkillsGenerateCommand(&buf)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		err := cmd.Action(ctx, &cli.Command{
 			Flags: []cli.Flag{
 				&cli.StringFlag{
@@ -185,7 +184,7 @@ func TestSkillsGenerateCommand(t *testing.T) {
 		var buf bytes.Buffer
 		cmd := SkillsGenerateCommand(&buf)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		err := cmd.Action(ctx, &cli.Command{
 			Flags: []cli.Flag{
 				&cli.StringFlag{
@@ -227,7 +226,7 @@ func TestSkillsGenerateCommand(t *testing.T) {
 		var buf bytes.Buffer
 		cmd := SkillsGenerateCommand(&buf)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		err := cmd.Action(ctx, &cli.Command{
 			Flags: []cli.Flag{
 				&cli.StringFlag{

--- a/internal/commands/stock_analyze.go
+++ b/internal/commands/stock_analyze.go
@@ -45,17 +45,15 @@ func StockAnalyzeCommand(c *client.Client, w io.Writer) *cli.Command {
 			// Process each symbol concurrently.
 			var wg sync.WaitGroup
 			for i, symbol := range symbols {
-				wg.Add(1)
-				go func(idx int, sym string) {
-					defer wg.Done()
-					result, errs := analyzeSymbol(ctx, c, sym)
-					results[idx] = result
+				wg.Go(func() {
+					result, errs := analyzeSymbol(ctx, c, symbol)
+					results[i] = result
 					if len(errs) > 0 {
 						mu.Lock()
 						allErrors = append(allErrors, errs...)
 						mu.Unlock()
 					}
-				}(i, symbol)
+				})
 			}
 			wg.Wait()
 
@@ -100,10 +98,8 @@ func analyzeSymbol(ctx context.Context, c *client.Client, symbol string) (result
 	var mu sync.Mutex
 
 	var wg sync.WaitGroup
-	wg.Add(3)
 
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		stock, err := c.GetStock(ctx, symbol)
 		if err != nil {
 			mu.Lock()
@@ -112,10 +108,9 @@ func analyzeSymbol(ctx context.Context, c *client.Client, symbol string) (result
 			return
 		}
 		result.Stock = stock
-	}()
+	})
 
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		fund, err := c.GetFundamentals(ctx, symbol)
 		if err != nil {
 			mu.Lock()
@@ -124,10 +119,9 @@ func analyzeSymbol(ctx context.Context, c *client.Client, symbol string) (result
 			return
 		}
 		result.Fundamentals = fund
-	}()
+	})
 
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		own, err := c.GetOwnership(ctx, symbol)
 		if err != nil {
 			mu.Lock()
@@ -136,7 +130,7 @@ func analyzeSymbol(ctx context.Context, c *client.Client, symbol string) (result
 			return
 		}
 		result.Ownership = own
-	}()
+	})
 
 	wg.Wait()
 	return result, errs

--- a/internal/cookies/cookies.go
+++ b/internal/cookies/cookies.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
+	"slices"
 
 	"github.com/browserutils/kooky"
 	"github.com/browserutils/kooky/browser/firefox"
@@ -39,6 +39,14 @@ func defaultFirefoxRoot() (string, error) {
 	}
 }
 
+// cookiePath pairs a file path with its precomputed stat result.
+// info is nil when os.Stat fails, keeping the path in output but
+// sorting it after paths with valid stats.
+type cookiePath struct {
+	path string
+	info os.FileInfo
+}
+
 // FindCookieDBPaths returns paths to all Firefox profile cookies.sqlite files,
 // sorted by modification time (most recent first). Profiles that were used
 // most recently are tried first during authentication.
@@ -54,18 +62,39 @@ func FindCookieDBPaths() ([]string, error) {
 		return nil, fmt.Errorf("glob firefox profiles: %w", err)
 	}
 
-	// Sort by modification time, most recent first. This makes the common
-	// case fast: the actively-used profile is tried first.
-	sort.Slice(matches, func(i, j int) bool {
-		si, ei := os.Stat(matches[i])
-		sj, ej := os.Stat(matches[j])
-		if ei != nil || ej != nil {
-			return ei == nil
+	// Precompute stat results once per path instead of repeatedly
+	// inside the comparator. Stat failures get nil info.
+	entries := make([]cookiePath, len(matches))
+	for i, p := range matches {
+		info, statErr := os.Stat(p)
+		if statErr != nil {
+			entries[i] = cookiePath{path: p}
+		} else {
+			entries[i] = cookiePath{path: p, info: info}
 		}
-		return si.ModTime().After(sj.ModTime())
+	}
+
+	// Sort by modification time, most recent first. Paths where
+	// stat failed sort last so they are still tried, just not first.
+	slices.SortFunc(entries, func(a, b cookiePath) int {
+		switch {
+		case a.info == nil && b.info == nil:
+			return 0
+		case a.info == nil:
+			return 1 // a sorts after b
+		case b.info == nil:
+			return -1 // a sorts before b
+		default:
+			return b.info.ModTime().Compare(a.info.ModTime())
+		}
 	})
 
-	return matches, nil
+	sorted := make([]string, len(entries))
+	for i, e := range entries {
+		sorted[i] = e.path
+	}
+
+	return sorted, nil
 }
 
 // ExtractCookies retrieves investors.com cookies from a specific Firefox

--- a/internal/cookies/cookies_test.go
+++ b/internal/cookies/cookies_test.go
@@ -79,3 +79,50 @@ func TestFindCookieDBPaths_RootError(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, paths)
 }
+
+// TestFindCookieDBPaths_StatFailureSortsLast verifies that cookie DB paths
+// where os.Stat fails are preserved in the output but sort after paths
+// with valid stats.
+func TestFindCookieDBPaths_StatFailureSortsLast(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create two valid profiles with different mtimes.
+	profiles := []struct {
+		dir string
+		age time.Duration
+	}{
+		{"aaa111.oldest", 2 * time.Hour},
+		{"bbb222.newest", 0},
+	}
+	for _, p := range profiles {
+		dir := filepath.Join(tmpDir, p.dir)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		dbPath := filepath.Join(dir, "cookies.sqlite")
+		require.NoError(t, os.WriteFile(dbPath, []byte{}, 0o644))
+		if p.age > 0 {
+			mtime := time.Now().Add(-p.age)
+			require.NoError(t, os.Chtimes(dbPath, mtime, mtime))
+		}
+	}
+
+	// Create a profile directory but remove the cookies.sqlite after glob
+	// discovers it. We simulate this by creating a broken symlink instead:
+	// glob matches it, but os.Stat fails.
+	brokenDir := filepath.Join(tmpDir, "ccc333.broken")
+	require.NoError(t, os.MkdirAll(brokenDir, 0o755))
+	brokenDB := filepath.Join(brokenDir, "cookies.sqlite")
+	require.NoError(t, os.Symlink("/nonexistent/path", brokenDB))
+
+	origRoot := firefoxRoot
+	firefoxRoot = func() (string, error) { return tmpDir, nil }
+	t.Cleanup(func() { firefoxRoot = origRoot })
+
+	paths, err := FindCookieDBPaths()
+	require.NoError(t, err)
+	require.Len(t, paths, 3, "stat failures must not be dropped")
+
+	// Newest valid stat first, oldest valid stat second, broken last.
+	assert.Contains(t, paths[0], "newest")
+	assert.Contains(t, paths[1], "oldest")
+	assert.Contains(t, paths[2], "broken")
+}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -32,7 +32,7 @@ func (e *MarketSurgeError) Unwrap() error {
 }
 
 // As implements custom error type matching for MarketSurgeError.
-func (e *MarketSurgeError) As(target interface{}) bool {
+func (e *MarketSurgeError) As(target any) bool {
 	if _, ok := target.(**MarketSurgeError); ok {
 		return true
 	}
@@ -51,7 +51,7 @@ type AuthenticationError struct {
 }
 
 // As implements custom error type matching for AuthenticationError.
-func (e *AuthenticationError) As(target interface{}) bool {
+func (e *AuthenticationError) As(target any) bool {
 	if _, ok := target.(**AuthenticationError); ok {
 		return true
 	}
@@ -75,7 +75,7 @@ type CookieExtractionError struct {
 }
 
 // As implements custom error type matching for CookieExtractionError.
-func (e *CookieExtractionError) As(target interface{}) bool {
+func (e *CookieExtractionError) As(target any) bool {
 	if _, ok := target.(**CookieExtractionError); ok {
 		return true
 	}
@@ -102,7 +102,7 @@ type TokenExpiredError struct {
 }
 
 // As implements custom error type matching for TokenExpiredError.
-func (e *TokenExpiredError) As(target interface{}) bool {
+func (e *TokenExpiredError) As(target any) bool {
 	if _, ok := target.(**TokenExpiredError); ok {
 		return true
 	}
@@ -127,7 +127,7 @@ type APIError struct {
 }
 
 // As implements custom error type matching for APIError.
-func (e *APIError) As(target interface{}) bool {
+func (e *APIError) As(target any) bool {
 	if _, ok := target.(**APIError); ok {
 		return true
 	}
@@ -151,7 +151,7 @@ type SymbolNotFoundError struct {
 }
 
 // As implements custom error type matching for SymbolNotFoundError.
-func (e *SymbolNotFoundError) As(target interface{}) bool {
+func (e *SymbolNotFoundError) As(target any) bool {
 	if _, ok := target.(**SymbolNotFoundError); ok {
 		return true
 	}
@@ -178,7 +178,7 @@ type HTTPError struct {
 }
 
 // As implements custom error type matching for HTTPError.
-func (e *HTTPError) As(target interface{}) bool {
+func (e *HTTPError) As(target any) bool {
 	if _, ok := target.(**HTTPError); ok {
 		return true
 	}
@@ -200,7 +200,7 @@ type ValidationError struct {
 }
 
 // As implements custom error type matching for ValidationError.
-func (e *ValidationError) As(target interface{}) bool {
+func (e *ValidationError) As(target any) bool {
 	if _, ok := target.(**ValidationError); ok {
 		return true
 	}

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -36,7 +36,7 @@ func TestStockDataMarshalUnmarshal(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify JSON contains expected fields
-	var jsonMap map[string]interface{}
+	var jsonMap map[string]any
 	err = json.Unmarshal(data, &jsonMap)
 	require.NoError(t, err)
 
@@ -65,7 +65,7 @@ func TestNilPointerFieldsOmitted(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify nil fields are omitted
-	var jsonMap map[string]interface{}
+	var jsonMap map[string]any
 	err = json.Unmarshal(data, &jsonMap)
 	require.NoError(t, err)
 
@@ -89,9 +89,9 @@ func TestCatalogKindConstants(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(string(tt.kind), func(t *testing.T) {
-	t.Parallel()
-	assert.Equal(t, tt.expected, string(tt.kind))
-})
+			t.Parallel()
+			assert.Equal(t, tt.expected, string(tt.kind))
+		})
 	}
 }
 
@@ -267,9 +267,9 @@ func TestChartMarkupMarshalUnmarshal(t *testing.T) {
 func TestPricingWithComplexFields(t *testing.T) {
 	t.Parallel()
 	pricing := Pricing{
-		BlueDotDailyDates: []string{"2024-01-01", "2024-01-02"},
-		BlueDotWeeklyDates: []string{},
-		AntDates:          []string{},
+		BlueDotDailyDates:         []string{"2024-01-01", "2024-01-02"},
+		BlueDotWeeklyDates:        []string{},
+		AntDates:                  []string{},
 		HistoricalPriceStatistics: []HistoricalPriceStatistic{},
 		VolumeMovingAverages:      []VolumeMovingAverage{},
 	}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -42,7 +42,7 @@ func WriteSuccess(w io.Writer, data any, metadata map[string]any) error {
 }
 
 // WriteError writes an error response to the writer.
-// It maps the error type to an appropriate error code string using errors.As().
+// It maps the error type to an appropriate error code string using errors.AsType().
 // The response is formatted as a JSON envelope with error details.
 func WriteError(w io.Writer, err error) error {
 	code := errorCode(err)
@@ -50,13 +50,11 @@ func WriteError(w io.Writer, err error) error {
 
 	// Extract details from specific error types
 	var details string
-	var symbolNotFound *mserr.SymbolNotFoundError
-	if errors.As(err, &symbolNotFound) {
+	if symbolNotFound, ok := errors.AsType[*mserr.SymbolNotFoundError](err); ok {
 		details = "symbol: " + symbolNotFound.Symbol
 	}
 
-	var httpErr *mserr.HTTPError
-	if errors.As(err, &httpErr) {
+	if httpErr, ok := errors.AsType[*mserr.HTTPError](err); ok {
 		details = fmt.Sprintf("status: %d", httpErr.StatusCode)
 	}
 


### PR DESCRIPTION
## Summary
- Target Go 1.26 and apply focused modernization: `go fix`, `errors.AsType`, `sync.WaitGroup.Go`, `t.Context()`, `slices.SortFunc`, and `min`/`max`.
- Enable the `modernize` linter and update Go requirement docs.
- Leave generated `skills/*.md`, dependencies, GitHub workflows, and GoReleaser config unchanged.

## Verification
- `go vet ./...`
- `go mod verify`
- `go build ./...`
- `go build -o /dev/null ./cmd/marketsurge-agent/`
- `make test`
- `make lint`
- Final review wave: F1/F2/F3/F4 approved

CodeRabbit local review skipped by request.