### PR TITLE
Fix multi-symbol RS history and summary analysis output

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ marketsurge-agent stock analyze AAPL MSFT NVDA GOOG
 # Analyze a comma-separated batch and remove formatted duplicate fields
 marketsurge-agent stock analyze --tickers AAPL,MSFT,NVDA --compact
 
+# Return screening fields for ranking many candidates
+marketsurge-agent stock analyze --summary AAPL MSFT NVDA
+
 # Flatten each analysis result for lower-token agent parsing
 marketsurge-agent stock analyze AAPL --flat
 
@@ -50,8 +53,8 @@ marketsurge-agent fundamental get TSLA
 # Institutional ownership
 marketsurge-agent ownership get AMZN
 
-# Relative strength history
-marketsurge-agent rs-history get META
+# Relative strength history for one or more symbols
+marketsurge-agent rs-history get META NVDA
 
 # Chart price history (daily, last 90 days)
 marketsurge-agent chart history AAPL --period 90
@@ -95,10 +98,10 @@ Errors follow the same pattern:
 | Command | Description |
 |---|---|
 | `stock get <symbol>` | Stock data (ratings, pricing, financials) |
-| `stock analyze [symbols...]` | Concurrent single-symbol or multi-symbol analysis with optional compact, flat, and comma-separated batch modes |
+| `stock analyze [symbols...]` | Concurrent single-symbol or multi-symbol analysis with optional compact, flat, summary, and comma-separated batch modes |
 | `fundamental get <symbol>` | Fundamental analysis data |
 | `ownership get <symbol>` | Institutional ownership |
-| `rs-history get <symbol>` | Relative strength rating history |
+| `rs-history get [symbols...]` | Relative strength rating history for one or more symbols |
 | `chart history <symbol>` | Price history (daily or weekly) |
 | `chart markups <symbol>` | Chart annotations and markups |
 | `catalog list` | List watchlists, screens, reports |
@@ -117,9 +120,12 @@ marketsurge-agent stock analyze --tickers AAPL,MSFT,NVDA --compact --flat
 
 - `--tickers AAPL,MSFT,NVDA` analyzes comma-separated symbols in one command. Positional symbols still work and can be combined with `--tickers`.
 - `--compact` removes duplicate formatted string fields such as `market_cap_formatted`, while keeping raw numeric values.
+- `--summary` returns one small screening object per symbol with rankings, signal flags, base details, liquidity, volatility, and ownership fields. Response metadata includes `mode: "summary"`.
 - `--flat` flattens each analysis result inside the standard JSON envelope, for example `stock.pricing.market_cap` becomes `pricing_market_cap`.
 
 `stock analyze` also includes MarketSurge technical context for chart-driven screening: `stock.base_pattern` summarizes the current base with pattern type, base stage, pivot price, base length, depth, and volume at pivot; `stock.signals` reports blue dot and ant signal flags when the API provides them.
+
+`rs-history get` accepts multiple symbols in one request. Multi-symbol output uses a `data` object keyed by ticker so agents can compare RS trends without shell loops.
 
 The `skills generate` command writes Markdown skill files to `skills/` that describe each command's inputs, outputs, and usage. These files are designed for consumption by AI agent frameworks that support tool/skill discovery.
 

