### PR TITLE
refactor: use resty v3 auto-parsing instead of manual json.Unmarshal

### DIFF
--- a/internal/auth/exchange.go
+++ b/internal/auth/exchange.go
@@ -3,7 +3,6 @@ package auth
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -33,7 +32,8 @@ func ExchangeJWT(ctx context.Context, cookies []*http.Cookie) (string, error) {
 
 	rc.SetTimeout(constants.HTTPTimeout).SetResponseBodyLimit(constants.MaxResponseSize)
 
-	req := rc.R().SetContext(ctx)
+	var data clientResponse
+	req := rc.R().SetContext(ctx).SetResult(&data)
 
 	// Set required headers from constants.
 	for key, values := range constants.JWTExchangeHeaders() {
@@ -53,20 +53,10 @@ func ExchangeJWT(ctx context.Context, cookies []*http.Cookie) (string, error) {
 		)
 	}
 
-	if resp.StatusCode() < http.StatusOK || resp.StatusCode() >= http.StatusMultipleChoices {
+	if !resp.IsSuccess() {
 		return "", errors.NewAuthenticationError(
 			fmt.Sprintf("JWT exchange failed: HTTP %d", resp.StatusCode()),
 			nil,
-		)
-	}
-
-	body := resp.Bytes()
-
-	var data clientResponse
-	if err := json.Unmarshal(body, &data); err != nil {
-		return "", errors.NewAuthenticationError(
-			fmt.Sprintf("failed to parse JWT exchange response: %s", err),
-			err,
 		)
 	}
 

--- a/internal/auth/exchange_test.go
+++ b/internal/auth/exchange_test.go
@@ -204,7 +204,7 @@ func TestExchangeJWT_InvalidJSON(t *testing.T) {
 
 	var authErr *errors.AuthenticationError
 	require.ErrorAs(t, err, &authErr)
-	assert.Contains(t, authErr.Message, "failed to parse JWT exchange response")
+	assert.Contains(t, authErr.Message, "JWT exchange request failed")
 }
 
 func TestExchangeJWT_UsesGETMethod(t *testing.T) {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -6,7 +6,6 @@ package client
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"mime"
 	"net/http"
@@ -76,7 +75,8 @@ func (c *Client) Close() error {
 
 // Execute sends a GraphQL request and returns the decoded response body.
 func (c *Client) Execute(ctx context.Context, payload Request) (map[string]any, error) {
-	req := c.RestyClient.R().SetContext(ctx)
+	var raw map[string]any
+	req := c.RestyClient.R().SetContext(ctx).SetResult(&raw)
 
 	headers := constants.GraphQLHeaders()
 	for key, values := range headers {
@@ -91,10 +91,9 @@ func (c *Client) Execute(ctx context.Context, payload Request) (map[string]any, 
 	if err != nil {
 		return nil, fmt.Errorf("execute graphql request: %w", err)
 	}
-	body := resp.Bytes()
 
-	if resp.StatusCode() < http.StatusOK || resp.StatusCode() >= http.StatusMultipleChoices {
-		return nil, mapHTTPError(resp.StatusCode(), string(body), nil)
+	if !resp.IsSuccess() {
+		return nil, mapHTTPError(resp.StatusCode(), string(resp.Bytes()), nil)
 	}
 
 	// Validate Content-Type before attempting JSON decode. Without this,
@@ -103,17 +102,12 @@ func (c *Client) Execute(ctx context.Context, payload Request) (map[string]any, 
 	if ct := resp.Header().Get("Content-Type"); ct != "" {
 		mediaType, _, err := mime.ParseMediaType(ct)
 		if err == nil && mediaType != "application/json" {
-			preview := string(body)
+			preview := string(resp.Bytes())
 			if len(preview) > 200 {
 				preview = preview[:200] + "..."
 			}
 			return nil, fmt.Errorf("unexpected Content-Type %q (expected application/json): %s", ct, preview)
 		}
-	}
-
-	var raw map[string]any
-	if err := json.Unmarshal(body, &raw); err != nil {
-		return nil, fmt.Errorf("decode graphql response: %w", err)
 	}
 
 	if err := mapGraphQLError(raw); err != nil {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -129,6 +129,7 @@ func TestExecuteRejectsUnexpectedContentType(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unexpected Content-Type")
 	assert.Contains(t, err.Error(), "text/html")
+	assert.Contains(t, err.Error(), "Service Unavailable")
 }
 
 func TestExecuteAcceptsJSONWithCharset(t *testing.T) {


### PR DESCRIPTION
## Summary

- Replace manual `json.Unmarshal` + status range checks with resty v3's `SetResult()` auto-parsing and `IsSuccess()` helpers in `Execute()` and `ExchangeJWT()`
- Remove `encoding/json` import from both files (no longer needed)
- Move `resp.Bytes()` calls to lazy evaluation (only in error branches) since auto-parse consumes the body on 2xx

Stacks on #35 (transport-only swap, now merged).

## Details

**`internal/auth/exchange.go`**: `SetResult(&data)` auto-unmarshals the `clientResponse` struct on success. `!resp.IsSuccess()` replaces the manual `StatusCode()` range check (correctly catches 3xx). The separate `json.Unmarshal` block and its error wrapping are removed.

**`internal/client/client.go`**: `SetResult(&raw)` auto-unmarshals the GraphQL response map on success. `resp.Bytes()` is now called lazily only in the `!resp.IsSuccess()` error branch and the Content-Type mismatch branch (safe because auto-parse skips on wrong CT, leaving bytes available). Content-Type validation and `mapGraphQLError()` are unchanged.

**`internal/auth/exchange_test.go`**: One assertion updated in `TestExchangeJWT_InvalidJSON` to match the new error wrapping path (`"JWT exchange request failed"` instead of `"failed to parse JWT exchange response"`). Error type is preserved.

## Verification

- All 143 tests pass (`go test -v -race ./...`)
- `golangci-lint run` clean
- Tested against live MarketSurge API: stock, fundamental, ownership, rs-history, chart commands all return valid data