### PR TITLE
feat(stock): add token-efficient analyze modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ marketsurge-agent stock get AAPL
 # Analyze multiple symbols concurrently
 marketsurge-agent stock analyze AAPL MSFT NVDA GOOG
 
+# Analyze a comma-separated batch and remove formatted duplicate fields
+marketsurge-agent stock analyze --tickers AAPL,MSFT,NVDA --compact
+
+# Flatten each analysis result for lower-token agent parsing
+marketsurge-agent stock analyze AAPL --flat
+
 # Fundamental data
 marketsurge-agent fundamental get TSLA
 
@@ -89,7 +95,7 @@ Errors follow the same pattern:
 | Command | Description |
 |---|---|
 | `stock get <symbol>` | Stock data (ratings, pricing, financials) |
-| `stock analyze <symbols...>` | Concurrent multi-symbol analysis |
+| `stock analyze [symbols...]` | Concurrent single-symbol or multi-symbol analysis with optional compact, flat, and comma-separated batch modes |
 | `fundamental get <symbol>` | Fundamental analysis data |
 | `ownership get <symbol>` | Institutional ownership |
 | `rs-history get <symbol>` | Relative strength rating history |
@@ -100,6 +106,18 @@ Errors follow the same pattern:
 | `skills generate` | Generate agent skill documentation |
 
 ## Agent integration
+
+### Token-efficient stock analysis
+
+`stock analyze` supports output modes designed for AI agents and batch comparison workflows:
+
+```bash
+marketsurge-agent stock analyze --tickers AAPL,MSFT,NVDA --compact --flat
+```
+
+- `--tickers AAPL,MSFT,NVDA` analyzes comma-separated symbols in one command. Positional symbols still work and can be combined with `--tickers`.
+- `--compact` removes duplicate formatted string fields such as `market_cap_formatted`, while keeping raw numeric values.
+- `--flat` flattens each analysis result inside the standard JSON envelope, for example `stock.pricing.market_cap` becomes `pricing_market_cap`.
 
 The `skills generate` command writes Markdown skill files to `skills/` that describe each command's inputs, outputs, and usage. These files are designed for consumption by AI agent frameworks that support tool/skill discovery.
 

