### PR TITLE
refactor(cmd): extract option structs for structcli 0.17.0 prep

### DIFF
--- a/cmd/AGENTS.md
+++ b/cmd/AGENTS.md
@@ -58,6 +58,77 @@ func TestFundamentalGet(t *testing.T) {
 }
 ```
 
+### Option struct pattern (structcli bridge)
+
+Commands use option structs to encapsulate flags and validation logic. This pattern bridges the gap between Cobra's flag system and the upcoming structcli migration.
+
+**Canonical 4-step pattern:**
+
+1. Constructor creates `opts := &XxxOptions{}` before the command
+2. `opts.BindFlags(cmd)` registers flags via `StringVar`, `IntVar`, etc. (called after command creation)
+3. RunE calls `opts.FromCommand(cmd)` if pointer fields exist, then `opts.Validate()` if validation exists
+4. RunE accesses `opts.Field` instead of `cmd.Flags().GetXxx()`
+
+**Simplest example (ChartMarkupsOptions):**
+
+```go
+type ChartMarkupsOptions struct {
+    Frequency string
+    SortDir   string
+}
+
+func (o *ChartMarkupsOptions) BindFlags(cmd *cobra.Command) {
+    cmd.Flags().StringVar(&o.Frequency, "frequency", "DAILY", "Chart frequency: DAILY or WEEKLY")
+    cmd.Flags().StringVar(&o.SortDir, "sort-dir", "ASC", "Sort direction: ASC or DESC")
+}
+
+func newChartMarkupsCmd() *cobra.Command {
+    opts := &ChartMarkupsOptions{}
+    cmd := &cobra.Command{
+        Use:   "markups <symbol>",
+        Short: "Get chart markup data for a symbol",
+        RunE: func(cmd *cobra.Command, args []string) error {
+            symbol := args[0]
+            c := ClientFromContext(cmd.Context())
+            data, err := c.GetChartMarkups(cmd.Context(), symbol, opts.Frequency, opts.SortDir)
+            if err != nil {
+                return err
+            }
+            return output.WriteSuccess(cmd.OutOrStdout(), data, output.SymbolMeta(symbol))
+        },
+    }
+    opts.BindFlags(cmd)
+    return cmd
+}
+```
+
+**Methods by command:**
+
+- `BindFlags()` only: ChartMarkupsOptions, StockAnalyzeOptions, CatalogListOptions, RootOptions
+- `BindFlags()` + `Validate()`: ChartHistoryOptions
+- `BindFlags()` + `Validate()` + transformation method: ChartHistoryOptions (also has `ResolveDates()`)
+- `BindFlags()` + `FromCommand()` + `Validate()` + helper method: CatalogRunOptions (also has `Filters()`)
+- `BindFlags()` + transformation method: StockAnalyzeOptions (also has `MergeSymbols()`)
+
+**Pointer fields and FromCommand():**
+
+Only CatalogRunOptions uses pointer fields (`MinComposite *int`, `MinRS *int`) to distinguish "not set" from "set to zero". These require `FromCommand(cmd)` to detect `Changed()` and populate the pointers:
+
+```go
+func (o *CatalogRunOptions) FromCommand(cmd *cobra.Command) {
+    if cmd.Flags().Changed("min-composite") {
+        v, _ := cmd.Flags().GetInt("min-composite")
+        o.MinComposite = &v
+    }
+}
+```
+
+This is the only place where `cmd.Flags().GetXxx()` is acceptable in RunE.
+
+**Structcli migration path:**
+
+When migrating to structcli, struct fields become `flag:"name"` tagged, `BindFlags()` is replaced by `structcli.Bind()`, and `Validate()` signature changes to `Validate(ctx context.Context) []error`. The RunE logic remains the same: call `FromCommand()` if needed, then `Validate()`, then use `opts.Field` directly.
+
 ## Adding a new command
 
 1. Create `cmd/<group>.go` with constructor function and init()

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -86,44 +86,114 @@ func newCatalogCmd() *cobra.Command {
 	return cmd
 }
 
+// CatalogRunOptions holds flags for the catalog run command.
+type CatalogRunOptions struct {
+	Kind          string
+	ReportID      int
+	WatchlistID   int64
+	CoachScreenID string
+	Limit         int
+	Offset        int
+	Fields        []string
+	MinComposite  *int
+	MinRS         *int
+	ExcludeSPACs  bool
+}
+
+// BindFlags registers catalog run flags on the given command.
+func (o *CatalogRunOptions) BindFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&o.Kind, "kind", "", "Catalog kind (required): report, watchlist, or coach_screen")
+	cmd.Flags().IntVar(&o.ReportID, "report-id", 0, "Report ID (required when --kind=report)")
+	cmd.Flags().Int64Var(&o.WatchlistID, "watchlist-id", 0, "Watchlist ID (required when --kind=watchlist)")
+	cmd.Flags().StringVar(&o.CoachScreenID, "coach-screen-id", "", "Coach screen ID (required when --kind=coach_screen)")
+	cmd.Flags().IntVar(&o.Limit, "limit", defaultCatalogRunLimit, "Maximum number of entries to return")
+	cmd.Flags().IntVar(&o.Offset, "offset", 0, "Starting offset for pagination")
+	cmd.Flags().StringSliceVar(&o.Fields, "fields", []string{}, "Optional fields to include in each entry")
+	cmd.Flags().BoolVar(&o.ExcludeSPACs, "exclude-spacs", false, "Exclude SPAC/blank-check entries")
+	cmd.Flags().Int("min-composite", 0, "Minimum composite rating filter")
+	cmd.Flags().Int("min-rs", 0, "Minimum RS rating filter")
+}
+
+// FromCommand populates pointer fields that require cobra's Changed() detection.
+func (o *CatalogRunOptions) FromCommand(cmd *cobra.Command) {
+	if cmd.Flags().Changed("min-composite") {
+		v, _ := cmd.Flags().GetInt("min-composite")
+		o.MinComposite = &v
+	}
+	if cmd.Flags().Changed("min-rs") {
+		v, _ := cmd.Flags().GetInt("min-rs")
+		o.MinRS = &v
+	}
+}
+
+// Validate checks that the catalog run options are consistent and complete.
+func (o *CatalogRunOptions) Validate() error {
+	if o.Kind == "" {
+		return mserrors.NewValidationError("kind is required", nil)
+	}
+
+	kind, err := parseCatalogKind(o.Kind)
+	if err != nil {
+		return err
+	}
+	if kind == nil {
+		return mserrors.NewValidationError("kind is required", nil)
+	}
+	if *kind == models.CatalogKindScreen {
+		return mserrors.NewValidationError("screens cannot be run directly, use catalog list to view them", nil)
+	}
+
+	switch *kind {
+	case models.CatalogKindReport:
+		if o.ReportID == 0 {
+			return mserrors.NewValidationError("report-id is required when kind=report", nil)
+		}
+	case models.CatalogKindWatchlist:
+		if o.WatchlistID == 0 {
+			return mserrors.NewValidationError("watchlist-id is required when kind=watchlist", nil)
+		}
+	case models.CatalogKindCoachScreen:
+		if o.CoachScreenID == "" {
+			return mserrors.NewValidationError("coach-screen-id is required when kind=coach_screen", nil)
+		}
+	}
+
+	return nil
+}
+
+// Filters returns the filter configuration derived from the options.
+func (o *CatalogRunOptions) Filters() catalogRunFilters {
+	return catalogRunFilters{
+		MinComposite: o.MinComposite,
+		MinRS:        o.MinRS,
+		ExcludeSPACs: o.ExcludeSPACs,
+	}
+}
+
 func newCatalogRunCmd() *cobra.Command {
+	opts := &CatalogRunOptions{}
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Run a catalog report, watchlist, or coach screen",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			kind, err := validateCatalogRunKind(cmd)
-			if err != nil {
+			opts.FromCommand(cmd)
+
+			if err := opts.Validate(); err != nil {
 				return err
 			}
 
-			entries, total, err := runCatalogEntries(cmd.Context(), ClientFromContext(cmd.Context()), cmd, kind)
-			if err != nil {
-				return err
-			}
+			kind, _ := parseCatalogKind(opts.Kind)
 
-			limit, err := cmd.Flags().GetInt("limit")
-			if err != nil {
-				return err
-			}
-			offset, err := cmd.Flags().GetInt("offset")
+			entries, total, err := runCatalogEntries(cmd.Context(), ClientFromContext(cmd.Context()), opts, *kind)
 			if err != nil {
 				return err
 			}
 
 			data := map[string]any{"entries": entries}
-			return output.WriteSuccess(cmd.OutOrStdout(), data, output.CatalogMeta(string(kind), total, limit, offset))
+			return output.WriteSuccess(cmd.OutOrStdout(), data, output.CatalogMeta(string(*kind), total, opts.Limit, opts.Offset))
 		},
 	}
-	cmd.Flags().String("kind", "", "Catalog kind (required): report, watchlist, or coach_screen")
-	cmd.Flags().Int("report-id", 0, "Report ID (required when --kind=report)")
-	cmd.Flags().Int64("watchlist-id", 0, "Watchlist ID (required when --kind=watchlist)")
-	cmd.Flags().String("coach-screen-id", "", "Coach screen ID (required when --kind=coach_screen)")
-	cmd.Flags().Int("limit", defaultCatalogRunLimit, "Maximum number of entries to return")
-	cmd.Flags().Int("offset", 0, "Starting offset for pagination")
-	cmd.Flags().StringSlice("fields", []string{}, "Optional fields to include in each entry")
-	cmd.Flags().Int("min-composite", 0, "Minimum composite rating filter")
-	cmd.Flags().Int("min-rs", 0, "Minimum RS rating filter")
-	cmd.Flags().Bool("exclude-spacs", false, "Exclude SPAC/blank-check entries")
+	opts.BindFlags(cmd)
 	return cmd
 }
 
@@ -133,119 +203,37 @@ type catalogRunFilters struct {
 	ExcludeSPACs bool
 }
 
-func validateCatalogRunKind(cmd *cobra.Command) (models.CatalogKind, error) {
-	value, err := cmd.Flags().GetString("kind")
-	if err != nil {
-		return "", err
-	}
-	if value == "" {
-		return "", mserrors.NewValidationError("kind is required", nil)
-	}
-
-	kind, err := parseCatalogKind(value)
-	if err != nil {
-		return "", err
-	}
-	if kind == nil {
-		return "", mserrors.NewValidationError("kind is required", nil)
-	}
-	if *kind == models.CatalogKindScreen {
-		return "", mserrors.NewValidationError("screens cannot be run directly, use catalog list to view them", nil)
-	}
-
-	return *kind, nil
-}
-
-func optionalIntFlag(cmd *cobra.Command, name string) *int {
-	if !cmd.Flags().Changed(name) {
-		return nil
-	}
-	v, _ := cmd.Flags().GetInt(name)
-	return &v
-}
-
-func runCatalogEntries(ctx context.Context, c *client.Client, cmd *cobra.Command, kind models.CatalogKind) (result any, total int, err error) {
-	filters, err := catalogRunFiltersFromFlags(cmd)
-	if err != nil {
-		return nil, 0, err
-	}
-	limit, err := cmd.Flags().GetInt("limit")
-	if err != nil {
-		return nil, 0, err
-	}
-	offset, err := cmd.Flags().GetInt("offset")
-	if err != nil {
-		return nil, 0, err
-	}
-	fields, err := cmd.Flags().GetStringSlice("fields")
-	if err != nil {
-		return nil, 0, err
-	}
+func runCatalogEntries(ctx context.Context, c *client.Client, opts *CatalogRunOptions, kind models.CatalogKind) (result any, total int, err error) {
+	filters := opts.Filters()
 
 	switch kind {
 	case models.CatalogKindReport:
-		reportID, err := cmd.Flags().GetInt("report-id")
-		if err != nil {
-			return nil, 0, err
-		}
-		if reportID == 0 {
-			return nil, 0, mserrors.NewValidationError("report-id is required when kind=report", nil)
-		}
-
-		result, err := c.RunReport(ctx, reportID)
+		result, err := c.RunReport(ctx, opts.ReportID)
 		if err != nil {
 			return nil, 0, err
 		}
 
 		entries := applyCatalogRunFilters(result.Entries, filters)
-		return projectWatchlistEntries(paginateSlice(entries, limit, offset), fields), len(entries), nil
+		return projectWatchlistEntries(paginateSlice(entries, opts.Limit, opts.Offset), opts.Fields), len(entries), nil
 	case models.CatalogKindWatchlist:
-		watchlistID, err := cmd.Flags().GetInt64("watchlist-id")
-		if err != nil {
-			return nil, 0, err
-		}
-		if watchlistID == 0 {
-			return nil, 0, mserrors.NewValidationError("watchlist-id is required when kind=watchlist", nil)
-		}
-
-		result, err := c.RunWatchlist(ctx, watchlistID)
+		result, err := c.RunWatchlist(ctx, opts.WatchlistID)
 		if err != nil {
 			return nil, 0, err
 		}
 
 		entries := applyCatalogRunFilters(result.Entries, filters)
-		return projectWatchlistEntries(paginateSlice(entries, limit, offset), fields), len(entries), nil
+		return projectWatchlistEntries(paginateSlice(entries, opts.Limit, opts.Offset), opts.Fields), len(entries), nil
 	case models.CatalogKindCoachScreen:
-		coachScreenID, err := cmd.Flags().GetString("coach-screen-id")
-		if err != nil {
-			return nil, 0, err
-		}
-		if coachScreenID == "" {
-			return nil, 0, mserrors.NewValidationError("coach-screen-id is required when kind=coach_screen", nil)
-		}
-
-		result, err := c.RunCoachScreen(ctx, coachScreenID)
+		result, err := c.RunCoachScreen(ctx, opts.CoachScreenID)
 		if err != nil {
 			return nil, 0, err
 		}
 
-		rows := paginateSlice(result.Rows, limit, offset)
+		rows := paginateSlice(result.Rows, opts.Limit, opts.Offset)
 		return rows, len(result.Rows), nil
 	default:
 		return nil, 0, mserrors.NewValidationError("kind must be one of: watchlist, screen, report, coach_screen", nil)
 	}
-}
-
-func catalogRunFiltersFromFlags(cmd *cobra.Command) (catalogRunFilters, error) {
-	excludeSPACs, err := cmd.Flags().GetBool("exclude-spacs")
-	if err != nil {
-		return catalogRunFilters{}, err
-	}
-	return catalogRunFilters{
-		MinComposite: optionalIntFlag(cmd, "min-composite"),
-		MinRS:        optionalIntFlag(cmd, "min-rs"),
-		ExcludeSPACs: excludeSPACs,
-	}, nil
 }
 
 func applyCatalogRunFilters(entries []models.WatchlistEntry, filters catalogRunFilters) []models.WatchlistEntry {
@@ -354,17 +342,23 @@ func normalizeWatchlistField(field string) (string, bool) {
 	return "", false
 }
 
+// CatalogListOptions holds flags for the catalog list command.
+type CatalogListOptions struct {
+	Kind string
+}
+
+// BindFlags registers catalog list flags on the given command.
+func (o *CatalogListOptions) BindFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&o.Kind, "kind", "", "Catalog kind (required): report, watchlist, coach_screen, screen")
+}
+
 func newCatalogListCmd() *cobra.Command {
+	opts := &CatalogListOptions{}
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List catalog entries",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			kindStr, err := cmd.Flags().GetString("kind")
-			if err != nil {
-				return err
-			}
-
-			kind, err := parseCatalogKind(kindStr)
+			kind, err := parseCatalogKind(opts.Kind)
 			if err != nil {
 				return err
 			}
@@ -376,14 +370,14 @@ func newCatalogListCmd() *cobra.Command {
 			}
 
 			data := map[string]any{"entries": catalog.Entries}
-			meta := output.CatalogMeta(kindStr, len(catalog.Entries), 0, 0)
+			meta := output.CatalogMeta(opts.Kind, len(catalog.Entries), 0, 0)
 			if len(catalog.Errors) > 0 {
 				return output.WritePartial(cmd.OutOrStdout(), data, catalog.Errors, meta)
 			}
 			return output.WriteSuccess(cmd.OutOrStdout(), data, meta)
 		},
 	}
-	cmd.Flags().String("kind", "", "Catalog kind (required): report, watchlist, coach_screen, screen")
+	opts.BindFlags(cmd)
 	return cmd
 }
 

--- a/cmd/catalog_test.go
+++ b/cmd/catalog_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/spf13/cobra"
+
 	"github.com/major/marketsurge-agent/internal/client"
 	"github.com/major/marketsurge-agent/internal/constants"
 	mserrors "github.com/major/marketsurge-agent/internal/errors"
@@ -496,6 +498,105 @@ func catalogRunScreenFixture() string {
 			}
 		}
 	}`
