### PR TITLE
Require browser cookie authentication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ cmd/
   symbol.go                      Shared symbol-fetcher pattern
   <group>.go                     One file per command group (stock, chart, etc.)
 internal/
-  auth/                          JWT resolution (4-tier chain)
+  auth/                          Cookie-based JWT exchange
   client/                        GraphQL client + domain methods
   constants/                     API endpoints, columns, report IDs
   cookies/                       Firefox cookie extraction
@@ -26,7 +26,7 @@ queries/                         Embedded .graphql files (go:embed)
 ### Request flow
 
 1. `main.go` calls `cmd.Execute()` which runs the root cobra command
-2. `PersistentPreRunE` resolves JWT via the auth chain, injects `client.Client` into context
+2. `PersistentPreRunE` exchanges Firefox cookies for a JWT, injects `client.Client` into context
 3. Command `RunE` retrieves client via `ClientFromContext(cmd.Context())`, validates args, calls client method
 4. Client loads embedded `.graphql` query, executes HTTP POST to GraphQL endpoint
 5. Response parsed into typed model, wrapped in JSON envelope via `output.WriteSuccess`
@@ -34,14 +34,12 @@ queries/                         Embedded .graphql files (go:embed)
 
 ### Auth chain (`internal/auth/chain.go`)
 
-Four-tier JWT precedence, first non-empty wins:
+Cookie database precedence:
 
-1. `--jwt` CLI flag
-2. `MARKETSURGE_JWT` env var
-3. `--cookie-db` explicit path to Firefox cookie DB
-4. Firefox profile auto-discovery
+1. `--cookie-db` explicit path to Firefox cookie DB
+2. Firefox profile auto-discovery
 
-The JWT is exchanged at `investors.com` using the DylanToken constant, then used for GraphQL requests at `dowjones.io`.
+Cookies are exchanged at `investors.com` using the DylanToken constant, then the resulting JWT is used for GraphQL requests at `dowjones.io`. The CLI does not accept JWT injection through arguments, environment variables, or config files.
 
 ### Error hierarchy (`internal/errors/errors.go`)
 
@@ -87,19 +85,27 @@ Root setup in `init()`:
 ```go
 structcli.Bind(rootCmd, rootOpts)
 structcli.Setup(rootCmd,
+    structcli.WithAppName("marketsurge-agent"),
+    structcli.WithConfig(),
     structcli.WithJSONSchema(),
     structcli.WithFlagErrors(),
     structcli.WithHelpTopics(helptopics.Options{ReferenceSection: true}),
-    structcli.WithDebug(debug.Options{AppName: "marketsurge-agent", Exit: true}),
+    structcli.WithDebug(debug.Options{Exit: true}),
 )
 ```
 
 Key behaviors:
+- `WithAppName("marketsurge-agent")` sets the structcli env prefix to `MARKETSURGE_AGENT` and propagates the app name to config/debug helpers
+- `WithConfig()` adds the persistent `--config` flag, auto-loads config before structcli unmarshals options, and honors `MARKETSURGE_AGENT_CONFIG`
 - `--jsonschema` prints a machine-readable JSON schema for all flags and exits without auth
 - `--debug-options` prints resolved flag values and exits (requires `Exit: true` in debug options)
 - `env-vars` and `config-keys` are built-in help topics (e.g., `marketsurge-agent help env-vars`)
 - `structcli.ExecuteC(rootCmd)` replaces `rootCmd.Execute()` in `Execute()`
 - `rootCmd.TraverseChildren = true` is required for root-bound flags to work on subcommands
+
+Root options use structcli-managed configuration:
+- `--cookie-db` and `--verbose` use `flagenv:"true"`, so structcli binds them to `MARKETSURGE_AGENT_COOKIE_DB` and `MARKETSURGE_AGENT_VERBOSE`
+- Config files can set non-secret root keys such as `cookie-db` and `verbose`
 
 `isNonAPICommand()` skips auth for: `completion`, `help`, `env-vars`, `config-keys`.
 

--- a/README.md
+++ b/README.md
@@ -16,18 +16,40 @@ go install github.com/major/marketsurge-agent/cmd/marketsurge-agent@latest
 
 ## Authentication
 