--- a/internal/client/rs_history.go
+++ b/internal/client/rs_history.go
@@ -2,14 +2,31 @@ package client
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/major/marketsurge-agent/internal/constants"
+	mserrors "github.com/major/marketsurge-agent/internal/errors"
 	"github.com/major/marketsurge-agent/internal/models"
 	"github.com/major/marketsurge-agent/queries"
 )
 
 // GetRSRatingHistory returns RS rating history for a symbol.
 func (c *Client) GetRSRatingHistory(ctx context.Context, symbol string) (*models.RSRatingHistory, error) {
+	histories, err := c.GetRSRatingHistories(ctx, []string{symbol})
+	if err != nil {
+		return nil, err
+	}
+
+	history, ok := histories[symbol]
+	if !ok {
+		return nil, firstMissingRSHistoryError([]string{symbol})
+	}
+	return history, nil
+}
+
+// GetRSRatingHistories returns RS rating history for each symbol returned by the API.
+func (c *Client) GetRSRatingHistories(ctx context.Context, symbols []string) (map[string]*models.RSRatingHistory, error) {
 	query, err := queries.Load("rs_rating_ri_panel.graphql")
 	if err != nil {
 		return nil, err
@@ -18,7 +35,7 @@ func (c *Client) GetRSRatingHistory(ctx context.Context, symbol string) (*models
 	raw, err := c.Execute(ctx, Request{
 		OperationName: "RSRatingRIPanel",
 		Variables: map[string]any{
-			"symbols":           []string{symbol},
+			"symbols":           symbols,
 			"symbolDialectType": constants.SymbolDialectType,
 		},
 		Query: query,
@@ -27,11 +44,42 @@ func (c *Client) GetRSRatingHistory(ctx context.Context, symbol string) (*models
 		return nil, err
 	}
 
-	item, err := firstMarketData(raw, symbol)
-	if err != nil {
-		return nil, err
+	marketData := getNestedSlice(raw, "data", "marketData")
+	if len(marketData) == 0 {
+		return nil, firstMissingRSHistoryError(symbols)
 	}
 
+	requestedSymbols := make(map[string]string, len(symbols))
+	for _, symbol := range symbols {
+		requestedSymbols[strings.ToUpper(symbol)] = symbol
+	}
+
+	histories := make(map[string]*models.RSRatingHistory, len(marketData))
+	for _, item := range marketData {
+		mapping, ok := item.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("invalid marketData item")
+		}
+		responseSymbol := rsHistoryResponseSymbol(mapping)
+		if responseSymbol == "" {
+			return nil, fmt.Errorf("missing originRequest symbol in marketData item")
+		}
+		symbol, ok := requestedSymbols[strings.ToUpper(responseSymbol)]
+		if !ok {
+			symbol = responseSymbol
+		}
+		histories[symbol] = rsRatingHistoryFromMarketData(symbol, mapping)
+	}
+
+	return histories, nil
+}
+
+func rsHistoryResponseSymbol(item map[string]any) string {
+	originRequest := getNestedMap(item, "originRequest")
+	return stringify(originRequest["symbol"])
+}
+
+func rsRatingHistoryFromMarketData(symbol string, item map[string]any) *models.RSRatingHistory {
 	ratings := getNestedSlice(item, "ratings", "rsRating")
 	intraday := getNestedMap(item, "pricingStatistics", "intradayStatistics")
 	result := &models.RSRatingHistory{
@@ -47,5 +95,16 @@ func (c *Client) GetRSRatingHistory(ctx context.Context, symbol string) (*models
 	}
 	result.RSLineNewHigh = boolPtr(intraday["rsLineNewHigh"])
 
-	return result, nil
+	return result
+}
+
+func firstMissingRSHistoryError(symbols []string) error {
+	if len(symbols) == 1 {
+		return firstMarketDataMissingError(symbols[0])
+	}
+	return firstMarketDataMissingError(strings.Join(symbols, ","))
+}
+
+func firstMarketDataMissingError(symbol string) error {
+	return mserrors.NewSymbolNotFoundError(fmt.Sprintf("symbol not found: %q", symbol), nil, symbol)
 }

--- a/internal/client/stock_test.go
+++ b/internal/client/stock_test.go
@@ -91,6 +91,7 @@ func stockResponseJSON() string {
 	return `{
 		"data": {
 			"marketData": [{
+				"originRequest": {"symbol": "AAPL"},
 				"ratings": {
 					"compRating": [{"value": 99}],
 					"epsRating": [{"value": 95}],

--- a/internal/commands/helpers_test.go
+++ b/internal/commands/helpers_test.go
@@ -57,6 +57,7 @@ func stockResponseFixture() string {
 	return `{
 		"data": {
 			"marketData": [{
+				"originRequest": {"symbol": "AAPL"},
 				"ratings": {
 					"compRating": [{"value": 99}],
 					"epsRating": [{"value": 95}],
@@ -184,4 +185,38 @@ func chartResponseFixture() string {
 // chartMarkupsFixture returns a minimal chart markups API response.
 func chartMarkupsFixture() string {
 	return `{"data":{"user":{"chartMarkups":{"cursorId":"cursor-abc","chartMarkups":[{"id":"m1","name":"My Markup","data":"{}","frequency":"DAILY","site":"marketsurge","createdAt":"2024-01-01","updatedAt":"2024-01-02"}]}}}}`
+}
+
+// rsHistoryMultiResponseFixture returns two marketData entries for multi-symbol RS history tests.
+func rsHistoryMultiResponseFixture() string {
+	return `{
+		"data": {
+			"marketData": [{
+				"originRequest": {"symbol": "AAPL"},
+				"ratings": {"rsRating": [{"value": 90, "letterValue": "A", "period": "WEEK", "periodOffset": "0"}]},
+				"pricingStatistics": {"intradayStatistics": {"rsLineNewHigh": true}}
+			}, {
+				"originRequest": {"symbol": "MSFT"},
+				"ratings": {"rsRating": [{"value": 82, "letterValue": "B", "period": "WEEK", "periodOffset": "0"}]},
+				"pricingStatistics": {"intradayStatistics": {"rsLineNewHigh": false}}
+			}]
+		}
+	}`
+}
+
+// rsHistoryMissingMiddleResponseFixture returns AAPL and MSFT after the API omits a missing middle symbol.
+func rsHistoryMissingMiddleResponseFixture() string {
+	return `{
+		"data": {
+			"marketData": [{
+				"originRequest": {"symbol": "AAPL"},
+				"ratings": {"rsRating": [{"value": 90, "letterValue": "A", "period": "WEEK", "periodOffset": "0"}]},
+				"pricingStatistics": {"intradayStatistics": {"rsLineNewHigh": true}}
+			}, {
+				"originRequest": {"symbol": "MSFT"},
+				"ratings": {"rsRating": [{"value": 82, "letterValue": "B", "period": "WEEK", "periodOffset": "0"}]},
+				"pricingStatistics": {"intradayStatistics": {"rsLineNewHigh": false}}
+			}]
+		}
+	}`
 }

--- a/internal/commands/rs_history_get.go
+++ b/internal/commands/rs_history_get.go
@@ -2,16 +2,69 @@ package commands
 
 import (
 	"context"
+	"fmt"
 	"io"
+	"time"
 
 	"github.com/urfave/cli/v3"
 
 	"github.com/major/marketsurge-agent/internal/client"
+	mserrors "github.com/major/marketsurge-agent/internal/errors"
+	"github.com/major/marketsurge-agent/internal/models"
+	"github.com/major/marketsurge-agent/internal/output"
 )
 
 // RSHistoryGetCommand returns the CLI command for retrieving RS rating history.
 func RSHistoryGetCommand(c *client.Client, w io.Writer) *cli.Command {
-	return symbolGetCommand(w, "get", "Get RS rating history for a symbol", func(ctx context.Context, symbol string) (any, error) {
-		return c.GetRSRatingHistory(ctx, symbol)
-	})
+	return &cli.Command{
+		Name:      "get",
+		Usage:     "Get RS rating history for one or more symbols",
+		ArgsUsage: "[symbol...]",
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			symbols := cmd.Args().Slice()
+			if len(symbols) == 0 {
+				return mserrors.NewValidationError("symbol is required", nil)
+			}
+
+			if len(symbols) == 1 {
+				data, err := c.GetRSRatingHistory(ctx, symbols[0])
+				if err != nil {
+					return err
+				}
+				return output.WriteSuccess(w, data, output.SymbolMeta(symbols[0]))
+			}
+
+			histories, err := c.GetRSRatingHistories(ctx, symbols)
+			if err != nil {
+				return err
+			}
+
+			data, errs := orderedRSHistoryData(symbols, histories)
+			meta := map[string]any{
+				"symbols":   symbols,
+				"timestamp": time.Now().UTC().Format(time.RFC3339),
+			}
+			if len(data) == 0 {
+				return fmt.Errorf("rs history failed for all symbols: %v", errs)
+			}
+			if len(errs) > 0 {
+				return output.WritePartial(w, data, errs, meta)
+			}
+			return output.WriteSuccess(w, data, meta)
+		},
+	}
+}
+
+func orderedRSHistoryData(symbols []string, histories map[string]*models.RSRatingHistory) (data map[string]*models.RSRatingHistory, errs []string) {
+	data = make(map[string]*models.RSRatingHistory, len(histories))
+	errs = make([]string, 0)
+	for _, symbol := range symbols {
+		history, ok := histories[symbol]
+		if !ok {
+			errs = append(errs, fmt.Sprintf("%s: symbol not found", symbol))
+			continue
+		}
+		data[symbol] = history
+	}
+	return data, errs
 }

--- a/internal/commands/rs_history_get_test.go
+++ b/internal/commands/rs_history_get_test.go
@@ -24,6 +24,77 @@ func TestRSHistoryGetSuccess(t *testing.T) {
 	assertSymbolMeta(t, result, "AAPL")
 }
 
+func TestRSHistoryGetMultiSymbol(t *testing.T) {
+	t.Parallel()
+	server := jsonServer(rsHistoryMultiResponseFixture())
+	defer server.Close()
+	c := testClient(t, server)
+
+	var buf bytes.Buffer
+	cmd := RSHistoryGetCommand(c, &buf)
+	require.NoError(t, runTestCommand(t, cmd, "get", "AAPL", "MSFT"))
+
+	result := parseJSONEnvelope(t, &buf)
+	data, ok := result["data"].(map[string]any)
+	require.True(t, ok, "multi-symbol RS history should be keyed by symbol")
+	assert.Contains(t, data, "AAPL")
+	assert.Contains(t, data, "MSFT")
+
+	meta, _ := result["metadata"].(map[string]any)
+	symbols, _ := meta["symbols"].([]any)
+	assert.Equal(t, []any{"AAPL", "MSFT"}, symbols)
+}
+
+func TestRSHistoryGetMultiSymbolPartial(t *testing.T) {
+	t.Parallel()
+	server := jsonServer(stockResponseFixture())
+	defer server.Close()
+	c := testClient(t, server)
+
+	var buf bytes.Buffer
+	cmd := RSHistoryGetCommand(c, &buf)
+	require.NoError(t, runTestCommand(t, cmd, "get", "AAPL", "MISSING"))
+
+	result := parseJSONEnvelope(t, &buf)
+	data, ok := result["data"].(map[string]any)
+	require.True(t, ok, "partial RS history data should be keyed by symbol")
+	assert.Contains(t, data, "AAPL")
+	assert.NotContains(t, data, "MISSING")
+
+	errors, ok := result["errors"].([]any)
+	require.True(t, ok, "partial envelope should include errors")
+	assert.Equal(t, []any{"MISSING: symbol not found"}, errors)
+}
+
+func TestRSHistoryGetMultiSymbolPartialMissingMiddle(t *testing.T) {
+	t.Parallel()
+	server := jsonServer(rsHistoryMissingMiddleResponseFixture())
+	defer server.Close()
+	c := testClient(t, server)
+
+	var buf bytes.Buffer
+	cmd := RSHistoryGetCommand(c, &buf)
+	require.NoError(t, runTestCommand(t, cmd, "get", "AAPL", "MISSING", "MSFT"))
+
+	result := parseJSONEnvelope(t, &buf)
+	data, ok := result["data"].(map[string]any)
+	require.True(t, ok, "partial RS history data should be keyed by response symbol")
+	assert.Contains(t, data, "AAPL")
+	assert.Contains(t, data, "MSFT")
+	assert.NotContains(t, data, "MISSING")
+
+	aapl, ok := data["AAPL"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "AAPL", aapl["symbol"])
+	msft, ok := data["MSFT"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "MSFT", msft["symbol"])
+
+	errors, ok := result["errors"].([]any)
+	require.True(t, ok, "partial envelope should include errors")
+	assert.Equal(t, []any{"MISSING: symbol not found"}, errors)
+}
+
 func TestRSHistoryGetSymbolNotFound(t *testing.T) {
 	t.Parallel()
 	server := jsonServer(emptyMarketDataFixture())

--- a/internal/commands/skills_generate_test.go
+++ b/internal/commands/skills_generate_test.go
@@ -136,12 +136,23 @@ func TestSkillsGenerateCommand(t *testing.T) {
 		if !bytes.Contains(content, []byte("marketsurge-agent stock analyze --tickers AAPL,NVDA,TSLA --compact --flat")) {
 			t.Error("Token-efficient analyze example not found in stock.md")
 		}
+		if !bytes.Contains(content, []byte("marketsurge-agent stock analyze --summary AAPL NVDA TSLA")) {
+			t.Error("Summary analyze example not found in stock.md")
+		}
 
 		// Verify token-efficient analyze parameters are generated from the template.
-		expectedParameters := []string{"tickers (optional)", "compact (optional)", "flat (optional)"}
+		expectedParameters := []string{"tickers (optional)", "compact (optional)", "summary (optional)", "flat (optional)"}
 		for _, parameter := range expectedParameters {
 			if !bytes.Contains(content, []byte(parameter)) {
 				t.Errorf("Expected analyze parameter %q not found in stock.md", parameter)
+			}
+		}
+
+		// Verify summary mode guidance is generated from the template.
+		expectedSummaryFields := []string{"Metadata mode is summary", "base_depth_percent", "avg_dollar_volume", "funds_float_percent"}
+		for _, field := range expectedSummaryFields {
+			if !bytes.Contains(content, []byte(field)) {
+				t.Errorf("Expected summary guidance %q not found in stock.md", field)
 			}
 		}
 
@@ -159,6 +170,43 @@ func TestSkillsGenerateCommand(t *testing.T) {
 		}
 
 		t.Logf("stock.md content length: %d bytes", len(contentStr))
+	})
+
+	t.Run("generates rs history multi-symbol guidance", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		outputDir := filepath.Join(tmpDir, "skills")
+
+		var buf bytes.Buffer
+		cmd := SkillsGenerateCommand(&buf)
+
+		ctx := t.Context()
+		err := cmd.Action(ctx, &cli.Command{
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:  "output-dir",
+					Value: outputDir,
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		rsHistoryFile := filepath.Join(outputDir, "rs-history.md")
+		content, err := os.ReadFile(rsHistoryFile)
+		require.NoError(t, err)
+
+		expectedPhrases := []string{
+			"one or more stocks",
+			"symbols (required)",
+			"marketsurge-agent rs-history get AAPL NVDA",
+			"multi-symbol output is keyed by ticker",
+			`"symbols": ["AAPL", "NVDA"]`,
+		}
+		for _, phrase := range expectedPhrases {
+			if !bytes.Contains(content, []byte(phrase)) {
+				t.Errorf("Expected RS history guidance %q not found in rs-history.md", phrase)
+			}
+		}
 	})
 
 	t.Run("uses custom output directory", func(t *testing.T) {

--- a/internal/commands/skills_templates.go
+++ b/internal/commands/skills_templates.go
@@ -21,12 +21,12 @@ Stock data now includes valuation ratios, risk metrics, short interest data, bas
 - symbol (required): Stock ticker symbol, e.g. AAPL, NVDA, TSLA
 
 **Example:**
-` + "```" + `bash
+` + "`" + `` + "`" + `` + "`" + `bash
 marketsurge-agent stock get AAPL
-` + "```" + `
+` + "`" + `` + "`" + `` + "`" + `
 
 **Expected Output Shape:**
-` + "```" + `json
+` + "`" + `` + "`" + `` + "`" + `json
 {
   "symbol": "AAPL",
   "ratings": {
@@ -39,7 +39,7 @@ marketsurge-agent stock get AAPL
     "eps": 5.28
   }
 }
-` + "```" + `
+` + "`" + `` + "`" + `` + "`" + `
 
 ### analyze_stock
 Analyze a stock with comprehensive data from MarketSurge.
@@ -52,17 +52,19 @@ Stock data now includes valuation ratios, risk metrics, short interest data, bas
 **Parameters:**
 - symbols (required): One or more stock ticker symbols separated by spaces, e.g. AAPL NVDA TSLA. Each symbol is fetched concurrently.
 - tickers (optional): Comma-separated stock ticker symbols, e.g. AAPL,NVDA,TSLA. Useful for larger agent batch comparisons.
-- compact (optional): Remove formatted string fields such as market_cap_formatted. Raw numeric values remain when the API provides them.
+- compact (optional): Remove duplicate formatted string fields such as market_cap_formatted while keeping raw numeric values.
+- summary (optional): Return compact screening fields for ranking many symbols. Includes ratings, blue dot/ant flags, base type/stage/pivot/depth, industry group RS, up/down volume, funds float percent, ATR percent, and average dollar volume. Metadata mode is summary.
 - flat (optional): Flatten each analysis result inside the standard JSON envelope for lower-token parsing.
 
 **Example:**
-` + "```" + `bash
+` + "`" + `` + "`" + `` + "`" + `bash
 marketsurge-agent stock analyze AAPL NVDA
+marketsurge-agent stock analyze --summary AAPL NVDA TSLA
 marketsurge-agent stock analyze --tickers AAPL,NVDA,TSLA --compact --flat
-` + "```" + `
+` + "`" + `` + "`" + `` + "`" + `
 
 **Expected Output Shape:**
-` + "```" + `json
+` + "`" + `` + "`" + `` + "`" + `json
 {
   "symbol": "AAPL",
   "stock": { ... },
@@ -70,7 +72,9 @@ marketsurge-agent stock analyze --tickers AAPL,NVDA,TSLA --compact --flat
   "ownership": { ... },
   "errors": []
 }
-` + "```" + `
+` + "`" + `` + "`" + `` + "`" + `
+
+With ` + "`" + `--summary` + "`" + `, each result is a small ranking object with keys such as ` + "`" + `symbol` + "`" + `, ` + "`" + `composite` + "`" + `, ` + "`" + `eps` + "`" + `, ` + "`" + `rs` + "`" + `, ` + "`" + `ad` + "`" + `, ` + "`" + `smr` + "`" + `, ` + "`" + `blue_dot` + "`" + `, ` + "`" + `ant_signal` + "`" + `, ` + "`" + `base_type` + "`" + `, ` + "`" + `base_stage` + "`" + `, ` + "`" + `pivot` + "`" + `, ` + "`" + `base_depth_percent` + "`" + `, ` + "`" + `industry_group_rs` + "`" + `, ` + "`" + `up_down_volume` + "`" + `, ` + "`" + `atr_percent` + "`" + `, ` + "`" + `avg_dollar_volume` + "`" + `, and ` + "`" + `funds_float_percent` + "`" + `.
 
 With ` + "`" + `--flat` + "`" + `, nested stock fields are emitted as single-level keys, for example ` + "`" + `stock.pricing.market_cap` + "`" + ` becomes ` + "`" + `pricing_market_cap` + "`" + `.
 
@@ -80,8 +84,9 @@ Technical analysis fields include ` + "`" + `stock.base_pattern` + "`" + ` for p
 
 1. Use **get_stock** for quick lookups of current ratings and pricing
 2. Use **analyze_stock** when you need comprehensive data including fundamentals and ownership
-3. Combine with chart history for technical analysis
-4. Use RS rating to identify relative strength vs market
+3. Use **analyze_stock --summary** to rank many candidates with minimal token usage
+4. Combine with chart history for technical analysis
+5. Use RS rating to identify relative strength vs market
 `,
 
 	"fundamental": `# Fundamental Data Skill
@@ -186,45 +191,53 @@ marketsurge-agent ownership get AAPL
 	"rs-history": `# RS Rating History Skill
 
 ## Overview
-Fetch reported relative strength rating history for a stock from MarketSurge.
+Fetch reported relative strength rating history for one or more stocks from MarketSurge.
 
 ## Tools
 
 ### get_rs_rating_history
-Fetch reported relative strength rating history for a stock from MarketSurge.
+Fetch reported relative strength rating history for one or more stocks from MarketSurge.
 
 Returns a time series of RS rating snapshots showing relative price performance
 vs the market over various periods. Includes the rs_line_new_high flag indicating
 when the RS line hits a new high ahead of price.
 
 **Parameters:**
-- symbol (required): Stock ticker symbol, e.g. AAPL, NVDA, TSLA
+- symbols (required): One or more stock ticker symbols separated by spaces, e.g. AAPL NVDA TSLA
 
 **Example:**
-` + "`" + `bash
-marketsurge-agent rs-history get AAPL
-` + "`" + `
+` + "`" + `` + "`" + `` + "`" + `bash
+marketsurge-agent rs-history get AAPL NVDA
+` + "`" + `` + "`" + `` + "`" + `
 
 **Expected Output Shape:**
-` + "`" + `json
+` + "`" + `` + "`" + `` + "`" + `json
 {
-  "symbol": "AAPL",
-  "rs_history": [
-    {
-      "date": "2024-04-21",
-      "rs_rating": 78,
+  "data": {
+    "AAPL": {
+      "symbol": "AAPL",
+      "ratings": [
+        {
+          "period": "Current",
+          "value": 78
+        }
+      ],
       "rs_line_new_high": true
     }
-  ]
+  },
+  "metadata": {
+    "symbols": ["AAPL", "NVDA"]
+  }
 }
-` + "`" + `
+` + "`" + `` + "`" + `` + "`" + `
 
 ## Workflow Guidance
 
 1. Track RS rating trends over time
-2. RS line new highs indicate strong relative strength
-3. Compare RS rating with price action for divergences
-4. Use for identifying leading stocks in uptrends
+2. Pass multiple symbols at once when comparing candidates; multi-symbol output is keyed by ticker
+3. RS line new highs indicate strong relative strength
+4. Compare RS rating with price action for divergences
+5. Use for identifying leading stocks in uptrends
 `,
 
 	"chart": `# Chart Data Skill

--- a/internal/commands/stock_analyze.go
+++ b/internal/commands/stock_analyze.go
@@ -37,6 +37,7 @@ func StockAnalyzeCommand(c *client.Client, w io.Writer) *cli.Command {
 			&cli.StringFlag{Name: "tickers", Usage: "Comma-separated ticker symbols to analyze"},
 			&cli.BoolFlag{Name: "compact", Usage: "Remove formatted string fields from analysis data"},
 			&cli.BoolFlag{Name: "flat", Usage: "Flatten each analysis result for token-efficient agent parsing"},
+			&cli.BoolFlag{Name: "summary", Usage: "Return compact screening fields for ranking multi-symbol candidates"},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			symbols := analyzeSymbols(cmd)
@@ -65,6 +66,9 @@ func StockAnalyzeCommand(c *client.Client, w io.Writer) *cli.Command {
 			wg.Wait()
 
 			meta := analyzeMetadata(symbols)
+			if cmd.Bool("summary") {
+				meta["mode"] = "summary"
+			}
 
 			// Determine if we have any data at all.
 			hasData := false
@@ -81,7 +85,7 @@ func StockAnalyzeCommand(c *client.Client, w io.Writer) *cli.Command {
 				return err
 			}
 
-			data, err := transformAnalysisOutput(results, cmd.Bool("compact"), cmd.Bool("flat"))
+			data, err := transformAnalysisOutput(results, cmd.Bool("compact"), cmd.Bool("flat"), cmd.Bool("summary"))
 			if err != nil {
 				return fmt.Errorf("transform analysis output: %w", err)
 			}
@@ -176,9 +180,14 @@ func analyzeMetadata(symbols []string) map[string]any {
 
 // transformAnalysisOutput applies optional token-efficiency transforms while
 // preserving the existing single-symbol object vs. multi-symbol array contract.
-func transformAnalysisOutput(results []AnalysisResult, compact, flat bool) (any, error) {
+func transformAnalysisOutput(results []AnalysisResult, compact, flat, summary bool) (any, error) {
 	transformed := make([]any, 0, len(results))
 	for _, result := range results {
+		if summary {
+			transformed = append(transformed, analysisSummaryMap(result))
+			continue
+		}
+
 		data, err := analysisResultMap(result)
 		if err != nil {
 			return nil, err
@@ -196,6 +205,68 @@ func transformAnalysisOutput(results []AnalysisResult, compact, flat bool) (any,
 		return transformed[0], nil
 	}
 	return transformed, nil
+}
+
+func analysisSummaryMap(result AnalysisResult) map[string]any {
+	data := map[string]any{"symbol": result.Symbol}
+	if result.Stock == nil {
+		return data
+	}
+
+	addRatingSummary(data, result.Stock.Ratings)
+	addSignalSummary(data, result.Stock.Signals)
+	addBaseSummary(data, result.Stock.BasePattern)
+	addScreeningMetrics(data, result.Stock)
+	return data
+}
+
+func addRatingSummary(data map[string]any, ratings *models.Ratings) {
+	if ratings == nil {
+		return
+	}
+	addPtrValue(data, "composite", ratings.Composite)
+	addPtrValue(data, "eps", ratings.EPS)
+	addPtrValue(data, "rs", ratings.RS)
+	addPtrValue(data, "ad", ratings.AD)
+	addPtrValue(data, "smr", ratings.SMR)
+}
+
+func addSignalSummary(data map[string]any, signals *models.Signals) {
+	if signals == nil {
+		return
+	}
+	addPtrValue(data, "blue_dot", signals.BlueDot)
+	addPtrValue(data, "ant_signal", signals.AntSignal)
+}
+
+func addBaseSummary(data map[string]any, base *models.BasePattern) {
+	if base == nil {
+		return
+	}
+	addPtrValue(data, "base_type", base.PatternType)
+	addPtrValue(data, "base_stage", base.BaseStage)
+	addPtrValue(data, "pivot", base.PivotPrice)
+	addPtrValue(data, "base_depth_percent", base.BaseDepthPercent)
+}
+
+func addScreeningMetrics(data map[string]any, stock *models.StockData) {
+	if stock.Company != nil {
+		addPtrValue(data, "industry_group_rs", stock.Company.IndustryGroupRS)
+	}
+	if stock.Pricing != nil {
+		addPtrValue(data, "up_down_volume", stock.Pricing.UpDownVolumeRatio)
+		addPtrValue(data, "atr_percent", stock.Pricing.ATRPercent21D)
+		addPtrValue(data, "avg_dollar_volume", stock.Pricing.AvgDollarVolume50D)
+	}
+	if stock.Ownership != nil {
+		addPtrValue(data, "funds_float_percent", stock.Ownership.FundsFloatPct)
+	}
+}
+
+func addPtrValue[T any](data map[string]any, key string, value *T) {
+	if value != nil {
+		data[key] = *value
+	}
 }
 
 func analysisResultMap(result AnalysisResult) (map[string]any, error) {

--- a/internal/commands/stock_analyze_test.go
+++ b/internal/commands/stock_analyze_test.go
@@ -203,6 +203,48 @@ func TestStockAnalyzeCompactFlatOutput(t *testing.T) {
 	assert.NotContains(t, data, "pricing_forward_price_to_earnings_ratio_formatted")
 }
 
+func TestStockAnalyzeSummaryOutput(t *testing.T) {
+	t.Parallel()
+	server := jsonServer(stockResponseFixture())
+	defer server.Close()
+	c := testClient(t, server)
+
+	var buf bytes.Buffer
+	cmd := StockAnalyzeCommand(c, &buf)
+	require.NoError(t, runTestCommand(t, cmd, "analyze", "--summary", "AAPL", "MSFT"))
+
+	result := parseJSONEnvelope(t, &buf)
+	data, ok := result["data"].([]any)
+	require.True(t, ok, "summary multi-symbol data should be an array")
+	assert.Len(t, data, 2)
+
+	first, ok := data[0].(map[string]any)
+	require.True(t, ok, "summary item should be an object")
+	assert.Equal(t, "AAPL", first["symbol"])
+	assert.Equal(t, float64(99), first["composite"])
+	assert.Equal(t, float64(95), first["eps"])
+	assert.Equal(t, float64(90), first["rs"])
+	assert.Equal(t, "B", first["ad"])
+	assert.Equal(t, "A", first["smr"])
+	assert.Equal(t, true, first["blue_dot"])
+	assert.Equal(t, true, first["ant_signal"])
+	assert.Equal(t, "Cup With Handle", first["base_type"])
+	assert.Equal(t, "STAGE_2", first["base_stage"])
+	assert.Equal(t, 199.99, first["pivot"])
+	assert.Equal(t, 18.5, first["base_depth_percent"])
+	assert.Equal(t, float64(95), first["industry_group_rs"])
+	assert.Equal(t, 1.2, first["up_down_volume"])
+	assert.Equal(t, float64(60), first["funds_float_percent"])
+	assert.Equal(t, 2.3, first["atr_percent"])
+	assert.Equal(t, float64(5000000), first["avg_dollar_volume"])
+	assert.NotContains(t, first, "stock")
+	assert.NotContains(t, first, "fundamentals")
+	assert.NotContains(t, first, "ownership")
+
+	meta, _ := result["metadata"].(map[string]any)
+	assert.Equal(t, "summary", meta["mode"])
+}
+
 func TestStockAnalyzeMissingSymbol(t *testing.T) {
 	t.Parallel()
 	server := jsonServer(`{}`)

--- a/internal/commands/symbol_command.go
+++ b/internal/commands/symbol_command.go
@@ -23,8 +23,6 @@ func requireSymbol(cmd *cli.Command) (string, error) {
 
 // symbolGetCommand builds a CLI command that fetches data for a single symbol.
 // It handles argument validation, calls the fetcher, and writes the JSON envelope.
-//
-//nolint:unparam // name is always "get" today but kept as a parameter for future subcommands
 func symbolGetCommand(w io.Writer, name, usage string, fetch symbolFetcher) *cli.Command {
 	return &cli.Command{
 		Name:      name,

--- a/queries/rs_rating_ri_panel.graphql
+++ b/queries/rs_rating_ri_panel.graphql
@@ -4,6 +4,10 @@ query RSRatingRIPanel(
 ) {
   marketData(symbols: $symbols, symbolDialectType: $symbolDialectType) {
     id
+    originRequest {
+      fromDialect
+      symbol
+    }
     ratings {
       rsRating {
         letterValue

--- a/skills/rs-history.md
+++ b/skills/rs-history.md
@@ -1,42 +1,50 @@
 # RS Rating History Skill
 
 ## Overview
-Fetch reported relative strength rating history for a stock from MarketSurge.
+Fetch reported relative strength rating history for one or more stocks from MarketSurge.
 
 ## Tools
 
 ### get_rs_rating_history
-Fetch reported relative strength rating history for a stock from MarketSurge.
+Fetch reported relative strength rating history for one or more stocks from MarketSurge.
 
 Returns a time series of RS rating snapshots showing relative price performance
 vs the market over various periods. Includes the rs_line_new_high flag indicating
 when the RS line hits a new high ahead of price.
 
 **Parameters:**
-- symbol (required): Stock ticker symbol, e.g. AAPL, NVDA, TSLA
+- symbols (required): One or more stock ticker symbols separated by spaces, e.g. AAPL NVDA TSLA
 
 **Example:**
-`bash
-marketsurge-agent rs-history get AAPL
-`
+```bash
+marketsurge-agent rs-history get AAPL NVDA
+```
 
 **Expected Output Shape:**
-`json
+```json
 {
-  "symbol": "AAPL",
-  "rs_history": [
-    {
-      "date": "2024-04-21",
-      "rs_rating": 78,
+  "data": {
+    "AAPL": {
+      "symbol": "AAPL",
+      "ratings": [
+        {
+          "period": "Current",
+          "value": 78
+        }
+      ],
       "rs_line_new_high": true
     }
-  ]
+  },
+  "metadata": {
+    "symbols": ["AAPL", "NVDA"]
+  }
 }
-`
+```
 
 ## Workflow Guidance
 
 1. Track RS rating trends over time
-2. RS line new highs indicate strong relative strength
-3. Compare RS rating with price action for divergences
-4. Use for identifying leading stocks in uptrends
+2. Pass multiple symbols at once when comparing candidates; multi-symbol output is keyed by ticker
+3. RS line new highs indicate strong relative strength
+4. Compare RS rating with price action for divergences
+5. Use for identifying leading stocks in uptrends

--- a/skills/stock.md
+++ b/skills/stock.md
@@ -49,11 +49,13 @@ Stock data now includes valuation ratios, risk metrics, short interest data, bas
 - symbols (required): One or more stock ticker symbols separated by spaces, e.g. AAPL NVDA TSLA. Each symbol is fetched concurrently.
 - tickers (optional): Comma-separated stock ticker symbols, e.g. AAPL,NVDA,TSLA. Useful for larger agent batch comparisons.
 - compact (optional): Remove duplicate formatted string fields such as market_cap_formatted while keeping raw numeric values.
+- summary (optional): Return compact screening fields for ranking many symbols. Includes ratings, blue dot/ant flags, base type/stage/pivot/depth, industry group RS, up/down volume, funds float percent, ATR percent, and average dollar volume. Metadata mode is summary.
 - flat (optional): Flatten each analysis result inside the standard JSON envelope for lower-token parsing.
 
 **Example:**
 ```bash
 marketsurge-agent stock analyze AAPL NVDA
+marketsurge-agent stock analyze --summary AAPL NVDA TSLA
 marketsurge-agent stock analyze --tickers AAPL,NVDA,TSLA --compact --flat
 ```
 
@@ -68,6 +70,8 @@ marketsurge-agent stock analyze --tickers AAPL,NVDA,TSLA --compact --flat
 }
 ```
 
+With `--summary`, each result is a small ranking object with keys such as `symbol`, `composite`, `eps`, `rs`, `ad`, `smr`, `blue_dot`, `ant_signal`, `base_type`, `base_stage`, `pivot`, `base_depth_percent`, `industry_group_rs`, `up_down_volume`, `atr_percent`, `avg_dollar_volume`, and `funds_float_percent`.
+
 With `--flat`, nested stock fields are emitted as single-level keys, for example `stock.pricing.market_cap` becomes `pricing_market_cap`.
 
 Technical analysis fields include `stock.base_pattern` for pattern type, base stage, pivot price, base length, depth, and volume at pivot, plus `stock.signals` for blue dot and ant signal flags.
@@ -76,5 +80,6 @@ Technical analysis fields include `stock.base_pattern` for pattern type, base st
 
 1. Use **get_stock** for quick lookups of current ratings and pricing
 2. Use **analyze_stock** when you need comprehensive data including fundamentals and ownership
-3. Combine with chart history for technical analysis
-4. Use RS rating to identify relative strength vs market
+3. Use **analyze_stock --summary** to rank many candidates with minimal token usage
+4. Combine with chart history for technical analysis
+5. Use RS rating to identify relative strength vs market


### PR DESCRIPTION
## Summary
- Add `stock analyze --summary` for compact screening fields across multi-symbol analysis.
- Let `rs-history get` accept multiple symbols and return multi-symbol data keyed by ticker.
- Sync generated skill docs/templates and add regression coverage for summary output and missing middle RS-history symbols.

Closes #30
Closes #31

## Verification
- `go test -v -race ./...`
- `go build ./cmd/marketsurge-agent`
- `golangci-lint run ./...`
- `git diff --check`