### PR TITLE
feat(cmd): add MCP server mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,11 +86,16 @@ Root setup in `init()`:
 structcli.Bind(rootCmd, rootOpts)
 structcli.Setup(rootCmd,
     structcli.WithAppName("marketsurge-agent"),
-    structcli.WithConfig(),
+    structcli.WithConfig(config.Options{ValidateKeys: true}),
     structcli.WithJSONSchema(),
     structcli.WithFlagErrors(),
     structcli.WithHelpTopics(helptopics.Options{ReferenceSection: true}),
     structcli.WithDebug(debug.Options{Exit: true}),
+    structcli.WithMCP(mcp.Options{
+        Name:    "marketsurge-agent",
+        Version: version,
+        Exclude: []string{"completion-bash", "completion-fish", "completion-powershell", "completion-zsh"},
+    }),
 )
 ```
 
@@ -98,6 +103,7 @@ Key behaviors:
 - `WithAppName("marketsurge-agent")` sets the structcli env prefix to `MARKETSURGE_AGENT` and propagates the app name to config/debug helpers
 - `WithConfig()` adds the persistent `--config` flag, auto-loads config before structcli unmarshals options, and honors `MARKETSURGE_AGENT_CONFIG`
 - `--jsonschema` prints a machine-readable JSON schema for all flags and exits without auth
+- `--mcp` runs a stdio Model Context Protocol server; `initialize` and `tools/list` discovery do not require auth, while `tools/call` for API commands uses the normal Firefox cookie auth chain; shell completion subcommands are excluded from the MCP tool list
 - `--debug-options` prints resolved flag values and exits (requires `Exit: true` in debug options)
 - `env-vars` and `config-keys` are built-in help topics (e.g., `marketsurge-agent help env-vars`)
 - `structcli.ExecuteC(rootCmd)` replaces `rootCmd.Execute()` in `Execute()`
@@ -107,7 +113,7 @@ Root options use structcli-managed configuration:
 - `--cookie-db` and `--verbose` use `flagenv:"true"`, so structcli binds them to `MARKETSURGE_AGENT_COOKIE_DB` and `MARKETSURGE_AGENT_VERBOSE`
 - Config files can set non-secret root keys such as `cookie-db` and `verbose`
 
-`isNonAPICommand()` skips auth for: `completion`, `help`, `env-vars`, `config-keys`.
+`isNonAPICommand()` skips auth for: `completion`, `help`, `env-vars`, `config-keys`. structcli intercepts `--mcp` before normal hooks for discovery requests, so MCP discovery also skips auth.
 
 ### Typed enums (`internal/models/enums.go`)
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ marketsurge-agent completion zsh > ~/.zsh/completions/_marketsurge-agent
 # Print machine-readable JSON schema for all flags (useful for LLM tool definitions)
 marketsurge-agent --jsonschema
 
+# Run as an MCP server over stdio for agent tool discovery and calls
+marketsurge-agent --mcp
+
 # List all supported environment variables
 marketsurge-agent help env-vars
 
@@ -189,6 +192,16 @@ Each command also carries a detailed `--help` description covering inputs, outpu
 marketsurge-agent help env-vars
 marketsurge-agent stock analyze --help
 ```
+
+### MCP server
+
+`--mcp` runs `marketsurge-agent` as a Model Context Protocol server over stdio. Agents can use MCP `initialize`, `tools/list`, and `tools/call` requests to discover and invoke CLI commands without scraping help output:
+
+```bash
+marketsurge-agent --mcp
+```
+
+MCP discovery does not require MarketSurge authentication. Tool calls that fetch MarketSurge data still use the same Firefox cookie authentication chain as normal CLI commands and return the same JSON envelopes.
 
 ## Development
 