--- a/internal/commands/skills_generate_test.go
+++ b/internal/commands/skills_generate_test.go
@@ -23,8 +23,8 @@ type skillsGenerateEnvelope struct {
 func TestSkillsGenerateCommand(t *testing.T) {
 	t.Parallel()
 	t.Run("generates skill files to default directory", func(t *testing.T) {
-	t.Parallel()
-	tmpDir := t.TempDir()
+		t.Parallel()
+		tmpDir := t.TempDir()
 		outputDir := filepath.Join(tmpDir, "skills")
 
 		var buf bytes.Buffer
@@ -75,11 +75,11 @@ func TestSkillsGenerateCommand(t *testing.T) {
 				t.Errorf("Skill file was not created: %s", fpath)
 			}
 		}
-})
+	})
 
 	t.Run("generates files with expected content", func(t *testing.T) {
-	t.Parallel()
-	tmpDir := t.TempDir()
+		t.Parallel()
+		tmpDir := t.TempDir()
 		outputDir := filepath.Join(tmpDir, "skills")
 
 		var buf bytes.Buffer
@@ -133,6 +133,17 @@ func TestSkillsGenerateCommand(t *testing.T) {
 		if !bytes.Contains(content, []byte("marketsurge-agent stock get AAPL")) {
 			t.Error("Example invocation not found in stock.md")
 		}
+		if !bytes.Contains(content, []byte("marketsurge-agent stock analyze --tickers AAPL,NVDA,TSLA --compact --flat")) {
+			t.Error("Token-efficient analyze example not found in stock.md")
+		}
+
+		// Verify token-efficient analyze parameters are generated from the template.
+		expectedParameters := []string{"tickers (optional)", "compact (optional)", "flat (optional)"}
+		for _, parameter := range expectedParameters {
+			if !bytes.Contains(content, []byte(parameter)) {
+				t.Errorf("Expected analyze parameter %q not found in stock.md", parameter)
+			}
+		}
 
 		// Verify expected output shape
 		if !bytes.Contains(content, []byte("\"symbol\": \"AAPL\"")) {
@@ -140,11 +151,11 @@ func TestSkillsGenerateCommand(t *testing.T) {
 		}
 
 		t.Logf("stock.md content length: %d bytes", len(contentStr))
-})
+	})
 
 	t.Run("uses custom output directory", func(t *testing.T) {
-	t.Parallel()
-	tmpDir := t.TempDir()
+		t.Parallel()
+		tmpDir := t.TempDir()
 		customDir := filepath.Join(tmpDir, "custom", "skills")
 
 		var buf bytes.Buffer
@@ -174,11 +185,11 @@ func TestSkillsGenerateCommand(t *testing.T) {
 		if _, err := os.Stat(stockFile); os.IsNotExist(err) {
 			t.Errorf("Skill file was not created in custom directory: %s", stockFile)
 		}
-})
+	})
 
 	t.Run("generates all command groups", func(t *testing.T) {
-	t.Parallel()
-	tmpDir := t.TempDir()
+		t.Parallel()
+		tmpDir := t.TempDir()
 		outputDir := filepath.Join(tmpDir, "skills")
 
 		var buf bytes.Buffer
@@ -216,11 +227,11 @@ func TestSkillsGenerateCommand(t *testing.T) {
 				t.Errorf("Skill file for group '%s' is empty", group)
 			}
 		}
-})
+	})
 
 	t.Run("outputs success message", func(t *testing.T) {
-	t.Parallel()
-	tmpDir := t.TempDir()
+		t.Parallel()
+		tmpDir := t.TempDir()
 		outputDir := filepath.Join(tmpDir, "skills")
 
 		var buf bytes.Buffer
@@ -241,7 +252,7 @@ func TestSkillsGenerateCommand(t *testing.T) {
 		assert.Equal(t, outputDir, envelope.Data.OutputDir)
 		assert.Len(t, envelope.Data.GeneratedFiles, 6)
 		assert.NotEmpty(t, envelope.Metadata["timestamp"])
-})
+	})
 }
 
 func decodeSkillsGenerateEnvelope(t *testing.T, data []byte) skillsGenerateEnvelope {

--- a/internal/commands/skills_templates.go
+++ b/internal/commands/skills_templates.go
@@ -21,12 +21,12 @@ Stock data now includes valuation ratios, risk metrics, short interest data, and
 - symbol (required): Stock ticker symbol, e.g. AAPL, NVDA, TSLA
 
 **Example:**
-` + "`" + `bash
+` + "```" + `bash
 marketsurge-agent stock get AAPL
-` + "`" + `
+` + "```" + `
 
 **Expected Output Shape:**
-` + "`" + `json
+` + "```" + `json
 {
   "symbol": "AAPL",
   "ratings": {
@@ -39,7 +39,7 @@ marketsurge-agent stock get AAPL
     "eps": 5.28
   }
 }
-` + "`" + `
+` + "```" + `
 
 ### analyze_stock
 Analyze a stock with comprehensive data from MarketSurge.
@@ -51,14 +51,18 @@ Stock data now includes valuation ratios, risk metrics, short interest data, and
 
 **Parameters:**
 - symbols (required): One or more stock ticker symbols separated by spaces, e.g. AAPL NVDA TSLA. Each symbol is fetched concurrently.
+- tickers (optional): Comma-separated stock ticker symbols, e.g. AAPL,NVDA,TSLA. Useful for larger agent batch comparisons.
+- compact (optional): Remove formatted string fields such as market_cap_formatted. Raw numeric values remain when the API provides them.
+- flat (optional): Flatten each analysis result inside the standard JSON envelope for lower-token parsing.
 
 **Example:**
-` + "`" + `bash
+` + "```" + `bash
 marketsurge-agent stock analyze AAPL NVDA
-` + "`" + `
+marketsurge-agent stock analyze --tickers AAPL,NVDA,TSLA --compact --flat
+` + "```" + `
 
 **Expected Output Shape:**
-` + "`" + `json
+` + "```" + `json
 {
   "symbol": "AAPL",
   "stock": { ... },
@@ -66,7 +70,9 @@ marketsurge-agent stock analyze AAPL NVDA
   "ownership": { ... },
   "errors": []
 }
-` + "`" + `
+` + "```" + `
+
+With ` + "`" + `--flat` + "`" + `, nested stock fields are emitted as single-level keys, for example ` + "`" + `stock.pricing.market_cap` + "`" + ` becomes ` + "`" + `pricing_market_cap` + "`" + `.
 
 ## Workflow Guidance
 

--- a/internal/commands/stock_analyze.go
+++ b/internal/commands/stock_analyze.go
@@ -2,8 +2,10 @@ package commands
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 	"time"
 
@@ -30,14 +32,19 @@ func StockAnalyzeCommand(c *client.Client, w io.Writer) *cli.Command {
 	return &cli.Command{
 		Name:      "analyze",
 		Usage:     "Analyze one or more stock symbols",
-		ArgsUsage: "<symbol> [symbol...]",
+		ArgsUsage: "[symbol...]",
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "tickers", Usage: "Comma-separated ticker symbols to analyze"},
+			&cli.BoolFlag{Name: "compact", Usage: "Remove formatted string fields from analysis data"},
+			&cli.BoolFlag{Name: "flat", Usage: "Flatten each analysis result for token-efficient agent parsing"},
+		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			if cmd.Args().Len() == 0 {
-				verr := mserrors.NewValidationError("at least one symbol argument required", nil)
+			symbols := analyzeSymbols(cmd)
+			if len(symbols) == 0 {
+				verr := mserrors.NewValidationError("at least one symbol required", nil)
 				return verr
 			}
 
-			symbols := cmd.Args().Slice()
 			results := make([]AnalysisResult, len(symbols))
 			var allErrors []string
 			var mu sync.Mutex
@@ -74,21 +81,39 @@ func StockAnalyzeCommand(c *client.Client, w io.Writer) *cli.Command {
 				return err
 			}
 
+			data, err := transformAnalysisOutput(results, cmd.Bool("compact"), cmd.Bool("flat"))
+			if err != nil {
+				return fmt.Errorf("transform analysis output: %w", err)
+			}
+
 			// Single symbol: unwrap from array.
 			if len(symbols) == 1 {
 				if len(allErrors) > 0 {
-					return output.WritePartial(w, results[0], allErrors, meta)
+					return output.WritePartial(w, data, allErrors, meta)
 				}
-				return output.WriteSuccess(w, results[0], meta)
+				return output.WriteSuccess(w, data, meta)
 			}
 
 			// Multi-symbol: output as array.
 			if len(allErrors) > 0 {
-				return output.WritePartial(w, results, allErrors, meta)
+				return output.WritePartial(w, data, allErrors, meta)
 			}
-			return output.WriteSuccess(w, results, meta)
+			return output.WriteSuccess(w, data, meta)
 		},
 	}
+}
+
+// analyzeSymbols combines positional symbols with the --tickers comma-separated
+// input used for larger batch analysis requests.
+func analyzeSymbols(cmd *cli.Command) []string {
+	symbols := append([]string{}, cmd.Args().Slice()...)
+	for symbol := range strings.SplitSeq(cmd.String("tickers"), ",") {
+		trimmed := strings.TrimSpace(symbol)
+		if trimmed != "" {
+			symbols = append(symbols, trimmed)
+		}
+	}
+	return symbols
 }
 
 // analyzeSymbol fetches stock, fundamental, and ownership data concurrently