+}
+
+func TestCatalogRunOptionsValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		opts    CatalogRunOptions
+		wantErr string
+	}{
+		{
+			name:    "missing kind",
+			opts:    CatalogRunOptions{},
+			wantErr: "kind is required",
+		},
+		{
+			name:    "invalid kind",
+			opts:    CatalogRunOptions{Kind: "bogus"},
+			wantErr: "kind must be one of",
+		},
+		{
+			name:    "screen kind rejected",
+			opts:    CatalogRunOptions{Kind: "screen"},
+			wantErr: "screens cannot be run directly",
+		},
+		{
+			name:    "report without report-id",
+			opts:    CatalogRunOptions{Kind: "report"},
+			wantErr: "report-id is required when kind=report",
+		},
+		{
+			name: "report with report-id",
+			opts: CatalogRunOptions{Kind: "report", ReportID: 42},
+		},
+		{
+			name:    "watchlist without watchlist-id",
+			opts:    CatalogRunOptions{Kind: "watchlist"},
+			wantErr: "watchlist-id is required when kind=watchlist",
+		},
+		{
+			name: "watchlist with watchlist-id",
+			opts: CatalogRunOptions{Kind: "watchlist", WatchlistID: 99},
+		},
+		{
+			name:    "coach_screen without coach-screen-id",
+			opts:    CatalogRunOptions{Kind: "coach_screen"},
+			wantErr: "coach-screen-id is required when kind=coach_screen",
+		},
+		{
+			name: "coach_screen with coach-screen-id",
+			opts: CatalogRunOptions{Kind: "coach_screen", CoachScreenID: "s-1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.opts.Validate()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				var verr *mserrors.ValidationError
+				assert.ErrorAs(t, err, &verr)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCatalogRunOptionsFromCommand(t *testing.T) {
+	t.Parallel()
+
+	t.Run("explicit zero is distinguishable from unset", func(t *testing.T) {
+		t.Parallel()
+		opts := &CatalogRunOptions{}
+		cmd := &cobra.Command{Use: "test"}
+		opts.BindFlags(cmd)
+
+		require.NoError(t, cmd.ParseFlags([]string{"--min-composite", "0"}))
+		opts.FromCommand(cmd)
+
+		require.NotNil(t, opts.MinComposite, "explicitly set --min-composite 0 should produce non-nil pointer")
+		assert.Equal(t, 0, *opts.MinComposite)
+		assert.Nil(t, opts.MinRS, "unset --min-rs should remain nil")
+	})
+
+	t.Run("unset flags remain nil", func(t *testing.T) {
+		t.Parallel()
+		opts := &CatalogRunOptions{}
+		cmd := &cobra.Command{Use: "test"}
+		opts.BindFlags(cmd)
+
+		require.NoError(t, cmd.ParseFlags([]string{}))
+		opts.FromCommand(cmd)
+
+		assert.Nil(t, opts.MinComposite)
+		assert.Nil(t, opts.MinRS)
+	})
 }
 
 func assertCatalogEntrySubset(t *testing.T, entries []map[string]any, expected map[string]any) {

--- a/cmd/chart.go
+++ b/cmd/chart.go
@@ -22,25 +22,35 @@ func newChartCmd() *cobra.Command {
 	return cmd
 }
 
+// ChartMarkupsOptions holds flags for the chart markups command.
+type ChartMarkupsOptions struct {
+	Frequency string
+	SortDir   string
+}
+
+// BindFlags registers chart markups flags and binds them to struct fields.
+func (o *ChartMarkupsOptions) BindFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&o.Frequency, "frequency", "DAILY", "Chart frequency: DAILY or WEEKLY")
+	cmd.Flags().StringVar(&o.SortDir, "sort-dir", "ASC", "Sort direction: ASC or DESC")
+}
+
 func newChartMarkupsCmd() *cobra.Command {
+	opts := &ChartMarkupsOptions{}
 	cmd := &cobra.Command{
 		Use:   "markups <symbol>",
 		Short: "Get chart markup data for a symbol",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			symbol := args[0]
-			frequency, _ := cmd.Flags().GetString("frequency")
-			sortDir, _ := cmd.Flags().GetString("sort-dir")
 			c := ClientFromContext(cmd.Context())
-			data, err := c.GetChartMarkups(cmd.Context(), symbol, frequency, sortDir)
+			data, err := c.GetChartMarkups(cmd.Context(), symbol, opts.Frequency, opts.SortDir)
 			if err != nil {
 				return err
 			}
 			return output.WriteSuccess(cmd.OutOrStdout(), data, output.SymbolMeta(symbol))
 		},
 	}
-	cmd.Flags().String("frequency", "DAILY", "Chart frequency: DAILY or WEEKLY")
-	cmd.Flags().String("sort-dir", "ASC", "Sort direction: ASC or DESC")
+	opts.BindFlags(cmd)
 	return cmd
 }
 
@@ -52,7 +62,70 @@ var validLookbacks = map[string]bool{
 // defaultExchangeName is used for daily chart queries.
 const defaultExchangeName = "NYSE"
 
+// ChartHistoryOptions holds flags for the chart history command.
+type ChartHistoryOptions struct {
+	StartDate string
+	EndDate   string
+	Lookback  string
+	Period    string
+	Benchmark string
+}
+
+// BindFlags registers chart history flags and binds them to struct fields.
+func (o *ChartHistoryOptions) BindFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&o.StartDate, "start-date", "", "Start date (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&o.EndDate, "end-date", "", "End date (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&o.Lookback, "lookback", "", "Relative lookback period: 1W, 1M, 3M, 6M, 1Y, YTD")
+	cmd.Flags().StringVar(&o.Period, "period", "daily", "Chart period: daily or weekly")
+	cmd.Flags().StringVar(&o.Benchmark, "benchmark", "", "Benchmark symbol for relative strength (e.g. 0S&P5)")
+}
+
+// Validate checks mutual exclusion and required-field constraints for chart history flags.
+func (o *ChartHistoryOptions) Validate() error {
+	hasExplicit := o.StartDate != "" || o.EndDate != ""
+	hasLookback := o.Lookback != ""
+
+	if hasExplicit && hasLookback {
+		return mserrors.NewValidationError(
+			"cannot use both --start-date/--end-date and --lookback", nil,
+		)
+	}
+
+	if !hasExplicit && !hasLookback {
+		return mserrors.NewValidationError(
+			"either --start-date and --end-date or --lookback is required", nil,
+		)
+	}
+
+	if hasExplicit {
+		if o.StartDate == "" || o.EndDate == "" {
+			return mserrors.NewValidationError(
+				"both --start-date and --end-date are required when using explicit dates", nil,
+			)
+		}
+		return nil
+	}
+
+	if !validLookbacks[o.Lookback] {
+		return mserrors.NewValidationError(
+			"invalid lookback value: must be one of 1W, 1M, 3M, 6M, 1Y, YTD", nil,
+		)
+	}
+
+	return nil
+}
+
+// ResolveDates computes start and end date strings from validated options.
+// Validate must be called before ResolveDates.
+func (o *ChartHistoryOptions) ResolveDates(now time.Time) (startDate, endDate string) {
+	if o.StartDate != "" {
+		return o.StartDate, o.EndDate
+	}
+	return resolveLookback(o.Lookback, now), now.Format("2006-01-02")
+}
+
 func newChartHistoryCmd() *cobra.Command {
+	opts := &ChartHistoryOptions{}
 	cmd := &cobra.Command{
 		Use:   "history <symbol>",
 		Short: "Get chart history for a symbol",
@@ -60,76 +133,28 @@ func newChartHistoryCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			symbol := args[0]
 
-			startDate, endDate, err := resolveChartDates(cmd, time.Now().UTC())
-			if err != nil {
+			if err := opts.Validate(); err != nil {
 				return err
 			}
 
-			period, _ := cmd.Flags().GetString("period")
-			graphqlPeriod, daily := mapPeriod(period)
+			startDate, endDate := opts.ResolveDates(time.Now().UTC())
+			graphqlPeriod, daily := mapPeriod(opts.Period)
 
 			exchangeName := ""
 			if daily {
 				exchangeName = defaultExchangeName
 			}
 
-			benchmark, _ := cmd.Flags().GetString("benchmark")
-
 			c := ClientFromContext(cmd.Context())
-			data, err := c.GetChartHistory(cmd.Context(), symbol, startDate, endDate, graphqlPeriod, daily, exchangeName, benchmark)
+			data, err := c.GetChartHistory(cmd.Context(), symbol, startDate, endDate, graphqlPeriod, daily, exchangeName, opts.Benchmark)
 			if err != nil {
 				return err
 			}
 			return output.WriteSuccess(cmd.OutOrStdout(), data, output.SymbolMeta(symbol))
 		},
 	}
-	cmd.Flags().String("start-date", "", "Start date (YYYY-MM-DD)")
-	cmd.Flags().String("end-date", "", "End date (YYYY-MM-DD)")
-	cmd.Flags().String("lookback", "", "Relative lookback period: 1W, 1M, 3M, 6M, 1Y, YTD")
-	cmd.Flags().String("period", "daily", "Chart period: daily or weekly")
-	cmd.Flags().String("benchmark", "", "Benchmark symbol for relative strength (e.g. 0S&P5)")
+	opts.BindFlags(cmd)
 	return cmd
-}
-
-// resolveChartDates validates and resolves the date flags into start/end date strings.
-// Either (--start-date AND --end-date) or --lookback must be provided, not both.
-func resolveChartDates(cmd *cobra.Command, now time.Time) (startDate, endDate string, err error) {
-	startDate, _ = cmd.Flags().GetString("start-date")
-	endDate, _ = cmd.Flags().GetString("end-date")
-	lookback, _ := cmd.Flags().GetString("lookback")
-
-	hasExplicit := cmd.Flags().Changed("start-date") || cmd.Flags().Changed("end-date")
-	hasLookback := cmd.Flags().Changed("lookback")
-
-	if hasExplicit && hasLookback {
-		return "", "", mserrors.NewValidationError(
-			"cannot use both --start-date/--end-date and --lookback", nil,
-		)
-	}
-
-	if !hasExplicit && !hasLookback {
-		return "", "", mserrors.NewValidationError(
-			"either --start-date and --end-date or --lookback is required", nil,
-		)
-	}
-
-	if hasExplicit {
-		if startDate == "" || endDate == "" {
-			return "", "", mserrors.NewValidationError(
-				"both --start-date and --end-date are required when using explicit dates", nil,
-			)
-		}
-		return startDate, endDate, nil
-	}
-
-	// Lookback mode.
-	if !validLookbacks[lookback] {
-		return "", "", mserrors.NewValidationError(
-			"invalid lookback value: must be one of 1W, 1M, 3M, 6M, 1Y, YTD", nil,
-		)
-	}
-
-	return resolveLookback(lookback, now), now.Format("2006-01-02"), nil
 }
 
 // resolveLookback computes the start date for a given lookback token.

--- a/cmd/chart_test.go
+++ b/cmd/chart_test.go
@@ -195,3 +195,79 @@ func TestMapPeriod(t *testing.T) {
 	assert.Equal(t, "P1W", period)
 	assert.False(t, daily)
 }
+
+func TestChartHistoryOptionsValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		opts    ChartHistoryOptions
+		wantErr string
+	}{
+		{
+			name:    "both explicit dates and lookback",
+			opts:    ChartHistoryOptions{StartDate: "2024-01-01", EndDate: "2024-06-30", Lookback: "3M"},
+			wantErr: "cannot use both",
+		},
+		{
+			name:    "neither dates nor lookback",
+			opts:    ChartHistoryOptions{},
+			wantErr: "either",
+		},
+		{
+			name:    "only start-date without end-date",
+			opts:    ChartHistoryOptions{StartDate: "2024-01-01"},
+			wantErr: "both --start-date and --end-date",
+		},
+		{
+			name: "valid explicit dates",
+			opts: ChartHistoryOptions{StartDate: "2024-01-01", EndDate: "2024-06-30"},
+		},
+		{
+			name: "valid lookback",
+			opts: ChartHistoryOptions{Lookback: "3M"},
+		},
+		{
+			name:    "invalid lookback value",
+			opts:    ChartHistoryOptions{Lookback: "2W"},
+			wantErr: "invalid lookback",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.opts.Validate()
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				var verr *mserrors.ValidationError
+				assert.ErrorAs(t, err, &verr)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestChartHistoryOptionsResolveDates(t *testing.T) {
+	t.Parallel()
+	// Fixed reference date: 2025-06-15
+	now := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+
+	t.Run("explicit dates pass through", func(t *testing.T) {
+		t.Parallel()
+		opts := ChartHistoryOptions{StartDate: "2024-01-01", EndDate: "2024-06-30"}
+		start, end := opts.ResolveDates(now)
+		assert.Equal(t, "2024-01-01", start)
+		assert.Equal(t, "2024-06-30", end)
+	})
+
+	t.Run("lookback computes dates", func(t *testing.T) {
+		t.Parallel()
+		opts := ChartHistoryOptions{Lookback: "3M"}
+		start, end := opts.ResolveDates(now)
+		assert.Equal(t, "2025-03-15", start)
+		assert.Equal(t, "2025-06-15", end)
+	})
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,23 @@ type clientKeyType struct{}
 
 var clientKey = clientKeyType{}
 
+// RootOptions holds persistent flag values for the root command.
+type RootOptions struct {
+	JWT      string
+	CookieDB string
+	Verbose  bool
+}
+
+// BindFlags registers persistent flags on the root command and binds them to RootOptions fields.
+func (o *RootOptions) BindFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVar(&o.JWT, "jwt", "", "JWT token for authentication (overrides env var and cookie)")
+	cmd.PersistentFlags().StringVar(&o.CookieDB, "cookie-db", "", "Path to Firefox cookie database file")
+	cmd.PersistentFlags().BoolVar(&o.Verbose, "verbose", false, "Enable verbose logging")
+}
+
+// rootOpts is the package-level instance of RootOptions, initialized by init().
+var rootOpts = &RootOptions{}
+
 // rootCmd is the root cobra command. Initialized as a package-level variable so
 // that each command file's init() can safely call rootCmd.AddCommand() regardless
 // of source-file initialization order.
@@ -36,9 +53,7 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.PersistentFlags().String("jwt", "", "JWT token for authentication (overrides env var and cookie)")
-	rootCmd.PersistentFlags().String("cookie-db", "", "Path to Firefox cookie database file")
-	rootCmd.PersistentFlags().Bool("verbose", false, "Enable verbose logging")
+	rootOpts.BindFlags(rootCmd)
 }
 
 // ClientFromContext returns the API client stored by PersistentPreRunE.
@@ -60,11 +75,7 @@ func persistentPreRunE(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	verbose, err := cmd.Flags().GetBool("verbose")
-	if err != nil {
-		return err
-	}
-	if verbose {
+	if rootOpts.Verbose {
 		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
 			Level: slog.LevelDebug,
 		})))