--- a/cmd/AGENTS.md
+++ b/cmd/AGENTS.md
@@ -40,6 +40,12 @@ Client is stored in context by PersistentPreRunE, retrieved in RunE:
 c := ClientFromContext(cmd.Context())
 ```
 
+### MCP behavior
+
+The root command enables structcli's stdio MCP server with `structcli.WithMCP()`. MCP discovery requests (`initialize`, `tools/list`) are intercepted before `PersistentPreRunE`, so they must not require Firefox cookie auth. MCP `tools/call` executes the normal Cobra command path and must keep using `PersistentPreRunE` auth for API commands.
+
+Shell completion subcommands are excluded from MCP tool discovery because they are not useful agent-callable API tools. Keep the MCP tool list focused on MarketSurge data commands.
+
 ### Test pattern
 
 Tests call constructors directly (not package-level vars) and inject client via context:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ import (
 	"github.com/leodido/structcli/config"
 	"github.com/leodido/structcli/debug"
 	"github.com/leodido/structcli/helptopics"
+	structclimcp "github.com/leodido/structcli/mcp"
 	"github.com/spf13/cobra"
 
 	"github.com/major/marketsurge-agent/internal/auth"
@@ -113,6 +114,16 @@ func init() {
 		structcli.WithFlagErrors(),
 		structcli.WithHelpTopics(helptopics.Options{ReferenceSection: true}),
 		structcli.WithDebug(debug.Options{Exit: true}),
+		structcli.WithMCP(structclimcp.Options{
+			Name:    "marketsurge-agent",
+			Version: version,
+			Exclude: []string{
+				"completion-bash",
+				"completion-fish",
+				"completion-powershell",
+				"completion-zsh",
+			},
+		}),
 	); err != nil {
 		panic(err)
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -46,10 +46,10 @@ func TestRootHelpShowsConfigFlag(t *testing.T) {
 
 func TestRootMCPInitializeAndToolsList(t *testing.T) {
 	cmd := rootExecCommand(t, "--mcp")
-	cmd.Stdin = strings.NewReader(strings.Join([]string{
-		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"test"}}}`,
-		`{"jsonrpc":"2.0","id":2,"method":"tools/list"}`,
-	}, "\n"))
+	cmd.Stdin = strings.NewReader(
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"test"}}}` + "\n" +
+			`{"jsonrpc":"2.0","id":2,"method":"tools/list"}`,
+	)
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(output))
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"encoding/json"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -38,7 +40,69 @@ func TestRootHelpShowsConfigFlag(t *testing.T) {
 	help := string(output)
 	assert.Contains(t, help, "--config string")
 	assert.Contains(t, help, "config file")
+	assert.Contains(t, help, "--mcp")
 	assert.Contains(t, help, "Sign into MarketSurge in Firefox")
+}
+
+func TestRootMCPInitializeAndToolsList(t *testing.T) {
+	cmd := rootExecCommand(t, "--mcp")
+	cmd.Stdin = strings.NewReader(strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"test"}}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/list"}`,
+	}, "\n"))
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	responses := decodeMCPResponses(t, output)
+	require.Len(t, responses, 2)
+
+	var initResult mcpInitializeResult
+	require.NoError(t, json.Unmarshal(responses[0].Result, &initResult))
+	assert.Equal(t, "marketsurge-agent", initResult.ServerInfo.Name)
+	assert.Equal(t, "dev", initResult.ServerInfo.Version)
+
+	var listResult mcpToolsListResult
+	require.NoError(t, json.Unmarshal(responses[1].Result, &listResult))
+	toolNames := make([]string, 0, len(listResult.Tools))
+	for _, tool := range listResult.Tools {
+		toolNames = append(toolNames, tool.Name)
+	}
+	assert.ElementsMatch(t, []string{
+		"catalog-list",
+		"catalog-run",
+		"chart-history",
+		"chart-markups",
+		"fundamental-get",
+		"ownership-get",
+		"rs-history-get",
+		"stock-analyze",
+		"stock-get",
+	}, toolNames)
+	assert.NotContains(t, toolNames, "completion-bash")
+	assert.NotContains(t, toolNames, "completion-fish")
+	assert.NotContains(t, toolNames, "completion-powershell")
+	assert.NotContains(t, toolNames, "completion-zsh")
+	assert.NotContains(t, string(output), "Firefox")
+	assert.NotContains(t, string(output), "cookie")
+}
+
+func TestRootMCPToolsCallUsesAPIAuth(t *testing.T) {
+	cmd := rootExecCommand(t, "--mcp")
+	cmd.Stdin = strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"stock-analyze","arguments":{"tickers":"AAPL"}}}` + "\n")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	responses := decodeMCPResponses(t, output)
+	require.Len(t, responses, 1)
+	require.Nil(t, responses[0].Error)
+
+	var callResult mcpToolCallResult
+	require.NoError(t, json.Unmarshal(responses[0].Result, &callResult))
+	assert.True(t, callResult.IsError)
+	require.Len(t, callResult.Content, 1)
+	assert.Contains(t, callResult.Content[0].Text, "no JWT available")
+	assert.Contains(t, callResult.Content[0].Text, "no Firefox profiles found")
+	assert.Contains(t, callResult.Content[0].Text, "marketsurge-agent stock analyze")
 }
 
 func TestRootConfigFileLoading(t *testing.T) {
@@ -126,4 +190,46 @@ func sanitizedRootCommandEnv() []string {
 		env = append(env, entry)
 	}
 	return env
+}
+
+type mcpResponse struct {
+	Result json.RawMessage `json:"result"`
+	Error  any             `json:"error"`
+}
+
+type mcpInitializeResult struct {
+	ServerInfo struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	} `json:"serverInfo"`
+}
+
+type mcpToolsListResult struct {
+	Tools []struct {
+		Name string `json:"name"`
+	} `json:"tools"`
+}
+
+type mcpToolCallResult struct {
+	Content []struct {
+		Text string `json:"text"`
+	} `json:"content"`
+	IsError bool `json:"isError"`
+}
+
+func decodeMCPResponses(t *testing.T, output []byte) []mcpResponse {
+	t.Helper()
+
+	dec := json.NewDecoder(strings.NewReader(string(output)))
+	responses := []mcpResponse{}
+	for {
+		var response mcpResponse
+		err := dec.Decode(&response)
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		responses = append(responses, response)
+	}
+	return responses
 }


### PR DESCRIPTION
## Summary
- Add structcli MCP stdio server mode with focused MarketSurge API tool discovery.
- Cover MCP initialize/tools-list discovery and tools/call auth behavior in root integration tests.
- Document MCP usage and auth expectations in README and AGENTS notes.

## Verification
- `go test ./cmd -run 'TestRootMCP|TestRootHelp'`
- `go test -v -race -coverprofile=coverage.out ./...`
- `go build ./cmd/marketsurge-agent`
- Live smoke sample passed for stock, fundamental, ownership, rs-history, chart history, and chart markups commands.
- Review agents passed goal, security, code quality, QA, and context-mining checks.