@@ -147,4 +172,112 @@ func analyzeMetadata(symbols []string) map[string]any {
 		meta["symbols"] = symbols
 	}
 	return meta
+}
+
+// transformAnalysisOutput applies optional token-efficiency transforms while
+// preserving the existing single-symbol object vs. multi-symbol array contract.
+func transformAnalysisOutput(results []AnalysisResult, compact, flat bool) (any, error) {
+	transformed := make([]any, 0, len(results))
+	for _, result := range results {
+		data, err := analysisResultMap(result)
+		if err != nil {
+			return nil, err
+		}
+		if compact {
+			data = removeFormattedFields(data).(map[string]any)
+		}
+		if flat {
+			data = flattenAnalysisMap(data)
+		}
+		transformed = append(transformed, data)
+	}
+
+	if len(transformed) == 1 {
+		return transformed[0], nil
+	}
+	return transformed, nil
+}
+
+func analysisResultMap(result AnalysisResult) (map[string]any, error) {
+	data, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("marshal analysis result: %w", err)
+	}
+
+	var resultMap map[string]any
+	if err := json.Unmarshal(data, &resultMap); err != nil {
+		return nil, fmt.Errorf("unmarshal analysis result: %w", err)
+	}
+	return resultMap, nil
+}
+
+func removeFormattedFields(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		cleaned := make(map[string]any, len(typed))
+		for key, nested := range typed {
+			if isFormattedField(key) {
+				continue
+			}
+			cleaned[key] = removeFormattedFields(nested)
+		}
+		return cleaned
+	case []any:
+		cleaned := make([]any, 0, len(typed))
+		for _, nested := range typed {
+			cleaned = append(cleaned, removeFormattedFields(nested))
+		}
+		return cleaned
+	default:
+		return value
+	}
+}
+
+func isFormattedField(key string) bool {
+	return strings.HasSuffix(key, "_formatted") || strings.HasPrefix(key, "formatted_")
+}
+
+func flattenAnalysisMap(data map[string]any) map[string]any {
+	flat := map[string]any{}
+	if symbol, ok := data["symbol"]; ok {
+		flat["symbol"] = symbol
+	}
+
+	for key, value := range data {
+		switch key {
+		case "symbol":
+			continue
+		case "stock":
+			flattenValue(flat, "", value)
+		default:
+			flattenValue(flat, key, value)
+		}
+	}
+	return flat
+}
+
+func flattenValue(flat map[string]any, prefix string, value any) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, nested := range typed {
+			flattenValue(flat, joinFlatKey(prefix, key), nested)
+		}
+	case []any:
+		if len(typed) > 0 {
+			flat[prefix] = typed
+		}
+	case nil:
+		return
+	default:
+		if prefix != "" {
+			flat[prefix] = typed
+		}
+	}
+}
+
+func joinFlatKey(prefix, key string) string {
+	if prefix == "" {
+		return key
+	}
+	return prefix + "_" + key
 }

