### PR TITLE
fix(output): include HTTP response body details

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -102,6 +102,20 @@ func TestExecuteReturnsHTTPErrorOn500(t *testing.T) {
 	assert.Contains(t, httpErr.Body, "boom")
 }
 
+func TestExecuteReturnsHTTPErrorBodyOn400(t *testing.T) {
+	t.Parallel()
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "invalid input value", http.StatusBadRequest)
+	})
+
+	_, err := client.Execute(t.Context(), Request{})
+	var httpErr *mserrors.HTTPError
+	require.Error(t, err)
+	assert.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusBadRequest, httpErr.StatusCode)
+	assert.Contains(t, httpErr.Body, "invalid input value")
+}
+
 func TestExecuteRejectsUnexpectedContentType(t *testing.T) {
 	t.Parallel()
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -55,7 +55,7 @@ func WriteError(w io.Writer, err error) error {
 	}
 
 	if httpErr, ok := errors.AsType[*mserr.HTTPError](err); ok {
-		details = fmt.Sprintf("status: %d", httpErr.StatusCode)
+		details = httpErrorDetails(httpErr)
 	}
 
 	errorEnvelope := ErrorEnvelope{
@@ -68,6 +68,22 @@ func WriteError(w io.Writer, err error) error {
 	encoder := json.NewEncoder(w)
 	encoder.SetEscapeHTML(false)
 	return encoder.Encode(errorEnvelope)
+}
+
+const maxHTTPErrorBodyDetailLength = 500
+
+func httpErrorDetails(err *mserr.HTTPError) string {
+	details := fmt.Sprintf("status: %d", err.StatusCode)
+	if err.Body == "" {
+		return details
+	}
+
+	body := err.Body
+	if len(body) > maxHTTPErrorBodyDetailLength {
+		body = body[:maxHTTPErrorBodyDetailLength] + "..."
+	}
+
+	return fmt.Sprintf("%s; body: %s", details, body)
 }
 
 // WritePartial writes a response with both data and errors (partial success).
@@ -86,10 +102,12 @@ func WritePartial(w io.Writer, data any, errs []string, metadata map[string]any)
 // errorCode maps an error to its corresponding error code string.
 // Each error type implements ErrorCode() to declare its own classification code.
 func errorCode(err error) string {
-	type errorCoder interface{ ErrorCode() string }
+	type errorCoder interface {
+		error
+		ErrorCode() string
+	}
 
-	var coder errorCoder
-	if errors.As(err, &coder) {
+	if coder, ok := errors.AsType[errorCoder](err); ok {
 		return coder.ErrorCode()
 	}
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"regexp"
 
 	mserr "github.com/major/marketsurge-agent/internal/errors"
 )
@@ -72,18 +73,37 @@ func WriteError(w io.Writer, err error) error {
 
 const maxHTTPErrorBodyDetailLength = 500
 
+var sensitiveHTTPBodyPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+`),
+	regexp.MustCompile(`(?i)Bearer\s+\S+`),
+	regexp.MustCompile(`\b[A-Za-z_][A-Za-z0-9_-]*=[^\s;,]+`),
+}
+
 func httpErrorDetails(err *mserr.HTTPError) string {
 	details := fmt.Sprintf("status: %d", err.StatusCode)
 	if err.Body == "" {
 		return details
 	}
 
-	body := err.Body
-	if len(body) > maxHTTPErrorBodyDetailLength {
-		body = body[:maxHTTPErrorBodyDetailLength] + "..."
-	}
+	body := truncateHTTPErrorBody(redactHTTPErrorBody(err.Body))
 
 	return fmt.Sprintf("%s; body: %s", details, body)
+}
+
+func redactHTTPErrorBody(body string) string {
+	for _, pattern := range sensitiveHTTPBodyPatterns {
+		body = pattern.ReplaceAllString(body, "[REDACTED]")
+	}
+	return body
+}
+
+func truncateHTTPErrorBody(body string) string {
+	runes := []rune(body)
+	if len(runes) <= maxHTTPErrorBodyDetailLength {
+		return body
+	}
+
+	return string(runes[:maxHTTPErrorBodyDetailLength]) + "..."
 }
 
 // WritePartial writes a response with both data and errors (partial success).

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -155,6 +155,44 @@ func TestWriteErrorHTTPErrorTruncatesLongBody(t *testing.T) {
 
 	assert.Len(t, errorEnvelope.Error.Details, len("status: 400; body: ")+maxHTTPErrorBodyDetailLength+len("..."))
 	assert.Contains(t, errorEnvelope.Error.Details, "status: 400")
+	assert.Contains(t, errorEnvelope.Error.Details, "aaaa")
+	assert.Contains(t, errorEnvelope.Error.Details, "...")
+}
+
+func TestWriteErrorHTTPErrorRedactsSensitiveBodyValues(t *testing.T) {
+	t.Parallel()
+	buf := &bytes.Buffer{}
+	body := "Authorization: Bearer secret-token jwt eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.signature cookie sessionid=abc123"
+	err := mserr.NewHTTPError("http error", nil, 400, body)
+
+	writeErr := WriteError(buf, err)
+	require.NoError(t, writeErr)
+
+	var errorEnvelope ErrorEnvelope
+	unmarshalErr := json.Unmarshal(buf.Bytes(), &errorEnvelope)
+	require.NoError(t, unmarshalErr)
+
+	assert.Contains(t, errorEnvelope.Error.Details, "[REDACTED]")
+	assert.NotContains(t, errorEnvelope.Error.Details, "secret-token")
+	assert.NotContains(t, errorEnvelope.Error.Details, "eyJhbGciOiJIUzI1NiJ9")
+	assert.NotContains(t, errorEnvelope.Error.Details, "sessionid=abc123")
+}
+
+func TestWriteErrorHTTPErrorTruncatesUTF8BodyAtRuneBoundary(t *testing.T) {
+	t.Parallel()
+	buf := &bytes.Buffer{}
+	body := string(bytes.Repeat([]byte("é"), maxHTTPErrorBodyDetailLength+1))
+	err := mserr.NewHTTPError("http error", nil, 400, body)
+
+	writeErr := WriteError(buf, err)
+	require.NoError(t, writeErr)
+
+	var errorEnvelope ErrorEnvelope
+	unmarshalErr := json.Unmarshal(buf.Bytes(), &errorEnvelope)
+	require.NoError(t, unmarshalErr)
+
+	assert.Contains(t, errorEnvelope.Error.Details, "éééé")
+	assert.NotContains(t, errorEnvelope.Error.Details, "�")
 	assert.Contains(t, errorEnvelope.Error.Details, "...")
 }
 

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -126,7 +126,7 @@ func TestWriteErrorAPIError(t *testing.T) {
 func TestWriteErrorHTTPError(t *testing.T) {
 	t.Parallel()
 	buf := &bytes.Buffer{}
-	err := mserr.NewHTTPError("http error", errors.New("500 response"), 500, "Internal Server Error")
+	err := mserr.NewHTTPError("http error", errors.New("500 response"), 500, "invalid input value")
 
 	writeErr := WriteError(buf, err)
 	require.NoError(t, writeErr)
@@ -136,6 +136,26 @@ func TestWriteErrorHTTPError(t *testing.T) {
 	require.NoError(t, unmarshalErr)
 
 	assert.Equal(t, "HTTP_ERROR", errorEnvelope.Error.Code)
+	assert.Contains(t, errorEnvelope.Error.Details, "status: 500")
+	assert.Contains(t, errorEnvelope.Error.Details, "body: invalid input value")
+}
+
+func TestWriteErrorHTTPErrorTruncatesLongBody(t *testing.T) {
+	t.Parallel()
+	buf := &bytes.Buffer{}
+	body := string(bytes.Repeat([]byte("a"), maxHTTPErrorBodyDetailLength+1))
+	err := mserr.NewHTTPError("http error", nil, 400, body)
+
+	writeErr := WriteError(buf, err)
+	require.NoError(t, writeErr)
+
+	var errorEnvelope ErrorEnvelope
+	unmarshalErr := json.Unmarshal(buf.Bytes(), &errorEnvelope)
+	require.NoError(t, unmarshalErr)
+
+	assert.Len(t, errorEnvelope.Error.Details, len("status: 400; body: ")+maxHTTPErrorBodyDetailLength+len("..."))
+	assert.Contains(t, errorEnvelope.Error.Details, "status: 400")
+	assert.Contains(t, errorEnvelope.Error.Details, "...")
 }
 
 func TestWriteErrorValidationError(t *testing.T) {


### PR DESCRIPTION
## Summary
- Include captured HTTP response bodies in structured error details so GraphQL validation failures are visible to callers.
- Truncate long bodies in output details to keep JSON errors readable while preserving the status code.
- Add regression coverage for 400 response-body capture and HTTP error output formatting.

Fixes #27

## Verification
- go test -v -race -coverprofile=coverage.out ./...
- make lint
- make build