### PR TITLE
feat(stock): add technical signal output

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ marketsurge-agent stock analyze --tickers AAPL,MSFT,NVDA --compact --flat
 - `--compact` removes duplicate formatted string fields such as `market_cap_formatted`, while keeping raw numeric values.
 - `--flat` flattens each analysis result inside the standard JSON envelope, for example `stock.pricing.market_cap` becomes `pricing_market_cap`.
 
+`stock analyze` also includes MarketSurge technical context for chart-driven screening: `stock.base_pattern` summarizes the current base with pattern type, base stage, pivot price, base length, depth, and volume at pivot; `stock.signals` reports blue dot and ant signal flags when the API provides them.
+
 The `skills generate` command writes Markdown skill files to `skills/` that describe each command's inputs, outputs, and usage. These files are designed for consumption by AI agent frameworks that support tool/skill discovery.
 
 ```bash

--- a/internal/client/stock.go
+++ b/internal/client/stock.go
@@ -54,6 +54,7 @@ func (c *Client) GetStock(ctx context.Context, symbol string) (*models.StockData
 	ownership := getNestedMap(item, "ownership")
 	fundamentals := getNestedMap(item, "fundamentals")
 	corporateActions := getNestedMap(item, "corporateActions")
+	patternInfo := getNestedMap(item, "patternInfo")
 	symbology := getNestedMap(item, "symbology")
 	company := firstMap(getNestedSlice(symbology, "company"))
 	instrument := firstMap(getNestedSlice(symbology, "instrument"))
@@ -68,6 +69,40 @@ func (c *Client) GetStock(ctx context.Context, symbol string) (*models.StockData
 	epsGrowth := firstMap(getNestedSlice(epsConsensus, "growthRate"))
 	salesGrowth := firstMap(getNestedSlice(salesConsensus, "growthRate"))
 	atr21d := firstMap(getNestedSlice(pricingEOD, "averageTrueRangePercent"))
+	patterns := buildPatterns(getNestedSlice(patternInfo, "patterns"))
+	pricing := &models.Pricing{
+		MarketCap:                            floatPtr(pricingEOD["marketCapitalization"]),
+		MarketCapFormatted:                   formattedValue(pricingEOD["marketCapitalization"]),
+		AvgDollarVolume50D:                   floatPtr(pricingEOD["avgDollarVolume50Day"]),
+		AvgDollarVolume50DFormatted:          formattedValue(pricingEOD["avgDollarVolume50Day"]),
+		UpDownVolumeRatio:                    floatPtr(pricingEOD["upDownVolumeRatio"]),
+		UpDownVolumeRatioFormatted:           formattedValue(pricingEOD["upDownVolumeRatio"]),
+		ATRPercent21D:                        floatPtr(atr21d),
+		ATRPercent21DFormatted:               formattedValue(atr21d),
+		BlueDotDailyDates:                    buildStringValues(getNestedSlice(pricingEOD, "blueDotDailyEvents")),
+		BlueDotWeeklyDates:                   buildStringValues(getNestedSlice(pricingEOD, "blueDotWeeklyEvents")),
+		AntDates:                             buildStringValues(getNestedSlice(pricingEOD, "antEvents")),
+		DividendYield:                        floatPtr(pricingIntraday["yield"]),
+		DividendYieldFormatted:               formattedValue(pricingIntraday["yield"]),
+		PriceToCashFlowRatio:                 floatPtr(pricingIntraday["priceToCashFlowRatio"]),
+		PriceToCashFlowRatioFormatted:        formattedValue(pricingIntraday["priceToCashFlowRatio"]),
+		ForwardPriceToEarningsRatio:          floatPtr(pricingIntraday["forwardPriceToEarningsRatio"]),
+		ForwardPriceToEarningsRatioFormatted: formattedValue(pricingIntraday["forwardPriceToEarningsRatio"]),
+		PriceToSalesRatio:                    floatPtr(pricingIntraday["priceToSalesRatio"]),
+		PriceToSalesRatioFormatted:           formattedValue(pricingIntraday["priceToSalesRatio"]),
+		PriceToEarningsRatio:                 floatPtr(pricingIntraday["priceToEarningsRatio"]),
+		PriceToEarningsRatioFormatted:        formattedValue(pricingIntraday["priceToEarningsRatio"]),
+		PEVsSP500:                            floatPtr(pricingIntraday["priceToEarningsVsSP500"]),
+		PEVsSP500Formatted:                   formattedValue(pricingIntraday["priceToEarningsVsSP500"]),
+		Alpha:                                floatPtr(pricingEOD["alpha"]),
+		AlphaFormatted:                       formattedValue(pricingEOD["alpha"]),
+		Beta:                                 floatPtr(pricingEOD["beta"]),
+		BetaFormatted:                        formattedValue(pricingEOD["beta"]),
+		IsDailyBlueDotEvent:                  boolPtr(pricingIntraday["isDailyBlueDotEvent"]),
+		IsWeeklyBlueDotEvent:                 boolPtr(pricingIntraday["isWeeklyBlueDotEvent"]),
+		PricingStartDate:                     stringPtr(pricingEOD["pricingStartDate"]),
+		PricingEndDate:                       stringPtr(pricingEOD["pricingEndDate"]),
+	}
 
 	return &models.StockData{
 		Symbol: symbol,
@@ -98,34 +133,9 @@ func (c *Client) GetStock(ctx context.Context, symbol string) (*models.StockData
 			StateProvince:         stringPtr(company["stateProvince"]),
 			InstrumentSubType:     stringPtr(instrument["subType"]),
 		},
-		Pricing: &models.Pricing{
-			MarketCap:                            floatPtr(pricingEOD["marketCapitalization"]),
-			MarketCapFormatted:                   formattedValue(pricingEOD["marketCapitalization"]),
-			AvgDollarVolume50D:                   floatPtr(pricingEOD["avgDollarVolume50Day"]),
-			AvgDollarVolume50DFormatted:          formattedValue(pricingEOD["avgDollarVolume50Day"]),
-			UpDownVolumeRatio:                    floatPtr(pricingEOD["upDownVolumeRatio"]),
-			UpDownVolumeRatioFormatted:           formattedValue(pricingEOD["upDownVolumeRatio"]),
-			ATRPercent21D:                        floatPtr(atr21d),
-			ATRPercent21DFormatted:               formattedValue(atr21d),
-			DividendYield:                        floatPtr(pricingIntraday["yield"]),
-			DividendYieldFormatted:               formattedValue(pricingIntraday["yield"]),
-			PriceToCashFlowRatio:                 floatPtr(pricingIntraday["priceToCashFlowRatio"]),
-			PriceToCashFlowRatioFormatted:        formattedValue(pricingIntraday["priceToCashFlowRatio"]),
-			ForwardPriceToEarningsRatio:          floatPtr(pricingIntraday["forwardPriceToEarningsRatio"]),
-			ForwardPriceToEarningsRatioFormatted: formattedValue(pricingIntraday["forwardPriceToEarningsRatio"]),
-			PriceToSalesRatio:                    floatPtr(pricingIntraday["priceToSalesRatio"]),
-			PriceToSalesRatioFormatted:           formattedValue(pricingIntraday["priceToSalesRatio"]),
-			PriceToEarningsRatio:                 floatPtr(pricingIntraday["priceToEarningsRatio"]),
-			PriceToEarningsRatioFormatted:        formattedValue(pricingIntraday["priceToEarningsRatio"]),
-			PEVsSP500:                            floatPtr(pricingIntraday["priceToEarningsVsSP500"]),
-			PEVsSP500Formatted:                   formattedValue(pricingIntraday["priceToEarningsVsSP500"]),
-			Alpha:                                floatPtr(pricingEOD["alpha"]),
-			AlphaFormatted:                       formattedValue(pricingEOD["alpha"]),
-			Beta:                                 floatPtr(pricingEOD["beta"]),
-			BetaFormatted:                        formattedValue(pricingEOD["beta"]),
-			PricingStartDate:                     stringPtr(pricingEOD["pricingStartDate"]),
-			PricingEndDate:                       stringPtr(pricingEOD["pricingEndDate"]),
-		},
+		Pricing:     pricing,
+		BasePattern: buildBasePattern(patterns),
+		Signals:     buildSignals(pricing),
 		Financials: &models.Financials{
 			EPSDueDate:                stringPtr(financials["epsDueDate"]),
 			EPSDueDateStatus:          stringPtr(financials["epsDueDateStatus"]),
@@ -166,9 +176,125 @@ func (c *Client) GetStock(ctx context.Context, symbol string) (*models.StockData
 			SalesEstimates:   buildQuarterlyEstimates(getNestedSlice(financials, "estimates", "salesEstimates")),
 			ProfitMargins:    buildQuarterlyProfitMargins(getNestedSlice(financials, "profitMarginValues")),
 		},
-		Patterns:   []models.Pattern{},
-		TightAreas: []models.TightArea{},
+		Patterns:   patterns,
+		TightAreas: buildTightAreas(getNestedSlice(patternInfo, "tightAreas")),
 	}, nil
+}
+
+func buildStringValues(items []any) []string {
+	values := make([]string, 0, len(items))
+	for _, item := range items {
+		value := stringPtr(item)
+		if value == nil {
+			continue
+		}
+		values = append(values, *value)
+	}
+	return values
+}
+
+func buildSignals(pricing *models.Pricing) *models.Signals {
+	blueDot := hasBlueDot(pricing)
+	antSignal := len(pricing.AntDates) > 0
+
+	return &models.Signals{
+		BlueDot:     &blueDot,
+		BlueDotDate: firstString(pricing.BlueDotDailyDates, pricing.BlueDotWeeklyDates),
+		AntSignal:   &antSignal,
+	}
+}
+
+func hasBlueDot(pricing *models.Pricing) bool {
+	if pricing.IsDailyBlueDotEvent != nil && *pricing.IsDailyBlueDotEvent {
+		return true
+	}
+	if pricing.IsWeeklyBlueDotEvent != nil && *pricing.IsWeeklyBlueDotEvent {
+		return true
+	}
+	return len(pricing.BlueDotDailyDates) > 0 || len(pricing.BlueDotWeeklyDates) > 0
+}
+
+func firstString(slices ...[]string) *string {
+	for _, values := range slices {
+		if len(values) == 0 {
+			continue
+		}
+		return &values[0]
+	}
+	return nil
+}
+
+func buildBasePattern(patterns []models.Pattern) *models.BasePattern {
+	pattern := latestPattern(patterns)
+	if pattern == nil {
+		return nil
+	}
+
+	return &models.BasePattern{
+		PatternType:      pattern.PatternType,
+		BaseStage:        pattern.BaseStage,
+		PivotPrice:       pattern.PivotPrice,
+		BaseLengthWeeks:  pattern.BaseLength,
+		BaseDepthPercent: pattern.BaseDepth,
+		VolumeAtPivotPct: pattern.AvgVolumeRatePctOnPivot,
+	}
+}
+
+func latestPattern(patterns []models.Pattern) *models.Pattern {
+	var latest *models.Pattern
+	for i := range patterns {
+		pattern := &patterns[i]
+		if latest == nil || dateValue(pattern.BaseEndDate) > dateValue(latest.BaseEndDate) {
+			latest = pattern
+		}
+	}
+	return latest
+}
+
+func dateValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func buildPatterns(items []any) []models.Pattern {
+	return buildSlice(items, func(item map[string]any) models.Pattern {
+		return models.Pattern{
+			ID:                               stringPtr(item["id"]),
+			PatternType:                      stringPtr(item["patternType"]),
+			Periodicity:                      stringPtr(item["periodicity"]),
+			BaseStage:                        stringPtr(item["baseStage"]),
+			BaseNumber:                       intPtr(item["baseNumber"]),
+			BaseStatus:                       stringPtr(item["baseStatus"]),
+			BaseLength:                       intPtr(item["baseLength"]),
+			BaseDepth:                        floatPtr(item["baseDepth"]),
+			BaseDepthFormatted:               formattedValue(item["baseDepth"]),
+			BaseStartDate:                    stringPtr(item["baseStartDate"]),
+			BaseEndDate:                      stringPtr(item["baseEndDate"]),
+			BaseBottomDate:                   stringPtr(item["baseBottomDate"]),
+			LeftSideHighDate:                 stringPtr(item["leftSideHighDate"]),
+			PivotPrice:                       floatPtr(item["pivotPrice"]),
+			PivotPriceFormatted:              formattedValue(item["pivotPrice"]),
+			PivotDate:                        stringPtr(item["pivotDate"]),
+			PivotPriceDate:                   stringPtr(item["pivotPriceDate"]),
+			AvgVolumeRatePctOnPivot:          floatPtr(item["avgVolumeRatePctOnPivot"]),
+			AvgVolumeRatePctOnPivotFormatted: formattedValue(item["avgVolumeRatePctOnPivot"]),
+			PricePctChangeOnPivot:            floatPtr(item["pricePctChangeOnPivot"]),
+			PricePctChangeOnPivotFormatted:   formattedValue(item["pricePctChangeOnPivot"]),
+		}
+	})
+}
+
+func buildTightAreas(items []any) []models.TightArea {
+	return buildSlice(items, func(item map[string]any) models.TightArea {
+		return models.TightArea{
+			PatternID: intPtr(item["patternID"]),
+			StartDate: stringPtr(item["startDate"]),
+			EndDate:   stringPtr(item["endDate"]),
+			Length:    intPtr(item["length"]),
+		}
+	})
 }
 
 func buildQuarterlyReported(items []any) []models.QuarterlyReportedPeriod {

--- a/internal/commands/helpers_test.go
+++ b/internal/commands/helpers_test.go
@@ -70,6 +70,9 @@ func stockResponseFixture() string {
 						"avgDollarVolume50Day": {"value": 5000000, "formattedValue": "$5M"},
 						"upDownVolumeRatio": {"value": 1.2, "formattedValue": "1.2"},
 						"averageTrueRangePercent": [{"value": 2.3, "formattedValue": "2.3%"}],
+						"antEvents": [{"value": "2024-12-18"}],
+						"blueDotDailyEvents": [{"value": "2024-12-20", "formattedValue": "Dec 20, 2024"}],
+						"blueDotWeeklyEvents": [{"value": "2024-12-16", "formattedValue": "Dec 16, 2024"}],
 						"alpha": {"value": 1.1, "formattedValue": "1.1"},
 						"beta": {"value": 0.9, "formattedValue": "0.9"},
 						"pricingStartDate": {"value": "2024-01-01"},
@@ -83,8 +86,37 @@ func stockResponseFixture() string {
 						"priceToEarningsRatio": {"value": 32, "formattedValue": "32"},
 						"priceToEarningsVsSP500": {"value": 1.5, "formattedValue": "1.5"},
 						"cashFlowPerShareLastYear": {"value": 7, "formattedValue": "7"},
+						"isDailyBlueDotEvent": true,
+						"isWeeklyBlueDotEvent": false,
 						"rsLineNewHigh": true
 					}
+				},
+				"patternInfo": {
+					"patterns": [{
+						"id": "pattern-1",
+						"patternType": "Cup With Handle",
+						"periodicity": "DAILY",
+						"baseStage": "STAGE_2",
+						"baseNumber": 2,
+						"baseStatus": "ACTIVE",
+						"baseLength": 7,
+						"baseDepth": {"value": 18.5, "formattedValue": "18.5%"},
+						"baseStartDate": {"value": "2024-10-01"},
+						"baseEndDate": {"value": "2024-12-15"},
+						"baseBottomDate": {"value": "2024-11-04"},
+						"leftSideHighDate": {"value": "2024-10-15"},
+						"pivotPrice": {"value": 199.99, "formattedValue": "$199.99"},
+						"pivotDate": {"value": "2024-12-16"},
+						"pivotPriceDate": {"value": "2024-12-16"},
+						"avgVolumeRatePctOnPivot": {"value": 42.3, "formattedValue": "42.3%"},
+						"pricePctChangeOnPivot": {"value": 3.1, "formattedValue": "3.1%"}
+					}],
+					"tightAreas": [{
+						"patternID": 123,
+						"startDate": {"value": "2024-12-01"},
+						"endDate": {"value": "2024-12-05"},
+						"length": 5
+					}]
 				},
 				"financials": {
 					"epsDueDate": {"value": "2025-01-30"},

--- a/internal/commands/skills_generate_test.go
+++ b/internal/commands/skills_generate_test.go
@@ -145,6 +145,14 @@ func TestSkillsGenerateCommand(t *testing.T) {
 			}
 		}
 
+		// Verify technical signal guidance is generated from the template.
+		expectedTechnicalFields := []string{"stock.base_pattern", "stock.signals", "blue dot", "ant signal"}
+		for _, field := range expectedTechnicalFields {
+			if !bytes.Contains(content, []byte(field)) {
+				t.Errorf("Expected technical signal guidance %q not found in stock.md", field)
+			}
+		}
+
 		// Verify expected output shape
 		if !bytes.Contains(content, []byte("\"symbol\": \"AAPL\"")) {
 			t.Error("Expected output shape not found in stock.md")

--- a/internal/commands/skills_templates.go
+++ b/internal/commands/skills_templates.go
@@ -15,7 +15,7 @@ Fetch stock data including ratings, pricing, financials, patterns, and company i
 Use this for targeted stock data without fundamentals or ownership.
 For comprehensive analysis, use analyze_stock instead.
 
-Stock data now includes valuation ratios, risk metrics, short interest data, and blue dot event flags.
+Stock data now includes valuation ratios, risk metrics, short interest data, base pattern summaries, and blue dot/ant signal flags.
 
 **Parameters:**
 - symbol (required): Stock ticker symbol, e.g. AAPL, NVDA, TSLA
@@ -47,7 +47,7 @@ Analyze a stock with comprehensive data from MarketSurge.
 Fetches stock ratings, fundamentals, and ownership data concurrently.
 Partial failures in fundamentals or ownership are returned in the errors list rather than failing the entire request.
 
-Stock data now includes valuation ratios, risk metrics, short interest data, and blue dot event flags.
+Stock data now includes valuation ratios, risk metrics, short interest data, base pattern summaries, and blue dot/ant signal flags.
 
 **Parameters:**
 - symbols (required): One or more stock ticker symbols separated by spaces, e.g. AAPL NVDA TSLA. Each symbol is fetched concurrently.
@@ -73,6 +73,8 @@ marketsurge-agent stock analyze --tickers AAPL,NVDA,TSLA --compact --flat
 ` + "```" + `
 
 With ` + "`" + `--flat` + "`" + `, nested stock fields are emitted as single-level keys, for example ` + "`" + `stock.pricing.market_cap` + "`" + ` becomes ` + "`" + `pricing_market_cap` + "`" + `.
+
+Technical analysis fields include ` + "`" + `stock.base_pattern` + "`" + ` for pattern type, base stage, pivot price, base length, depth, and volume at pivot, plus ` + "`" + `stock.signals` + "`" + ` for blue dot and ant signal flags.
 
 ## Workflow Guidance
 

--- a/internal/commands/stock_analyze_test.go
+++ b/internal/commands/stock_analyze_test.go
@@ -31,6 +31,48 @@ func TestStockAnalyzeSuccess(t *testing.T) {
 	assert.Contains(t, data, "ownership")
 }
 
+func TestStockAnalyzeTechnicalSignals(t *testing.T) {
+	t.Parallel()
+	server := jsonServer(stockResponseFixture())
+	defer server.Close()
+	c := testClient(t, server)
+
+	var buf bytes.Buffer
+	cmd := StockAnalyzeCommand(c, &buf)
+	require.NoError(t, runTestCommand(t, cmd, "analyze", "AAPL"))
+
+	result := parseJSONEnvelope(t, &buf)
+	data, _ := result["data"].(map[string]any)
+	stock, _ := data["stock"].(map[string]any)
+
+	signals, ok := stock["signals"].(map[string]any)
+	require.True(t, ok, "stock should include technical signals")
+	assert.Equal(t, true, signals["blue_dot"])
+	assert.Equal(t, "2024-12-20", signals["blue_dot_date"])
+	assert.Equal(t, true, signals["ant_signal"])
+
+	basePattern, ok := stock["base_pattern"].(map[string]any)
+	require.True(t, ok, "stock should include base pattern summary")
+	assert.Equal(t, "Cup With Handle", basePattern["pattern_type"])
+	assert.Equal(t, "STAGE_2", basePattern["base_stage"])
+	assert.Equal(t, 199.99, basePattern["pivot_price"])
+	assert.Equal(t, float64(7), basePattern["base_length_weeks"])
+	assert.Equal(t, 18.5, basePattern["base_depth_percent"])
+	assert.Equal(t, 42.3, basePattern["volume_at_pivot_pct"])
+
+	pricing, _ := stock["pricing"].(map[string]any)
+	assert.Equal(t, []any{"2024-12-20"}, pricing["blue_dot_daily_dates"])
+	assert.Equal(t, []any{"2024-12-16"}, pricing["blue_dot_weekly_dates"])
+	assert.Equal(t, []any{"2024-12-18"}, pricing["ant_dates"])
+
+	patterns, ok := stock["patterns"].([]any)
+	require.True(t, ok, "stock should include parsed patterns")
+	assert.Len(t, patterns, 1)
+	tightAreas, ok := stock["tight_areas"].([]any)
+	require.True(t, ok, "stock should include parsed tight areas")
+	assert.Len(t, tightAreas, 1)
+}
+
 func TestStockAnalyzeMultiSymbol(t *testing.T) {
 	t.Parallel()
 	server := jsonServer(stockResponseFixture())
@@ -139,6 +181,8 @@ func TestStockAnalyzeFlatOutput(t *testing.T) {
 	assert.NotContains(t, data, "stock")
 	assert.Contains(t, data, "ratings_composite")
 	assert.Contains(t, data, "pricing_market_cap")
+	assert.Contains(t, data, "base_pattern_pivot_price")
+	assert.Contains(t, data, "signals_blue_dot")
 	assert.Contains(t, data, "fundamentals_reported_earnings")
 }
 

--- a/internal/models/stock.go
+++ b/internal/models/stock.go
@@ -11,57 +11,57 @@ type Ratings struct {
 
 // Company represents company profile information.
 type Company struct {
-	Name                   *string `json:"name,omitempty"`
-	Industry               *string `json:"industry,omitempty"`
-	Sector                 *string `json:"sector,omitempty"`
-	IndustryGroupRank      *int    `json:"industry_group_rank,omitempty"`
-	IndustryGroupRS        *int    `json:"industry_group_rs,omitempty"`
-	IndustryGroupRSLetter  *string `json:"industry_group_rs_letter,omitempty"`
-	Description            *string `json:"description,omitempty"`
-	Website                *string `json:"website,omitempty"`
-	Address                *string `json:"address,omitempty"`
-	Address2               *string `json:"address2,omitempty"`
-	Phone                  *string `json:"phone,omitempty"`
-	IPODate                *string `json:"ipo_date,omitempty"`
-	IPOPrice               *float64 `json:"ipo_price,omitempty"`
-	IPOPriceFormatted      *string `json:"ipo_price_formatted,omitempty"`
-	City                   *string `json:"city,omitempty"`
-	Country                *string `json:"country,omitempty"`
-	StateProvince          *string `json:"state_province,omitempty"`
-	InstrumentSubType      *string `json:"instrument_sub_type,omitempty"`
+	Name                  *string  `json:"name,omitempty"`
+	Industry              *string  `json:"industry,omitempty"`
+	Sector                *string  `json:"sector,omitempty"`
+	IndustryGroupRank     *int     `json:"industry_group_rank,omitempty"`
+	IndustryGroupRS       *int     `json:"industry_group_rs,omitempty"`
+	IndustryGroupRSLetter *string  `json:"industry_group_rs_letter,omitempty"`
+	Description           *string  `json:"description,omitempty"`
+	Website               *string  `json:"website,omitempty"`
+	Address               *string  `json:"address,omitempty"`
+	Address2              *string  `json:"address2,omitempty"`
+	Phone                 *string  `json:"phone,omitempty"`
+	IPODate               *string  `json:"ipo_date,omitempty"`
+	IPOPrice              *float64 `json:"ipo_price,omitempty"`
+	IPOPriceFormatted     *string  `json:"ipo_price_formatted,omitempty"`
+	City                  *string  `json:"city,omitempty"`
+	Country               *string  `json:"country,omitempty"`
+	StateProvince         *string  `json:"state_province,omitempty"`
+	InstrumentSubType     *string  `json:"instrument_sub_type,omitempty"`
 }
 
 // PricePercentChanges represents price percent changes vs various reference periods.
 type PricePercentChanges struct {
-	YTD           *float64 `json:"ytd,omitempty"`
-	MTD           *float64 `json:"mtd,omitempty"`
-	QTD           *float64 `json:"qtd,omitempty"`
-	WTD           *float64 `json:"wtd,omitempty"`
-	Vs1D          *float64 `json:"vs_1d,omitempty"`
-	Vs1M          *float64 `json:"vs_1m,omitempty"`
-	Vs3M          *float64 `json:"vs_3m,omitempty"`
-	VsYearHigh    *float64 `json:"vs_year_high,omitempty"`
-	VsYearLow     *float64 `json:"vs_year_low,omitempty"`
-	Vs5D          *float64 `json:"vs_5d,omitempty"`
-	VsSP50026W    *float64 `json:"vs_sp500_26w,omitempty"`
-	VsMA10D       *float64 `json:"vs_ma10d,omitempty"`
-	VsMA21D       *float64 `json:"vs_ma21d,omitempty"`
-	VsMA50D       *float64 `json:"vs_ma50d,omitempty"`
-	VsMA150D      *float64 `json:"vs_ma150d,omitempty"`
-	VsMA200D      *float64 `json:"vs_ma200d,omitempty"`
+	YTD        *float64 `json:"ytd,omitempty"`
+	MTD        *float64 `json:"mtd,omitempty"`
+	QTD        *float64 `json:"qtd,omitempty"`
+	WTD        *float64 `json:"wtd,omitempty"`
+	Vs1D       *float64 `json:"vs_1d,omitempty"`
+	Vs1M       *float64 `json:"vs_1m,omitempty"`
+	Vs3M       *float64 `json:"vs_3m,omitempty"`
+	VsYearHigh *float64 `json:"vs_year_high,omitempty"`
+	VsYearLow  *float64 `json:"vs_year_low,omitempty"`
+	Vs5D       *float64 `json:"vs_5d,omitempty"`
+	VsSP50026W *float64 `json:"vs_sp500_26w,omitempty"`
+	VsMA10D    *float64 `json:"vs_ma10d,omitempty"`
+	VsMA21D    *float64 `json:"vs_ma21d,omitempty"`
+	VsMA50D    *float64 `json:"vs_ma50d,omitempty"`
+	VsMA150D   *float64 `json:"vs_ma150d,omitempty"`
+	VsMA200D   *float64 `json:"vs_ma200d,omitempty"`
 }
 
 // HistoricalPriceStatistic represents a single period of historical price statistics.
 type HistoricalPriceStatistic struct {
-	Period              *string  `json:"period,omitempty"`
-	PeriodOffset        *string  `json:"period_offset,omitempty"`
-	PeriodEndDate       *string  `json:"period_end_date,omitempty"`
-	PriceHighDate       *string  `json:"price_high_date,omitempty"`
-	PriceHigh           *float64 `json:"price_high,omitempty"`
-	PriceLowDate        *string  `json:"price_low_date,omitempty"`
-	PriceLow            *float64 `json:"price_low,omitempty"`
-	PriceClose          *float64 `json:"price_close,omitempty"`
-	PricePercentChange  *float64 `json:"price_percent_change,omitempty"`
+	Period             *string  `json:"period,omitempty"`
+	PeriodOffset       *string  `json:"period_offset,omitempty"`
+	PeriodEndDate      *string  `json:"period_end_date,omitempty"`
+	PriceHighDate      *string  `json:"price_high_date,omitempty"`
+	PriceHigh          *float64 `json:"price_high,omitempty"`
+	PriceLowDate       *string  `json:"price_low_date,omitempty"`
+	PriceLow           *float64 `json:"price_low,omitempty"`
+	PriceClose         *float64 `json:"price_close,omitempty"`
+	PricePercentChange *float64 `json:"price_percent_change,omitempty"`
 }
 
 // VolumeMovingAverage represents a single volume moving average with period metadata.
@@ -73,82 +73,82 @@ type VolumeMovingAverage struct {
 
 // Pricing represents pricing statistics and market data.
 type Pricing struct {
-	MarketCap                              *float64                      `json:"market_cap,omitempty"`
-	MarketCapFormatted                     *string                       `json:"market_cap_formatted,omitempty"`
-	AvgDollarVolume50D                     *float64                      `json:"avg_dollar_volume_50d,omitempty"`
-	AvgDollarVolume50DFormatted            *string                       `json:"avg_dollar_volume_50d_formatted,omitempty"`
-	UpDownVolumeRatio                      *float64                      `json:"up_down_volume_ratio,omitempty"`
-	UpDownVolumeRatioFormatted             *string                       `json:"up_down_volume_ratio_formatted,omitempty"`
-	ATRPercent21D                          *float64                      `json:"atr_percent_21d,omitempty"`
-	ATRPercent21DFormatted                 *string                       `json:"atr_percent_21d_formatted,omitempty"`
-	ShortInterestPercentFloat              *float64                      `json:"short_interest_percent_float,omitempty"`
-	ShortInterestPercentFloatFormatted     *string                       `json:"short_interest_percent_float_formatted,omitempty"`
-	BlueDotDailyDates                      []string                      `json:"blue_dot_daily_dates,omitempty"`
-	BlueDotWeeklyDates                     []string                      `json:"blue_dot_weekly_dates,omitempty"`
-	AntDates                               []string                      `json:"ant_dates,omitempty"`
-	PricePercentChanges                    *PricePercentChanges          `json:"price_percent_changes,omitempty"`
-	VolumePercentChangeVs50D               *float64                      `json:"volume_percent_change_vs_50d,omitempty"`
-	HistoricalPriceStatistics              []HistoricalPriceStatistic    `json:"historical_price_statistics,omitempty"`
-	VolumeMovingAverages                   []VolumeMovingAverage         `json:"volume_moving_averages,omitempty"`
-	VolumePercentChangeVs6M                *float64                      `json:"volume_percent_change_vs_6m,omitempty"`
-	VolumePercentChangeVs10W               *float64                      `json:"volume_percent_change_vs_10w,omitempty"`
-	DividendYield                          *float64                      `json:"dividend_yield,omitempty"`
-	DividendYieldFormatted                 *string                       `json:"dividend_yield_formatted,omitempty"`
-	PriceToCashFlowRatio                   *float64                      `json:"price_to_cash_flow_ratio,omitempty"`
-	PriceToCashFlowRatioFormatted          *string                       `json:"price_to_cash_flow_ratio_formatted,omitempty"`
-	ForwardPriceToEarningsRatio            *float64                      `json:"forward_price_to_earnings_ratio,omitempty"`
-	ForwardPriceToEarningsRatioFormatted   *string                       `json:"forward_price_to_earnings_ratio_formatted,omitempty"`
-	PriceToSalesRatio                      *float64                      `json:"price_to_sales_ratio,omitempty"`
-	PriceToSalesRatioFormatted             *string                       `json:"price_to_sales_ratio_formatted,omitempty"`
-	PriceToEarningsRatio                   *float64                      `json:"price_to_earnings_ratio,omitempty"`
-	PriceToEarningsRatioFormatted          *string                       `json:"price_to_earnings_ratio_formatted,omitempty"`
-	PEVsSP500                              *float64                      `json:"pe_vs_sp500,omitempty"`
-	PEVsSP500Formatted                     *string                       `json:"pe_vs_sp500_formatted,omitempty"`
-	Alpha                                  *float64                      `json:"alpha,omitempty"`
-	AlphaFormatted                         *string                       `json:"alpha_formatted,omitempty"`
-	Beta                                   *float64                      `json:"beta,omitempty"`
-	BetaFormatted                          *string                       `json:"beta_formatted,omitempty"`
-	ShortInterestDaysToCover               *float64                      `json:"short_interest_days_to_cover,omitempty"`
-	ShortInterestDaysToCoverFormatted      *string                       `json:"short_interest_days_to_cover_formatted,omitempty"`
-	ShortInterestDaysToCoverPctChange      *float64                      `json:"short_interest_days_to_cover_pct_change,omitempty"`
-	ShortInterestDaysToCoverPctChangeFormatted *string                   `json:"short_interest_days_to_cover_pct_change_formatted,omitempty"`
-	ShortInterestVolume                    *int                          `json:"short_interest_volume,omitempty"`
-	ShortInterestVolumeFormatted           *string                       `json:"short_interest_volume_formatted,omitempty"`
-	IsDailyBlueDotEvent                    *bool                         `json:"is_daily_blue_dot_event,omitempty"`
-	IsWeeklyBlueDotEvent                   *bool                         `json:"is_weekly_blue_dot_event,omitempty"`
-	PricingStartDate                       *string                       `json:"pricing_start_date,omitempty"`
-	PricingEndDate                         *string                       `json:"pricing_end_date,omitempty"`
+	MarketCap                                  *float64                   `json:"market_cap,omitempty"`
+	MarketCapFormatted                         *string                    `json:"market_cap_formatted,omitempty"`
+	AvgDollarVolume50D                         *float64                   `json:"avg_dollar_volume_50d,omitempty"`
+	AvgDollarVolume50DFormatted                *string                    `json:"avg_dollar_volume_50d_formatted,omitempty"`
+	UpDownVolumeRatio                          *float64                   `json:"up_down_volume_ratio,omitempty"`
+	UpDownVolumeRatioFormatted                 *string                    `json:"up_down_volume_ratio_formatted,omitempty"`
+	ATRPercent21D                              *float64                   `json:"atr_percent_21d,omitempty"`
+	ATRPercent21DFormatted                     *string                    `json:"atr_percent_21d_formatted,omitempty"`
+	ShortInterestPercentFloat                  *float64                   `json:"short_interest_percent_float,omitempty"`
+	ShortInterestPercentFloatFormatted         *string                    `json:"short_interest_percent_float_formatted,omitempty"`
+	BlueDotDailyDates                          []string                   `json:"blue_dot_daily_dates,omitempty"`
+	BlueDotWeeklyDates                         []string                   `json:"blue_dot_weekly_dates,omitempty"`
+	AntDates                                   []string                   `json:"ant_dates,omitempty"`
+	PricePercentChanges                        *PricePercentChanges       `json:"price_percent_changes,omitempty"`
+	VolumePercentChangeVs50D                   *float64                   `json:"volume_percent_change_vs_50d,omitempty"`
+	HistoricalPriceStatistics                  []HistoricalPriceStatistic `json:"historical_price_statistics,omitempty"`
+	VolumeMovingAverages                       []VolumeMovingAverage      `json:"volume_moving_averages,omitempty"`
+	VolumePercentChangeVs6M                    *float64                   `json:"volume_percent_change_vs_6m,omitempty"`
+	VolumePercentChangeVs10W                   *float64                   `json:"volume_percent_change_vs_10w,omitempty"`
+	DividendYield                              *float64                   `json:"dividend_yield,omitempty"`
+	DividendYieldFormatted                     *string                    `json:"dividend_yield_formatted,omitempty"`
+	PriceToCashFlowRatio                       *float64                   `json:"price_to_cash_flow_ratio,omitempty"`
+	PriceToCashFlowRatioFormatted              *string                    `json:"price_to_cash_flow_ratio_formatted,omitempty"`
+	ForwardPriceToEarningsRatio                *float64                   `json:"forward_price_to_earnings_ratio,omitempty"`
+	ForwardPriceToEarningsRatioFormatted       *string                    `json:"forward_price_to_earnings_ratio_formatted,omitempty"`
+	PriceToSalesRatio                          *float64                   `json:"price_to_sales_ratio,omitempty"`
+	PriceToSalesRatioFormatted                 *string                    `json:"price_to_sales_ratio_formatted,omitempty"`
+	PriceToEarningsRatio                       *float64                   `json:"price_to_earnings_ratio,omitempty"`
+	PriceToEarningsRatioFormatted              *string                    `json:"price_to_earnings_ratio_formatted,omitempty"`
+	PEVsSP500                                  *float64                   `json:"pe_vs_sp500,omitempty"`
+	PEVsSP500Formatted                         *string                    `json:"pe_vs_sp500_formatted,omitempty"`
+	Alpha                                      *float64                   `json:"alpha,omitempty"`
+	AlphaFormatted                             *string                    `json:"alpha_formatted,omitempty"`
+	Beta                                       *float64                   `json:"beta,omitempty"`
+	BetaFormatted                              *string                    `json:"beta_formatted,omitempty"`
+	ShortInterestDaysToCover                   *float64                   `json:"short_interest_days_to_cover,omitempty"`
+	ShortInterestDaysToCoverFormatted          *string                    `json:"short_interest_days_to_cover_formatted,omitempty"`
+	ShortInterestDaysToCoverPctChange          *float64                   `json:"short_interest_days_to_cover_pct_change,omitempty"`
+	ShortInterestDaysToCoverPctChangeFormatted *string                    `json:"short_interest_days_to_cover_pct_change_formatted,omitempty"`
+	ShortInterestVolume                        *int                       `json:"short_interest_volume,omitempty"`
+	ShortInterestVolumeFormatted               *string                    `json:"short_interest_volume_formatted,omitempty"`
+	IsDailyBlueDotEvent                        *bool                      `json:"is_daily_blue_dot_event,omitempty"`
+	IsWeeklyBlueDotEvent                       *bool                      `json:"is_weekly_blue_dot_event,omitempty"`
+	PricingStartDate                           *string                    `json:"pricing_start_date,omitempty"`
+	PricingEndDate                             *string                    `json:"pricing_end_date,omitempty"`
 }
 
 // Financials represents financial metrics and earnings data.
 type Financials struct {
-	EPSDueDate              *string  `json:"eps_due_date,omitempty"`
-	EPSDueDateStatus        *string  `json:"eps_due_date_status,omitempty"`
-	EPSLastReportedDate     *string  `json:"eps_last_reported_date,omitempty"`
-	EPSGrowthRate           *float64 `json:"eps_growth_rate,omitempty"`
-	SalesGrowthRate3Y       *float64 `json:"sales_growth_rate_3y,omitempty"`
-	PreTaxMargin            *float64 `json:"pre_tax_margin,omitempty"`
-	AfterTaxMargin          *float64 `json:"after_tax_margin,omitempty"`
-	GrossMargin             *float64 `json:"gross_margin,omitempty"`
-	ReturnOnEquity          *float64 `json:"return_on_equity,omitempty"`
-	EarningsStability       *int     `json:"earnings_stability,omitempty"`
-	CashFlowPerShare        *float64 `json:"cash_flow_per_share,omitempty"`
-	CashFlowPerShareFormatted *string `json:"cash_flow_per_share_formatted,omitempty"`
+	EPSDueDate                *string  `json:"eps_due_date,omitempty"`
+	EPSDueDateStatus          *string  `json:"eps_due_date_status,omitempty"`
+	EPSLastReportedDate       *string  `json:"eps_last_reported_date,omitempty"`
+	EPSGrowthRate             *float64 `json:"eps_growth_rate,omitempty"`
+	SalesGrowthRate3Y         *float64 `json:"sales_growth_rate_3y,omitempty"`
+	PreTaxMargin              *float64 `json:"pre_tax_margin,omitempty"`
+	AfterTaxMargin            *float64 `json:"after_tax_margin,omitempty"`
+	GrossMargin               *float64 `json:"gross_margin,omitempty"`
+	ReturnOnEquity            *float64 `json:"return_on_equity,omitempty"`
+	EarningsStability         *int     `json:"earnings_stability,omitempty"`
+	CashFlowPerShare          *float64 `json:"cash_flow_per_share,omitempty"`
+	CashFlowPerShareFormatted *string  `json:"cash_flow_per_share_formatted,omitempty"`
 }
 
 // Dividend represents an individual dividend event.
 type Dividend struct {
-	ExDate            *string `json:"ex_date,omitempty"`
-	Amount            *string `json:"amount,omitempty"`
-	ChangeIndicator   *string `json:"change_indicator,omitempty"`
+	ExDate          *string `json:"ex_date,omitempty"`
+	Amount          *string `json:"amount,omitempty"`
+	ChangeIndicator *string `json:"change_indicator,omitempty"`
 }
 
 // CorporateActions represents corporate action history (dividends, splits, spinoffs).
 type CorporateActions struct {
-	NextExDividendDate *string     `json:"next_ex_dividend_date,omitempty"`
-	Dividends          []Dividend  `json:"dividends,omitempty"`
-	Splits             []string    `json:"splits,omitempty"`
-	Spinoffs           []any       `json:"spinoffs,omitempty"`
+	NextExDividendDate *string    `json:"next_ex_dividend_date,omitempty"`
+	Dividends          []Dividend `json:"dividends,omitempty"`
+	Splits             []string   `json:"splits,omitempty"`
+	Spinoffs           []any      `json:"spinoffs,omitempty"`
 }
 
 // TightArea represents a tight price consolidation area on a chart.
@@ -159,41 +159,58 @@ type TightArea struct {
 	Length    *int    `json:"length,omitempty"`
 }
 
+// BasePattern summarizes the most recent base pattern for quick agent analysis.
+type BasePattern struct {
+	PatternType      *string  `json:"pattern_type,omitempty"`
+	BaseStage        *string  `json:"base_stage,omitempty"`
+	PivotPrice       *float64 `json:"pivot_price,omitempty"`
+	BaseLengthWeeks  *int     `json:"base_length_weeks,omitempty"`
+	BaseDepthPercent *float64 `json:"base_depth_percent,omitempty"`
+	VolumeAtPivotPct *float64 `json:"volume_at_pivot_pct,omitempty"`
+}
+
+// Signals represents current MarketSurge technical signal flags.
+type Signals struct {
+	BlueDot     *bool   `json:"blue_dot,omitempty"`
+	BlueDotDate *string `json:"blue_dot_date,omitempty"`
+	AntSignal   *bool   `json:"ant_signal,omitempty"`
+}
+
 // Pattern represents a base class for all technical chart patterns.
 type Pattern struct {
-	ID                              *string  `json:"id,omitempty"`
-	PatternType                     *string  `json:"pattern_type,omitempty"`
-	Periodicity                     *string  `json:"periodicity,omitempty"`
-	BaseStage                       *string  `json:"base_stage,omitempty"`
-	BaseNumber                      *int     `json:"base_number,omitempty"`
-	BaseStatus                      *string  `json:"base_status,omitempty"`
-	BaseLength                      *int     `json:"base_length,omitempty"`
-	BaseDepth                       *float64 `json:"base_depth,omitempty"`
-	BaseDepthFormatted              *string  `json:"base_depth_formatted,omitempty"`
-	BaseStartDate                   *string  `json:"base_start_date,omitempty"`
-	BaseEndDate                     *string  `json:"base_end_date,omitempty"`
-	BaseBottomDate                  *string  `json:"base_bottom_date,omitempty"`
-	LeftSideHighDate                *string  `json:"left_side_high_date,omitempty"`
-	PivotPrice                      *float64 `json:"pivot_price,omitempty"`
-	PivotPriceFormatted             *string  `json:"pivot_price_formatted,omitempty"`
-	PivotDate                       *string  `json:"pivot_date,omitempty"`
-	PivotPriceDate                  *string  `json:"pivot_price_date,omitempty"`
-	AvgVolumeRatePctOnPivot         *float64 `json:"avg_volume_rate_pct_on_pivot,omitempty"`
-	AvgVolumeRatePctOnPivotFormatted *string `json:"avg_volume_rate_pct_on_pivot_formatted,omitempty"`
-	PricePctChangeOnPivot           *float64 `json:"price_pct_change_on_pivot,omitempty"`
-	PricePctChangeOnPivotFormatted  *string  `json:"price_pct_change_on_pivot_formatted,omitempty"`
+	ID                               *string  `json:"id,omitempty"`
+	PatternType                      *string  `json:"pattern_type,omitempty"`
+	Periodicity                      *string  `json:"periodicity,omitempty"`
+	BaseStage                        *string  `json:"base_stage,omitempty"`
+	BaseNumber                       *int     `json:"base_number,omitempty"`
+	BaseStatus                       *string  `json:"base_status,omitempty"`
+	BaseLength                       *int     `json:"base_length,omitempty"`
+	BaseDepth                        *float64 `json:"base_depth,omitempty"`
+	BaseDepthFormatted               *string  `json:"base_depth_formatted,omitempty"`
+	BaseStartDate                    *string  `json:"base_start_date,omitempty"`
+	BaseEndDate                      *string  `json:"base_end_date,omitempty"`
+	BaseBottomDate                   *string  `json:"base_bottom_date,omitempty"`
+	LeftSideHighDate                 *string  `json:"left_side_high_date,omitempty"`
+	PivotPrice                       *float64 `json:"pivot_price,omitempty"`
+	PivotPriceFormatted              *string  `json:"pivot_price_formatted,omitempty"`
+	PivotDate                        *string  `json:"pivot_date,omitempty"`
+	PivotPriceDate                   *string  `json:"pivot_price_date,omitempty"`
+	AvgVolumeRatePctOnPivot          *float64 `json:"avg_volume_rate_pct_on_pivot,omitempty"`
+	AvgVolumeRatePctOnPivotFormatted *string  `json:"avg_volume_rate_pct_on_pivot_formatted,omitempty"`
+	PricePctChangeOnPivot            *float64 `json:"price_pct_change_on_pivot,omitempty"`
+	PricePctChangeOnPivotFormatted   *string  `json:"price_pct_change_on_pivot_formatted,omitempty"`
 }
 
 // CupPattern represents a cup or saucer pattern with or without handle.
 type CupPattern struct {
 	Pattern
-	HandleDepth       *float64 `json:"handle_depth,omitempty"`
-	HandleDepthFormatted *string `json:"handle_depth_formatted,omitempty"`
-	HandleLength      *int     `json:"handle_length,omitempty"`
-	CupLength         *int     `json:"cup_length,omitempty"`
-	CupEndDate        *string  `json:"cup_end_date,omitempty"`
-	HandleLowDate     *string  `json:"handle_low_date,omitempty"`
-	HandleStartDate   *string  `json:"handle_start_date,omitempty"`
+	HandleDepth          *float64 `json:"handle_depth,omitempty"`
+	HandleDepthFormatted *string  `json:"handle_depth_formatted,omitempty"`
+	HandleLength         *int     `json:"handle_length,omitempty"`
+	CupLength            *int     `json:"cup_length,omitempty"`
+	CupEndDate           *string  `json:"cup_end_date,omitempty"`
+	HandleLowDate        *string  `json:"handle_low_date,omitempty"`
+	HandleStartDate      *string  `json:"handle_start_date,omitempty"`
 }
 
 // DoubleBottomPattern represents a double bottom (W-shaped) chart pattern.
@@ -207,34 +224,34 @@ type DoubleBottomPattern struct {
 // AscendingBasePattern represents an ascending base pattern.
 type AscendingBasePattern struct {
 	Pattern
-	FirstBottomDate           *string  `json:"first_bottom_date,omitempty"`
-	SecondAscendingHighDate   *string  `json:"second_ascending_high_date,omitempty"`
-	SecondBottomDate          *string  `json:"second_bottom_date,omitempty"`
-	ThirdAscendingHighDate    *string  `json:"third_ascending_high_date,omitempty"`
-	ThirdBottomDate           *string  `json:"third_bottom_date,omitempty"`
-	PullBack1Depth            *float64 `json:"pull_back_1_depth,omitempty"`
-	PullBack1DepthFormatted   *string  `json:"pull_back_1_depth_formatted,omitempty"`
-	PullBack2Depth            *float64 `json:"pull_back_2_depth,omitempty"`
-	PullBack2DepthFormatted   *string  `json:"pull_back_2_depth_formatted,omitempty"`
-	PullBack3Depth            *float64 `json:"pull_back_3_depth,omitempty"`
-	PullBack3DepthFormatted   *string  `json:"pull_back_3_depth_formatted,omitempty"`
+	FirstBottomDate         *string  `json:"first_bottom_date,omitempty"`
+	SecondAscendingHighDate *string  `json:"second_ascending_high_date,omitempty"`
+	SecondBottomDate        *string  `json:"second_bottom_date,omitempty"`
+	ThirdAscendingHighDate  *string  `json:"third_ascending_high_date,omitempty"`
+	ThirdBottomDate         *string  `json:"third_bottom_date,omitempty"`
+	PullBack1Depth          *float64 `json:"pull_back_1_depth,omitempty"`
+	PullBack1DepthFormatted *string  `json:"pull_back_1_depth_formatted,omitempty"`
+	PullBack2Depth          *float64 `json:"pull_back_2_depth,omitempty"`
+	PullBack2DepthFormatted *string  `json:"pull_back_2_depth_formatted,omitempty"`
+	PullBack3Depth          *float64 `json:"pull_back_3_depth,omitempty"`
+	PullBack3DepthFormatted *string  `json:"pull_back_3_depth_formatted,omitempty"`
 }
 
 // IpoBasePattern represents the first base pattern after an IPO.
 type IpoBasePattern struct {
 	Pattern
-	UpBars                      *int     `json:"up_bars,omitempty"`
-	BlueBars                    *int     `json:"blue_bars,omitempty"`
-	StallBars                   *int     `json:"stall_bars,omitempty"`
-	DownBars                    *int     `json:"down_bars,omitempty"`
-	RedBars                     *int     `json:"red_bars,omitempty"`
-	SupportBars                 *int     `json:"support_bars,omitempty"`
-	UpVolumeTotal               *float64 `json:"up_volume_total,omitempty"`
-	UpVolumeTotalFormatted      *string  `json:"up_volume_total_formatted,omitempty"`
-	DownVolumeTotal             *float64 `json:"down_volume_total,omitempty"`
-	DownVolumeTotalFormatted    *string  `json:"down_volume_total_formatted,omitempty"`
-	VolumePctChangeOnPivot      *float64 `json:"volume_pct_change_on_pivot,omitempty"`
-	VolumePctChangeOnPivotFormatted *string `json:"volume_pct_change_on_pivot_formatted,omitempty"`
+	UpBars                          *int     `json:"up_bars,omitempty"`
+	BlueBars                        *int     `json:"blue_bars,omitempty"`
+	StallBars                       *int     `json:"stall_bars,omitempty"`
+	DownBars                        *int     `json:"down_bars,omitempty"`
+	RedBars                         *int     `json:"red_bars,omitempty"`
+	SupportBars                     *int     `json:"support_bars,omitempty"`
+	UpVolumeTotal                   *float64 `json:"up_volume_total,omitempty"`
+	UpVolumeTotalFormatted          *string  `json:"up_volume_total_formatted,omitempty"`
+	DownVolumeTotal                 *float64 `json:"down_volume_total,omitempty"`
+	DownVolumeTotalFormatted        *string  `json:"down_volume_total_formatted,omitempty"`
+	VolumePctChangeOnPivot          *float64 `json:"volume_pct_change_on_pivot,omitempty"`
+	VolumePctChangeOnPivotFormatted *string  `json:"volume_pct_change_on_pivot_formatted,omitempty"`
 }
 
 // IndustryGroupSnapshot represents a single time snapshot of industry group rank or RS.
@@ -246,12 +263,12 @@ type IndustryGroupSnapshot struct {
 
 // Industry represents industry group information.
 type Industry struct {
-	Name              *string                    `json:"name,omitempty"`
-	Sector            *string                    `json:"sector,omitempty"`
-	Code              *string                    `json:"code,omitempty"`
-	NumberOfStocks    *int                       `json:"number_of_stocks,omitempty"`
-	GroupRankHistory  []IndustryGroupSnapshot    `json:"group_rank_history,omitempty"`
-	GroupRSHistory    []IndustryGroupSnapshot    `json:"group_rs_history,omitempty"`
+	Name             *string                 `json:"name,omitempty"`
+	Sector           *string                 `json:"sector,omitempty"`
+	Code             *string                 `json:"code,omitempty"`
+	NumberOfStocks   *int                    `json:"number_of_stocks,omitempty"`
+	GroupRankHistory []IndustryGroupSnapshot `json:"group_rank_history,omitempty"`
+	GroupRSHistory   []IndustryGroupSnapshot `json:"group_rs_history,omitempty"`
 }
 
 // BasicOwnership represents basic fund ownership metrics.
@@ -270,16 +287,18 @@ type Fundamentals struct {
 
 // StockData represents complete stock data response.
 type StockData struct {
-	Symbol            string              `json:"symbol"`
-	Ratings           *Ratings            `json:"ratings,omitempty"`
-	Company           *Company            `json:"company,omitempty"`
-	Pricing           *Pricing            `json:"pricing,omitempty"`
-	Financials        *Financials         `json:"financials,omitempty"`
-	CorporateActions  *CorporateActions   `json:"corporate_actions,omitempty"`
-	Industry          *Industry           `json:"industry,omitempty"`
-	Ownership         *BasicOwnership     `json:"ownership,omitempty"`
-	Fundamentals      *Fundamentals       `json:"fundamentals,omitempty"`
+	Symbol              string               `json:"symbol"`
+	Ratings             *Ratings             `json:"ratings,omitempty"`
+	Company             *Company             `json:"company,omitempty"`
+	Pricing             *Pricing             `json:"pricing,omitempty"`
+	BasePattern         *BasePattern         `json:"base_pattern,omitempty"`
+	Signals             *Signals             `json:"signals,omitempty"`
+	Financials          *Financials          `json:"financials,omitempty"`
+	CorporateActions    *CorporateActions    `json:"corporate_actions,omitempty"`
+	Industry            *Industry            `json:"industry,omitempty"`
+	Ownership           *BasicOwnership      `json:"ownership,omitempty"`
+	Fundamentals        *Fundamentals        `json:"fundamentals,omitempty"`
 	QuarterlyFinancials *QuarterlyFinancials `json:"quarterly_financials,omitempty"`
-	Patterns          []Pattern           `json:"patterns,omitempty"`
-	TightAreas        []TightArea         `json:"tight_areas,omitempty"`
+	Patterns            []Pattern            `json:"patterns,omitempty"`
+	TightAreas          []TightArea          `json:"tight_areas,omitempty"`
 }

--- a/skills/stock.md
+++ b/skills/stock.md
@@ -11,7 +11,7 @@ Fetch stock data including ratings, pricing, financials, patterns, and company i
 Use this for targeted stock data without fundamentals or ownership.
 For comprehensive analysis, use analyze_stock instead.
 
-Stock data now includes valuation ratios, risk metrics, short interest data, and blue dot event flags.
+Stock data now includes valuation ratios, risk metrics, short interest data, base pattern summaries, and blue dot/ant signal flags.
 
 **Parameters:**
 - symbol (required): Stock ticker symbol, e.g. AAPL, NVDA, TSLA
@@ -43,7 +43,7 @@ Analyze a stock with comprehensive data from MarketSurge.
 Fetches stock ratings, fundamentals, and ownership data concurrently.
 Partial failures in fundamentals or ownership are returned in the errors list rather than failing the entire request.
 
-Stock data now includes valuation ratios, risk metrics, short interest data, and blue dot event flags.
+Stock data now includes valuation ratios, risk metrics, short interest data, base pattern summaries, and blue dot/ant signal flags.
 
 **Parameters:**
 - symbols (required): One or more stock ticker symbols separated by spaces, e.g. AAPL NVDA TSLA. Each symbol is fetched concurrently.
@@ -69,6 +69,8 @@ marketsurge-agent stock analyze --tickers AAPL,NVDA,TSLA --compact --flat
 ```
 
 With `--flat`, nested stock fields are emitted as single-level keys, for example `stock.pricing.market_cap` becomes `pricing_market_cap`.
+
+Technical analysis fields include `stock.base_pattern` for pattern type, base stage, pivot price, base length, depth, and volume at pivot, plus `stock.signals` for blue dot and ant signal flags.
 
 ## Workflow Guidance
 


### PR DESCRIPTION
## Summary
- Parse MarketSurge base pattern, tight area, blue dot, and ant signal fields into stock output.
- Add `stock.base_pattern` summary and `stock.signals` flags for agent-friendly analysis.
- Update fixtures, stock analyze coverage, generated stock skill docs, and README.

## Verification
- `go test ./internal/commands -run 'Test(StockAnalyze|SkillsGenerate)'`
- `go test ./...`
- `go test -race ./...`
- `golangci-lint run`
- `go build ./cmd/marketsurge-agent`

Closes #18
Closes #19