-MarketSurge requires a valid JWT. The CLI resolves credentials in this order:
+MarketSurge requires an active browser session. The CLI exchanges Firefox cookies for the API JWT automatically. Cookie databases resolve in this order:
 
-1. `--jwt` flag
-2. `MARKETSURGE_JWT` environment variable
-3. `--cookie-db` path to a Firefox `cookies.sqlite` file
-4. Auto-discovery from local Firefox profiles
+1. `--cookie-db` path to a Firefox `cookies.sqlite` file
+2. Auto-discovery from local Firefox profiles
 
-The simplest approach for automation:
+Sign into MarketSurge in Firefox before running API commands. For automation, point the CLI at the Firefox cookie database used by that logged-in profile:
 
 ```bash
-export MARKETSURGE_JWT="your-jwt-here"
+marketsurge-agent --cookie-db "$HOME/.mozilla/firefox/profile/cookies.sqlite" stock get AAPL
 ```
+
+Non-secret root options can also come from structcli-managed environment variables:
+
+```bash
+export MARKETSURGE_AGENT_COOKIE_DB="$HOME/.mozilla/firefox/profile/cookies.sqlite"
+export MARKETSURGE_AGENT_VERBOSE=true
+```
+
+## Configuration file
+
+Config files can provide non-secret root options such as `cookie-db` and `verbose`:
+
+```yaml
+cookie-db: /home/alice/.mozilla/firefox/profile/cookies.sqlite
+verbose: false
+```
+
+Use `--config` to load a specific file:
+
+```bash
+marketsurge-agent --config ~/.config/marketsurge-agent/config.yaml stock get AAPL
+```
+
+Without `--config`, structcli searches its default config locations for `config.yaml`, `config.json`, or `config.toml`, including `/etc/marketsurge-agent`, an executable-adjacent `.marketsurge-agent` directory, and `$HOME/.marketsurge-agent`. Set `MARKETSURGE_AGENT_CONFIG` to point at a config file from the environment. For root options managed by structcli, precedence is CLI flag, environment variable, config file, then default.
 
 ## Usage
 
@@ -124,6 +146,9 @@ marketsurge-agent help env-vars
 # List all supported config file keys
 marketsurge-agent help config-keys
 
+# Load config from a specific file
+marketsurge-agent --config ~/.config/marketsurge-agent/config.yaml --debug-options
+
 # Print resolved flag values for debugging
 marketsurge-agent --debug-options
 
@@ -185,7 +210,7 @@ cmd/
   symbol.go              Shared symbol-fetcher pattern
   <group>.go             One file per command group
 internal/
-  auth/                  JWT resolution (4-tier chain)
+  auth/                  Cookie-based JWT exchange
   client/                GraphQL client + API methods
   constants/             API endpoints, column names
   cookies/               Firefox cookie extraction

--- a/cmd/marketsurge-agent/main_test.go
+++ b/cmd/marketsurge-agent/main_test.go
@@ -62,17 +62,19 @@ func TestUnknownCommandReturnsError(t *testing.T) {
 	assert.Contains(t, strings.ToLower(string(out)), "unknown command")
 }
 