@@ -72,20 +83,12 @@ func persistentPreRunE(cmd *cobra.Command, _ []string) error {
 		slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
 	}
 
-	jwt, err := cmd.Flags().GetString("jwt")
-	if err != nil {
-		return err
-	}
+	jwt := rootOpts.JWT
 	if jwt == "" {
 		jwt = os.Getenv("MARKETSURGE_JWT")
 	}
 
-	cookieDB, err := cmd.Flags().GetString("cookie-db")
-	if err != nil {
-		return err
-	}
-
-	token, err := auth.ResolveJWT(cmd.Context(), jwt, cookieDB)
+	token, err := auth.ResolveJWT(cmd.Context(), jwt, rootOpts.CookieDB)
 	if err != nil {
 		return err
 	}

--- a/cmd/stock.go
+++ b/cmd/stock.go
@@ -41,12 +41,54 @@ type AnalysisResult struct {
 	Errors      []string                `json:"errors,omitempty"`
 }
 
+// StockAnalyzeOptions holds the options for the stock analyze command.
+type StockAnalyzeOptions struct {
+	Tickers []string
+	Compact bool
+	Flat    bool
+	Summary bool
+}
+
+// BindFlags registers the stock analyze command flags and binds them to the options struct.
+func (o *StockAnalyzeOptions) BindFlags(cmd *cobra.Command) {
+	cmd.Flags().StringSliceVar(&o.Tickers, "tickers", []string{}, "Additional ticker symbols to analyze")
+	cmd.Flags().BoolVar(&o.Compact, "compact", false, "Remove formatted string fields from analysis data")
+	cmd.Flags().BoolVar(&o.Flat, "flat", false, "Flatten each analysis result for token-efficient agent parsing")
+	cmd.Flags().BoolVar(&o.Summary, "summary", false, "Return compact screening fields for ranking multi-symbol candidates")
+}
+
+// MergeSymbols merges positional arguments with --tickers flag values, deduplicating and trimming whitespace.
+func (o *StockAnalyzeOptions) MergeSymbols(args []string) []string {
+	symbols := make([]string, 0, len(args)+len(o.Tickers))
+	seen := make(map[string]struct{}, len(args)+len(o.Tickers))
+	addSymbol := func(symbol string) {
+		trimmed := strings.TrimSpace(symbol)
+		if trimmed == "" {
+			return
+		}
+		if _, ok := seen[trimmed]; ok {
+			return
+		}
+		seen[trimmed] = struct{}{}
+		symbols = append(symbols, trimmed)
+	}
+
+	for _, symbol := range args {
+		addSymbol(symbol)
+	}
+	for _, symbol := range o.Tickers {
+		addSymbol(symbol)
+	}
+	return symbols
+}
+
 func newStockAnalyzeCmd() *cobra.Command {
+	opts := &StockAnalyzeOptions{}
 	cmd := &cobra.Command{
 		Use:   "analyze [symbol...]",
 		Short: "Analyze one or more stock symbols",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			symbols := analyzeSymbols(cmd, args)
+			symbols := opts.MergeSymbols(args)
 			if len(symbols) == 0 {
 				return mserrors.NewValidationError("at least one symbol required", nil)
 			}
@@ -75,26 +117,13 @@ func newStockAnalyzeCmd() *cobra.Command {
 				return fmt.Errorf("analysis failed for all symbols: %v", allErrors)
 			}
 
-			compact, err := cmd.Flags().GetBool("compact")
-			if err != nil {
-				return fmt.Errorf("read compact flag: %w", err)
-			}
-			flat, err := cmd.Flags().GetBool("flat")
-			if err != nil {
-				return fmt.Errorf("read flat flag: %w", err)
-			}
-			summary, err := cmd.Flags().GetBool("summary")
-			if err != nil {
-				return fmt.Errorf("read summary flag: %w", err)
-			}
-
-			data, err := transformAnalysisOutput(results, compact, flat, summary)
+			data, err := transformAnalysisOutput(results, opts.Compact, opts.Flat, opts.Summary)
 			if err != nil {
 				return fmt.Errorf("transform analysis output: %w", err)
 			}
 
 			metadata := analyzeMetadata(symbols)
-			if summary {
+			if opts.Summary {
 				metadata["mode"] = "summary"
 			}
 			if len(allErrors) > 0 {
@@ -103,40 +132,8 @@ func newStockAnalyzeCmd() *cobra.Command {
 			return output.WriteSuccess(cmd.OutOrStdout(), data, metadata)
 		},
 	}
-	cmd.Flags().StringSlice("tickers", []string{}, "Additional ticker symbols to analyze")
-	cmd.Flags().Bool("compact", false, "Remove formatted string fields from analysis data")
-	cmd.Flags().Bool("flat", false, "Flatten each analysis result for token-efficient agent parsing")
-	cmd.Flags().Bool("summary", false, "Return compact screening fields for ranking multi-symbol candidates")
+	opts.BindFlags(cmd)
 	return cmd
-}
-
-func analyzeSymbols(cmd *cobra.Command, args []string) []string {
-	tickers, err := cmd.Flags().GetStringSlice("tickers")
-	if err != nil {
-		tickers = nil
-	}
-
-	symbols := make([]string, 0, len(args)+len(tickers))
-	seen := make(map[string]struct{}, len(args)+len(tickers))
-	addSymbol := func(symbol string) {
-		trimmed := strings.TrimSpace(symbol)
-		if trimmed == "" {
-			return
-		}
-		if _, ok := seen[trimmed]; ok {
-			return
-		}
-		seen[trimmed] = struct{}{}
-		symbols = append(symbols, trimmed)
-	}
-
-	for _, symbol := range args {
-		addSymbol(symbol)
-	}
-	for _, symbol := range tickers {
-		addSymbol(symbol)
-	}
-	return symbols
 }
 
 func analyzeSymbol(ctx context.Context, c *client.Client, symbol string) AnalysisResult {


### PR DESCRIPTION
## Summary

Extracts typed option structs from 4 cobra command groups, moving flag values from inline `cmd.Flags().GetXxx()` calls into struct fields with `BindFlags()` methods. This is bridge work toward [structcli 0.17.0](https://github.com/leodido/structcli) migration, where these structs will gain `flag:"name"` struct tags and be bound via `structcli.Bind()`.

## Changes

- **root.go**: `RootOptions` struct (JWT, CookieDB, Verbose) with `BindFlags()`, package-level `rootOpts`
- **chart.go**: `ChartMarkupsOptions` (2 flags) and `ChartHistoryOptions` (5 flags) with `BindFlags()`, `Validate()`, `ResolveDates()`. Deletes monolithic `resolveChartDates()`, splitting it into pure validation vs date computation
- **stock.go**: `StockAnalyzeOptions` (4 flags) with `BindFlags()`, `MergeSymbols()`. Deletes `analyzeSymbols()` helper
- **catalog.go**: `CatalogRunOptions` (10 flags, pointer fields for optional ints) with `BindFlags()`, `FromCommand()`, `Validate()`, `Filters()`. `CatalogListOptions` (1 flag). Deletes `validateCatalogRunKind()`, `optionalIntFlag()`, `catalogRunFiltersFromFlags()`
- **cmd/AGENTS.md**: Documents the option struct pattern with code examples and method inventory

## Pattern

Each refactored command follows the closure pattern:

```go
func newXxxCmd() *cobra.Command {
    opts := &XxxOptions{}
    cmd := &cobra.Command{RunE: func(cmd *cobra.Command, args []string) error {
        if err := opts.Validate(); err != nil { return err }
        // use opts.Field directly
    }}
    opts.BindFlags(cmd)
    return cmd
}
```

## Testing

- 62 existing tests pass unchanged (transparent refactoring)
- New unit tests for `Validate()` methods: chart history (6 cases), catalog run (9 cases)
- New test for `FromCommand()` pointer field semantics (min-composite 0 vs unset)
- `go test -race`, `golangci-lint`, `go build` all clean