--- a/internal/commands/stock_analyze_test.go
+++ b/internal/commands/stock_analyze_test.go
@@ -2,6 +2,10 @@ package commands
 
 import (
 	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	mserrors "github.com/major/marketsurge-agent/internal/errors"
@@ -27,21 +31,6 @@ func TestStockAnalyzeSuccess(t *testing.T) {
 	assert.Contains(t, data, "ownership")
 }
 
-func TestStockAnalyzePartialFailure(t *testing.T) {
-	// Server that always returns valid data. Since goroutines run concurrently,
-	// we can't predict request order. This test verifies the output format
-	// when all calls succeed (no partial failure in this case).
-	server := jsonServer(stockResponseFixture())
-	defer server.Close()
-	c := testClient(t, server)
-
-	var buf bytes.Buffer
-	cmd := StockAnalyzeCommand(c, &buf)
-	require.NoError(t, runTestCommand(t, cmd, "analyze", "AAPL"))
-
-	parseJSONEnvelope(t, &buf)
-}
-
 func TestStockAnalyzeMultiSymbol(t *testing.T) {
 	t.Parallel()
 	server := jsonServer(stockResponseFixture())
@@ -62,6 +51,112 @@ func TestStockAnalyzeMultiSymbol(t *testing.T) {
 	meta, _ := result["metadata"].(map[string]any)
 	symbols, _ := meta["symbols"].([]any)
 	assert.Len(t, symbols, 2)
+}
+
+func TestStockAnalyzePartialFailureWithCompactFlatOutput(t *testing.T) {
+	server := stockAnalyzePartialServer(t)
+	defer server.Close()
+	c := testClient(t, server)
+
+	var buf bytes.Buffer
+	cmd := StockAnalyzeCommand(c, &buf)
+	require.NoError(t, runTestCommand(t, cmd, "analyze", "--compact", "--flat", "AAPL", "MSFT"))
+
+	result := parseJSONEnvelope(t, &buf)
+	data, ok := result["data"].([]any)
+	require.True(t, ok, "partial multi-symbol data should remain an array")
+	assert.Len(t, data, 2)
+	assert.Contains(t, result, "errors")
+
+	first, ok := data[0].(map[string]any)
+	require.True(t, ok, "flattened successful item should be an object")
+	assert.Contains(t, first, "pricing_market_cap")
+	assert.NotContains(t, first, "pricing_market_cap_formatted")
+	assert.NotContains(t, first, "stock")
+
+	second, ok := data[1].(map[string]any)
+	require.True(t, ok, "flattened failed item should be an object")
+	assert.Equal(t, "MSFT", second["symbol"])
+	assert.NotContains(t, second, "stock")
+
+	errors, ok := result["errors"].([]any)
+	require.True(t, ok, "partial envelope should include top-level errors")
+	assert.NotEmpty(t, errors)
+}
+
+func TestStockAnalyzeTickersFlag(t *testing.T) {
+	t.Parallel()
+	server := jsonServer(stockResponseFixture())
+	defer server.Close()
+	c := testClient(t, server)
+
+	var buf bytes.Buffer
+	cmd := StockAnalyzeCommand(c, &buf)
+	require.NoError(t, runTestCommand(t, cmd, "analyze", "--tickers", "AAPL, MSFT"))
+
+	result := parseJSONEnvelope(t, &buf)
+	data, ok := result["data"].([]any)
+	require.True(t, ok, "--tickers should return multi-symbol data as an array")
+	assert.Len(t, data, 2)
+
+	meta, _ := result["metadata"].(map[string]any)
+	symbols, _ := meta["symbols"].([]any)
+	assert.Equal(t, []any{"AAPL", "MSFT"}, symbols)
+}
+
+func TestStockAnalyzeCompactOutput(t *testing.T) {
+	t.Parallel()
+	server := jsonServer(stockResponseFixture())
+	defer server.Close()
+	c := testClient(t, server)
+
+	var buf bytes.Buffer
+	cmd := StockAnalyzeCommand(c, &buf)
+	require.NoError(t, runTestCommand(t, cmd, "analyze", "--compact", "AAPL"))
+
+	result := parseJSONEnvelope(t, &buf)
+	data, _ := result["data"].(map[string]any)
+	stock, _ := data["stock"].(map[string]any)
+	pricing, _ := stock["pricing"].(map[string]any)
+	assert.Contains(t, pricing, "market_cap")
+	assert.NotContains(t, pricing, "market_cap_formatted")
+	assert.NotContains(t, pricing, "forward_price_to_earnings_ratio_formatted")
+}
+
+func TestStockAnalyzeFlatOutput(t *testing.T) {
+	t.Parallel()
+	server := jsonServer(stockResponseFixture())
+	defer server.Close()
+	c := testClient(t, server)
+
+	var buf bytes.Buffer
+	cmd := StockAnalyzeCommand(c, &buf)
+	require.NoError(t, runTestCommand(t, cmd, "analyze", "--flat", "AAPL"))
+
+	result := parseJSONEnvelope(t, &buf)
+	data, _ := result["data"].(map[string]any)
+	assert.Equal(t, "AAPL", data["symbol"])
+	assert.NotContains(t, data, "stock")
+	assert.Contains(t, data, "ratings_composite")
+	assert.Contains(t, data, "pricing_market_cap")
+	assert.Contains(t, data, "fundamentals_reported_earnings")
+}
+
+func TestStockAnalyzeCompactFlatOutput(t *testing.T) {
+	t.Parallel()
+	server := jsonServer(stockResponseFixture())
+	defer server.Close()
+	c := testClient(t, server)
+
+	var buf bytes.Buffer
+	cmd := StockAnalyzeCommand(c, &buf)
+	require.NoError(t, runTestCommand(t, cmd, "analyze", "--compact", "--flat", "AAPL"))
+
+	result := parseJSONEnvelope(t, &buf)
+	data, _ := result["data"].(map[string]any)
+	assert.Contains(t, data, "pricing_market_cap")
+	assert.NotContains(t, data, "pricing_market_cap_formatted")
+	assert.NotContains(t, data, "pricing_forward_price_to_earnings_ratio_formatted")
 }
 
 func TestStockAnalyzeMissingSymbol(t *testing.T) {
@@ -90,4 +185,27 @@ func TestStockAnalyzeTotalFailure(t *testing.T) {
 	err := runTestCommand(t, cmd, "analyze", "MISSING")
 	require.Error(t, err)
 	assert.Empty(t, buf.String())
+}
+
+func stockAnalyzePartialServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(string(body), "MSFT") {
+			_, err = w.Write([]byte(emptyMarketDataFixture()))
+		} else {
+			_, err = w.Write([]byte(stockResponseFixture()))
+		}
+		if err != nil {
+			t.Errorf("write response body: %v", err)
+		}
+	}))
 }