-// TestErrorOutputIsValidJSON runs a command with no valid auth
-// (HOME=/nonexistent, no JWT) and confirms the error output is a JSON
+// TestErrorOutputIsValidJSON runs a command with no valid Firefox profile
+// (HOME=/nonexistent) and confirms the error output is a JSON
 // envelope with an "error" key.
 func TestErrorOutputIsValidJSON(t *testing.T) {
 	cmd := exec.Command(testBinary, "stock", "get", "AAPL")
 
-	// Strip HOME and MARKETSURGE_JWT so the auth chain fails entirely.
+	// Strip home and structcli configuration inputs so browser-cookie auth fails
+	// even on developer machines with local marketsurge-agent settings.
 	var env []string
 	for _, e := range os.Environ() {
 		if strings.HasPrefix(e, "HOME=") ||
-			strings.HasPrefix(e, "MARKETSURGE_JWT=") {
+			strings.HasPrefix(e, "XDG_CONFIG_HOME=") ||
+			strings.HasPrefix(e, "MARKETSURGE_AGENT_") {
 			continue
 		}
 		env = append(env, e)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,14 +2,17 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/leodido/structcli"
+	"github.com/leodido/structcli/config"
 	"github.com/leodido/structcli/debug"
 	"github.com/leodido/structcli/helptopics"
 	"github.com/spf13/cobra"
@@ -28,9 +31,8 @@ var clientKey = clientKeyType{}
 
 // RootOptions holds persistent flag values for the root command.
 type RootOptions struct {
-	JWT      string `flag:"jwt" flagdescr:"JWT token for authentication (overrides env var and cookie)"`
-	CookieDB string `flag:"cookie-db" flagdescr:"Path to Firefox cookie database file"`
-	Verbose  bool   `flag:"verbose" flagshort:"v" flagdescr:"Enable verbose logging"`
+	CookieDB string `flag:"cookie-db" flagdescr:"Path to Firefox cookie database file" flagenv:"true"`
+	Verbose  bool   `flag:"verbose" flagshort:"v" flagdescr:"Enable verbose logging" flagenv:"true"`
 }
 
 // rootOpts is the package-level instance of RootOptions, initialized by init().
@@ -47,17 +49,14 @@ All output is structured JSON with semantic exit codes.
 
 Auth
 
-  MarketSurge requires a valid JWT. Credentials resolve in this order
-  (first non-empty wins):
+  MarketSurge authentication uses Firefox browser cookies. The CLI exchanges
+  the local browser session for the API JWT automatically. Cookie databases
+  resolve in this order:
 
-    1. --jwt flag
-    2. MARKETSURGE_JWT env var
-    3. --cookie-db path to a Firefox cookies.sqlite file
-    4. Auto-discovery from local Firefox profiles
+    1. --cookie-db path to a Firefox cookies.sqlite file
+    2. Auto-discovery from local Firefox profiles
 
-  For automation, set the env var:
-
-    export MARKETSURGE_JWT="your-jwt-here"
+  Sign into MarketSurge in Firefox before running API commands.
 
 Output
 
@@ -80,8 +79,8 @@ Exit Codes
 
 Gotchas
 
-  - JWT expiry: exit code 32 means the user needs to refresh their token
-    or ensure Firefox has an active MarketSurge session.
+  - Auth expiry: exit code 32 means Firefox needs an active MarketSurge
+    session or the explicit --cookie-db path is not usable.
   - Chart date params: --start-date/--end-date and --lookback are
     mutually exclusive.
   - Catalog kind: catalog run requires --kind and the matching ID flag.
@@ -108,10 +107,12 @@ func init() {
 		panic(err)
 	}
 	if err := structcli.Setup(rootCmd,
+		structcli.WithAppName("marketsurge-agent"),
+		structcli.WithConfig(config.Options{ValidateKeys: true}),
 		structcli.WithJSONSchema(),
 		structcli.WithFlagErrors(),
 		structcli.WithHelpTopics(helptopics.Options{ReferenceSection: true}),
-		structcli.WithDebug(debug.Options{AppName: "marketsurge-agent", Exit: true}),
+		structcli.WithDebug(debug.Options{Exit: true}),
 	); err != nil {
 		panic(err)
 	}
@@ -158,12 +159,7 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 		slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
 	}
 
-	jwt := rootOpts.JWT
-	if jwt == "" {
-		jwt = os.Getenv("MARKETSURGE_JWT")
-	}
-
-	token, err := auth.ResolveJWT(cmd.Context(), jwt, rootOpts.CookieDB)
+	token, err := auth.ResolveJWT(cmd.Context(), rootOpts.CookieDB)
 	if err != nil {
 		return err
 	}
@@ -193,7 +189,17 @@ func isNonAPICommand(cmd *cobra.Command) bool {
 
 // Execute runs the root command and writes errors as JSON envelopes.
 func Execute() {
+	rootCmd.SetArgs(os.Args[1:])
+
+	originalOut := rootCmd.OutOrStdout()
+	filter := &configStatusFilter{w: originalOut}
+	rootCmd.SetOut(filter)
 	executed, err := structcli.ExecuteC(rootCmd)
+	if flushErr := filter.Flush(); err == nil && flushErr != nil {
+		err = flushErr
+	}
+	rootCmd.SetOut(nil)
+
 	if err == nil && executed == rootCmd && len(rootCmd.Flags().Args()) > 0 {
 		err = fmt.Errorf("unknown command %q", rootCmd.Flags().Arg(0))
 	}
@@ -205,4 +211,52 @@ func Execute() {
 		}
 		os.Exit(1)
 	}
+}
+
+type configStatusFilter struct {
+	w       io.Writer
+	pending []byte
+}
+
+func (f *configStatusFilter) Write(p []byte) (int, error) {
+	f.pending = append(f.pending, p...)
+
+	for {
+		line, rest, found := bytes.Cut(f.pending, []byte("\n"))
+		if !found {
+			break
+		}
+
+		line = append(line, '\n')
+		if err := f.writeLine(line); err != nil {
+			return 0, err
+		}
+		f.pending = rest
+	}
+
+	return len(p), nil
+}
+
+func (f *configStatusFilter) Flush() error {
+	if len(f.pending) == 0 {
+		return nil
+	}
+
+	err := f.writeLine(f.pending)
+	f.pending = nil
+	return err
+}
+
+func (f *configStatusFilter) writeLine(line []byte) error {
+	if isConfigStatusLine(line) {
+		return nil
+	}
+
+	_, err := f.w.Write(line)
+	return err
+}
+
+func isConfigStatusLine(line []byte) bool {
+	trimmed := strings.TrimSpace(string(line))
+	return trimmed == "Running without a configuration file" || strings.HasPrefix(trimmed, "Using config file: ")
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -10,16 +12,118 @@ import (
 )
 
 func TestRootJSONSchema(t *testing.T) {
-	cmd := exec.Command("go", "run", "./marketsurge-agent", "--jsonschema")
+	cmd := rootExecCommand(t, "--jsonschema")
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(output))
 
 	schema := string(output)
 	assert.True(t, strings.Contains(schema, `"$schema"`) || strings.Contains(schema, `"properties"`))
+	assert.Contains(t, schema, `"x-structcli-env-prefix": "MARKETSURGE_AGENT"`)
+	assert.Contains(t, schema, `"MARKETSURGE_AGENT_COOKIE_DB"`)
+	assert.Contains(t, schema, `"MARKETSURGE_AGENT_VERBOSE"`)
+	assert.Contains(t, schema, `"x-structcli-config-flag": "config"`)
 }
 
 func TestRootDebugOptions(t *testing.T) {
-	cmd := exec.Command("go", "run", "./marketsurge-agent", "--debug-options")
+	cmd := rootExecCommand(t, "--debug-options")
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(output))
+}
+
+func TestRootHelpShowsConfigFlag(t *testing.T) {
+	cmd := rootExecCommand(t, "--help")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	help := string(output)
+	assert.Contains(t, help, "--config string")
+	assert.Contains(t, help, "config file")
+	assert.Contains(t, help, "Sign into MarketSurge in Firefox")
+}
+
+func TestRootConfigFileLoading(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := tmpDir + "/config.yaml"
+	cookiePath := tmpDir + "/cookies.sqlite"
+	require.NoError(t, os.WriteFile(configPath, []byte("cookie-db: "+cookiePath+"\nverbose: true\n"), 0o600))
+
+	cmd := rootExecCommand(t, "--config", configPath, "--debug-options=json")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	debugOutput := string(output)
+	assert.Contains(t, debugOutput, `"name": "cookie-db"`)
+	assert.Contains(t, debugOutput, `"value": "`+cookiePath+`"`)
+	assert.Contains(t, debugOutput, `"source": "config"`)
+	assert.Contains(t, debugOutput, `"verbose": true`)
+	assert.NotContains(t, debugOutput, `"jwt"`)
+}
+
+func TestRootConfigKeysListCookieAuthOnly(t *testing.T) {
+	cmd := rootExecCommand(t, "config-keys")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	configKeys := string(output)
+	assert.Contains(t, configKeys, "cookie-db")
+	assert.Contains(t, configKeys, "verbose")
+	assert.NotContains(t, configKeys, "jwt")
+}
+
+func TestRootEnvVarLoading(t *testing.T) {
+	cmd := rootExecCommand(t, "--debug-options=json")
+	cmd.Env = append(cmd.Env,
+		"MARKETSURGE_AGENT_COOKIE_DB=/tmp/marketsurge-agent-env-cookies.sqlite",
+		"MARKETSURGE_AGENT_VERBOSE=true",
+	)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	debugOutput := string(output)
+	assert.Contains(t, debugOutput, `"value": "/tmp/marketsurge-agent-env-cookies.sqlite"`)
+	assert.Contains(t, debugOutput, `"source": "env"`)
+	assert.Contains(t, debugOutput, `"verbose": "true"`)
+}
+
+func TestRootRejectsJWTFlag(t *testing.T) {
+	cmd := rootExecCommand(t, "--jwt", "token", "stock", "get", "AAPL")
+	output, err := cmd.CombinedOutput()
+	require.Error(t, err, string(output))
+
+	assert.Contains(t, string(output), "unknown flag: --jwt")
+}
+
+func rootExecCommand(t *testing.T, args ...string) *exec.Cmd {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	cmdArgs := append([]string{"run", "./marketsurge-agent"}, args...)
+	cmd := exec.Command("go", cmdArgs...)
+	cmd.Env = append(sanitizedRootCommandEnv(),
+		"HOME="+tmpDir,
+		"GOPATH="+filepath.Join(userHomeDir(t), "go"),
+		"XDG_CONFIG_HOME="+tmpDir+"/xdg",
+	)
+	return cmd
+}
+
+func userHomeDir(t *testing.T) string {
+	t.Helper()
+
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+	return homeDir
+}
+
+func sanitizedRootCommandEnv() []string {
+	env := make([]string, 0, len(os.Environ()))
+	for _, entry := range os.Environ() {
+		if strings.HasPrefix(entry, "MARKETSURGE_AGENT_") ||
+			strings.HasPrefix(entry, "HOME=") ||
+			strings.HasPrefix(entry, "XDG_CONFIG_HOME=") {
+			continue
+		}
+		env = append(env, entry)
+	}
+	return env
 }

--- a/internal/auth/chain.go
+++ b/internal/auth/chain.go
@@ -7,36 +7,23 @@ package auth
 import (
 	"context"
 	"log/slog"
-	"os"
 
 	"github.com/major/marketsurge-agent/internal/cookies"
 	"github.com/major/marketsurge-agent/internal/errors"
 )
 
-// ResolveJWT resolves a JWT token using the auth precedence chain:
-//  1. flagJWT (from --jwt flag) - highest priority
-//  2. MARKETSURGE_JWT env var
-//  3. Explicit cookie DB path (--cookie-db flag)
-//  4. Auto-discover Firefox profiles, try each until one succeeds
+// ResolveJWT resolves a JWT token from Firefox browser cookies:
+//  1. Explicit cookie DB path (--cookie-db flag)
+//  2. Auto-discover Firefox profiles, try each until one succeeds
 //
 // Returns AuthenticationError if all sources fail.
-func ResolveJWT(ctx context.Context, flagJWT, cookieDBPath string) (string, error) {
-	// 1. CLI flag takes highest precedence.
-	if flagJWT != "" {
-		return flagJWT, nil
-	}
-
-	// 2. MARKETSURGE_JWT env var.
-	if jwt := os.Getenv("MARKETSURGE_JWT"); jwt != "" {
-		return jwt, nil
-	}
-
-	// 3. Explicit cookie DB path.
+func ResolveJWT(ctx context.Context, cookieDBPath string) (string, error) {
+	// 1. Explicit cookie DB path.
 	if cookieDBPath != "" {
 		return resolveFromCookieDB(ctx, cookieDBPath)
 	}
 
-	// 4. Auto-discover: try each Firefox profile until one succeeds.
+	// 2. Auto-discover: try each Firefox profile until one succeeds.
 	return resolveFromFirefoxProfiles(ctx)
 }
 
@@ -46,7 +33,7 @@ func resolveFromCookieDB(ctx context.Context, cookieDBPath string) (string, erro
 	cookieJar, err := cookies.ExtractCookies(ctx, cookieDBPath)
 	if err != nil {
 		return "", errors.NewAuthenticationError(
-			"no JWT available: try --jwt flag, MARKETSURGE_JWT env var, or sign into MarketSurge in Firefox",
+			"no JWT available: sign into MarketSurge in Firefox or check the --cookie-db path",
 			err,
 		)
 	}
@@ -61,14 +48,14 @@ func resolveFromFirefoxProfiles(ctx context.Context) (string, error) {
 	dbPaths, err := cookies.FindCookieDBPaths()
 	if err != nil {
 		return "", errors.NewAuthenticationError(
-			"no JWT available: could not discover Firefox profiles; try --jwt flag, MARKETSURGE_JWT env var, or --cookie-db",
+			"no JWT available: could not discover Firefox profiles; sign into MarketSurge in Firefox or pass --cookie-db",
 			err,
 		)
 	}
 
 	if len(dbPaths) == 0 {
 		return "", errors.NewAuthenticationError(
-			"no JWT available: no Firefox profiles found; try --jwt flag, MARKETSURGE_JWT env var, or sign into MarketSurge in Firefox",
+			"no JWT available: no Firefox profiles found; sign into MarketSurge in Firefox or pass --cookie-db",
 			nil,
 		)
 	}
@@ -101,7 +88,7 @@ func resolveFromFirefoxProfiles(ctx context.Context) (string, error) {
 	}
 
 	return "", errors.NewAuthenticationError(
-		"no JWT available: tried all Firefox profiles but none produced a valid login; try --jwt flag, MARKETSURGE_JWT env var, or sign into MarketSurge in Firefox",
+		"no JWT available: tried all Firefox profiles but none produced a valid login; sign into MarketSurge in Firefox or pass --cookie-db",
 		lastErr,
 	)
 }

--- a/internal/auth/chain_test.go
+++ b/internal/auth/chain_test.go
@@ -9,42 +9,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// clearAuthEnv unsets all JWT env vars so tests start from a clean state.
-func clearAuthEnv(t *testing.T) {
-	t.Helper()
-	t.Setenv("MARKETSURGE_JWT", "")
-}
-
-// TestResolveJWT_FlagPrecedence verifies that the --jwt flag takes highest
-// priority, even when env vars are also set.
-func TestResolveJWT_FlagPrecedence(t *testing.T) {
-	t.Setenv("MARKETSURGE_JWT", "env-jwt")
-
-	jwt, err := ResolveJWT(context.Background(), "flag-jwt", "")
-	require.NoError(t, err)
-	assert.Equal(t, "flag-jwt", jwt)
-}
-
-// TestResolveJWT_MarketSurgeEnv verifies MARKETSURGE_JWT is used when no flag
-// is provided.
-func TestResolveJWT_MarketSurgeEnv(t *testing.T) {
-	clearAuthEnv(t)
-	t.Setenv("MARKETSURGE_JWT", "ms-jwt")
-
-	jwt, err := ResolveJWT(context.Background(), "", "")
-	require.NoError(t, err)
-	assert.Equal(t, "ms-jwt", jwt)
-}
-
 // TestResolveJWT_NoSources verifies that AuthenticationError is returned when
-// no JWT flag, env vars, or Firefox profile are available.
+// no Firefox profile is available.
 func TestResolveJWT_NoSources(t *testing.T) {
-	clearAuthEnv(t)
-
 	// Point HOME to a temp dir so FindCookieDBPaths finds no profiles.
 	t.Setenv("HOME", t.TempDir())
 
-	jwt, err := ResolveJWT(context.Background(), "", "")
+	jwt, err := ResolveJWT(context.Background(), "")
 	assert.Empty(t, jwt)
 	require.Error(t, err)
 
@@ -57,9 +28,7 @@ func TestResolveJWT_NoSources(t *testing.T) {
 // to a nonexistent file produces an AuthenticationError wrapping a
 // CookieExtractionError.
 func TestResolveJWT_CookieDBPath(t *testing.T) {
-	clearAuthEnv(t)
-
-	jwt, err := ResolveJWT(context.Background(), "", "/nonexistent/cookies.sqlite")
+	jwt, err := ResolveJWT(context.Background(), "/nonexistent/cookies.sqlite")
 	assert.Empty(t, jwt)
 	require.Error(t, err)
 


### PR DESCRIPTION
## Summary
- Remove `--jwt`, `MARKETSURGE_JWT`, and config-based JWT injection paths.
- Keep Firefox cookie discovery as the only token source while preserving `--cookie-db`, env, and config support for non-secret root options.
- Update docs and tests for browser-cookie-only authentication.

## Verification
- LSP diagnostics clean on modified Go files
- `go test ./...`
- `go build ./cmd/marketsurge-agent`
- `make test`
- `make lint`

CodeRabbit local review skipped by request.