--- a/skills/stock.md
+++ b/skills/stock.md
@@ -17,12 +17,12 @@ Stock data now includes valuation ratios, risk metrics, short interest data, and
 - symbol (required): Stock ticker symbol, e.g. AAPL, NVDA, TSLA
 
 **Example:**
-`bash
+```bash
 marketsurge-agent stock get AAPL
-`
+```
 
 **Expected Output Shape:**
-`json
+```json
 {
   "symbol": "AAPL",
   "ratings": {
@@ -35,7 +35,7 @@ marketsurge-agent stock get AAPL
     "eps": 5.28
   }
 }
-`
+```
 
 ### analyze_stock
 Analyze a stock with comprehensive data from MarketSurge.
@@ -47,14 +47,18 @@ Stock data now includes valuation ratios, risk metrics, short interest data, and
 
 **Parameters:**
 - symbols (required): One or more stock ticker symbols separated by spaces, e.g. AAPL NVDA TSLA. Each symbol is fetched concurrently.
+- tickers (optional): Comma-separated stock ticker symbols, e.g. AAPL,NVDA,TSLA. Useful for larger agent batch comparisons.
+- compact (optional): Remove duplicate formatted string fields such as market_cap_formatted while keeping raw numeric values.
+- flat (optional): Flatten each analysis result inside the standard JSON envelope for lower-token parsing.
 
 **Example:**
-`bash
+```bash
 marketsurge-agent stock analyze AAPL NVDA
-`
+marketsurge-agent stock analyze --tickers AAPL,NVDA,TSLA --compact --flat
+```
 
 **Expected Output Shape:**
-`json
+```json
 {
   "symbol": "AAPL",
   "stock": { ... },
@@ -62,7 +66,9 @@ marketsurge-agent stock analyze AAPL NVDA
   "ownership": { ... },
   "errors": []
 }
-`
+```
+
+With `--flat`, nested stock fields are emitted as single-level keys, for example `stock.pricing.market_cap` becomes `pricing_market_cap`.
 
 ## Workflow Guidance
 


### PR DESCRIPTION
## Summary
- Add `stock analyze --tickers` for comma-separated batch analysis while preserving positional symbol support.
- Add `--compact` and `--flat` output transforms inside the existing JSON envelope for lower-token agent parsing.
- Update generated and checked-in stock skill docs plus tests for transformed and partial output behavior.

## Verification
- `go test ./internal/commands -run 'Test(StockAnalyze|SkillsGenerate)'`
- `go test ./...`
- `go test -race ./...`
- `golangci-lint run`
- `go build ./cmd/marketsurge-agent`

Refs #16
Refs #17
Refs #20