### PR TITLE
feat(cmd): improve schema metadata for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,22 @@ Typed string enums are registered with structcli so flag validation and schema g
 
 **Optional enum fields**: fields with no `default:` struct tag must stay `string` type. structcli rejects an empty string for a registered enum during unmarshal, before `Validate()` can return a typed `ValidationError`. Only use typed enum fields when a non-empty default is always present.
 
+### Schema fidelity for LLM agents
+
+LLM agents should prefer the full command tree schema:
+
+```bash
+marketsurge-agent --jsonschema=tree
+```
+
+Schema tags should make command selection and flag filling obvious:
+- Use `flaggroup:` for logical groups such as `Date Range`, `Output Format`, `Pagination`, and `Filtering & Projection`
+- Use `flagdescr:` to document conditional requirements and examples, especially when a flag is only required for one mode
+- Keep conditional and domain-specific requirements in `Validate()` when they need the CLI's JSON error envelope and MarketSurge exit codes
+- Do not mark chart history date fields or catalog ID fields with `flagrequired`, because their requirements depend on other flags
+
+The schema should describe enough for agents to choose flags without scraping prose help, while runtime validation remains the source of truth for mutually exclusive and conditional rules.
+
 ## Conventions
 
 ### Code style

--- a/README.md
+++ b/README.md
@@ -137,8 +137,11 @@ Errors follow the same pattern:
 # Generate shell completion (bash, zsh, fish, powershell)
 marketsurge-agent completion zsh > ~/.zsh/completions/_marketsurge-agent
 
-# Print machine-readable JSON schema for all flags (useful for LLM tool definitions)
+# Print machine-readable JSON schema for the current command
 marketsurge-agent --jsonschema
+
+# Print the full command tree schema for LLM tool definitions
+marketsurge-agent --jsonschema=tree
 
 # Run as an MCP server over stdio for agent tool discovery and calls
 marketsurge-agent --mcp
@@ -180,11 +183,14 @@ marketsurge-agent stock analyze --tickers AAPL,MSFT,NVDA --compact --flat
 
 ### Schema discovery
 
-`--jsonschema` prints a machine-readable JSON schema for all flags and exits without making any API calls. This is useful for generating tool definitions in LLM agent frameworks:
+`--jsonschema` prints a machine-readable JSON schema for the current command and exits without making any API calls. For LLM tool definitions, prefer `--jsonschema=tree` so the agent sees every subcommand plus flag groups, enum values, defaults, environment bindings, and descriptions in one response:
 
 ```bash
 marketsurge-agent --jsonschema
+marketsurge-agent --jsonschema=tree
 ```
+
+Required and conditional inputs are documented in flag descriptions. Some rules are intentionally validated by the command instead of structcli tags so errors keep the normal JSON envelope and MarketSurge exit codes, for example `chart history` requires either `--lookback` or `--start-date/--end-date`, and `catalog run` requires the ID flag that matches `--kind`.
 
 Each command also carries a detailed `--help` description covering inputs, outputs, and gotchas. The `env-vars` and `config-keys` help topics list every supported environment variable and config file key:
 

--- a/cmd/AGENTS.md
+++ b/cmd/AGENTS.md
@@ -132,9 +132,11 @@ Fields with no `default:` struct tag must stay `string` type. structcli rejects 
 ## Adding a new command
 
 1. Create `cmd/<group>.go` with constructor function and init()
-2. Define an options struct with `flag:`, `flagdescr:`, and `default:` struct tags
+2. Define an options struct with `flag:`, `flagdescr:`, `flaggroup:`, and `default:` struct tags
 3. Call `structcli.Bind(cmd, opts)` in the constructor (replaces manual flag registration)
 4. Add client method in `internal/client/<group>.go`
 5. Add GraphQL query in `queries/<operation>.graphql`
 6. Add model structs in `internal/models/` if needed
 7. Add tests in `cmd/<group>_test.go`
+
+Use `flaggroup:` on every non-trivial flag so `--jsonschema=tree` and MCP tool metadata are useful to LLM agents. Prefer `Validate()` over `flagrequired:"true"` for conditional requirements or domain errors that must preserve the JSON error envelope and MarketSurge exit codes.

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -18,7 +18,10 @@ import (
 	"github.com/major/marketsurge-agent/internal/output"
 )
 
-const defaultCatalogRunLimit = 50
+const (
+	defaultCatalogRunLimit       = 50
+	structcliFlagGroupAnnotation = "leodido/structcli/flag-groups"
+)
 
 var watchlistFieldAliases = map[string]string{
 	"symbol":                      "symbol",
@@ -101,16 +104,16 @@ Workflow:
 
 // CatalogRunOptions holds flags for the catalog run command.
 type CatalogRunOptions struct {
-	Kind          models.CatalogKind `flag:"kind" flagdescr:"Catalog kind to run: watchlist, report, coach_screen" flagcustom:"true"`
-	ReportID      int                `flag:"report-id" flagdescr:"Report ID (required when kind=report)"`
-	WatchlistID   int64              `flag:"watchlist-id" flagdescr:"Watchlist ID (required when kind=watchlist)"`
-	CoachScreenID string             `flag:"coach-screen-id" flagdescr:"Coach screen ID (required when kind=coach_screen)"`
-	Limit         int                `flag:"limit" flagdescr:"Maximum number of results to return" default:"50"`
-	Offset        int                `flag:"offset" flagdescr:"Number of results to skip"`
-	Fields        []string           `flag:"fields" flagdescr:"Fields to include in results"`
+	Kind          models.CatalogKind `flag:"kind" flaggroup:"Catalog Selection" flagdescr:"Required catalog kind to run (watchlist, report, coach_screen); screens are list-only" flagcustom:"true"`
+	ReportID      int                `flag:"report-id" flaggroup:"Kind-Specific IDs" flagdescr:"Report ID; required when kind=report (discover with catalog list --kind report)"`
+	WatchlistID   int64              `flag:"watchlist-id" flaggroup:"Kind-Specific IDs" flagdescr:"Watchlist ID; required when kind=watchlist (discover with catalog list --kind watchlist)"`
+	CoachScreenID string             `flag:"coach-screen-id" flaggroup:"Kind-Specific IDs" flagdescr:"Coach screen ID; required when kind=coach_screen (discover with catalog list --kind coach_screen)"`
+	Limit         int                `flag:"limit" flaggroup:"Pagination" flagdescr:"Maximum number of results to return" default:"50"`
+	Offset        int                `flag:"offset" flaggroup:"Pagination" flagdescr:"Number of results to skip for pagination"`
+	Fields        []string           `flag:"fields" flaggroup:"Filtering & Projection" flagdescr:"Project specific result fields, such as symbol, price, composite_rating, eps_rating, rs_rating"`
 	MinComposite  *int
 	MinRS         *int
-	ExcludeSPACs  bool `flag:"exclude-spacs" flagdescr:"Exclude SPACs from results"`
+	ExcludeSPACs  bool `flag:"exclude-spacs" flaggroup:"Filtering & Projection" flagdescr:"Exclude SPAC/blank-check entries from results"`
 }
 
 // DefineKind keeps catalog kind parsing in Validate so missing and invalid kind
@@ -204,8 +207,8 @@ Useful flags:
   --fields            Project columns: symbol, price, composite_rating,
                       eps_rating, rs_rating, acc_dis_rating, smr_rating,
                       industry_name, market_cap, volume_dollar_avg_50d
-  --min-composite     Minimum composite rating filter
-  --min-rs            Minimum RS rating filter
+  --min-composite     Minimum composite rating for report/watchlist rows
+  --min-rs            Minimum RS rating for report/watchlist rows
   --exclude-spacs     Exclude SPAC/blank-check entries
 
 Coach screen rows are paginated, but field projection and filters do
@@ -231,8 +234,13 @@ not behave like report or watchlist rows.`,
 	if err := structcli.Bind(cmd, opts); err != nil {
 		panic(err)
 	}
-	cmd.Flags().Int("min-composite", 0, "Minimum composite rating filter (0-99)")
-	cmd.Flags().Int("min-rs", 0, "Minimum RS rating filter (0-99)")
+	cmd.Flags().Int("min-composite", 0, "Minimum composite rating for report/watchlist rows (0-99); omitted when unset")
+	cmd.Flags().Int("min-rs", 0, "Minimum RS rating for report/watchlist rows (0-99); omitted when unset")
+	for _, name := range []string{"min-composite", "min-rs"} {
+		if err := cmd.Flags().SetAnnotation(name, structcliFlagGroupAnnotation, []string{"Filtering & Projection"}); err != nil {
+			panic(err)
+		}
+	}
 	return cmd
 }
 
@@ -383,7 +391,7 @@ func normalizeWatchlistField(field string) (string, bool) {
 
 // CatalogListOptions holds flags for the catalog list command.
 type CatalogListOptions struct {
-	Kind models.CatalogKind `flag:"kind" flagdescr:"Catalog kind: watchlist, report, coach_screen, screen" flagcustom:"true"`
+	Kind models.CatalogKind `flag:"kind" flaggroup:"Filtering" flagdescr:"Filter by catalog kind (watchlist, report, coach_screen, screen); omit to list all sources" flagcustom:"true"`
 }
 
 // DefineKind keeps catalog kind parsing in RunE so invalid list kinds continue

--- a/cmd/catalog_test.go
+++ b/cmd/catalog_test.go
@@ -357,7 +357,8 @@ func TestCatalogListStructTags(t *testing.T) {
 	field, ok := typ.FieldByName("Kind")
 	require.True(t, ok, "Kind field should exist")
 	assert.Equal(t, "kind", field.Tag.Get("flag"))
-	assert.Equal(t, "Catalog kind: watchlist, report, coach_screen, screen", field.Tag.Get("flagdescr"))
+	assert.Equal(t, "Filtering", field.Tag.Get("flaggroup"))
+	assert.Equal(t, "Filter by catalog kind (watchlist, report, coach_screen, screen); omit to list all sources", field.Tag.Get("flagdescr"))
 }
 
 func TestCatalogRunStructTags(t *testing.T) {
@@ -367,17 +368,18 @@ func TestCatalogRunStructTags(t *testing.T) {
 	tests := []struct {
 		field        string
 		flag         string
+		group        string
 		descr        string
 		defaultValue string
 	}{
-		{field: "Kind", flag: "kind", descr: "Catalog kind to run: watchlist, report, coach_screen"},
-		{field: "ReportID", flag: "report-id", descr: "Report ID (required when kind=report)"},
-		{field: "WatchlistID", flag: "watchlist-id", descr: "Watchlist ID (required when kind=watchlist)"},
-		{field: "CoachScreenID", flag: "coach-screen-id", descr: "Coach screen ID (required when kind=coach_screen)"},
-		{field: "Limit", flag: "limit", descr: "Maximum number of results to return", defaultValue: "50"},
-		{field: "Offset", flag: "offset", descr: "Number of results to skip"},
-		{field: "Fields", flag: "fields", descr: "Fields to include in results"},
-		{field: "ExcludeSPACs", flag: "exclude-spacs", descr: "Exclude SPACs from results"},
+		{field: "Kind", flag: "kind", group: "Catalog Selection", descr: "Required catalog kind to run (watchlist, report, coach_screen); screens are list-only"},
+		{field: "ReportID", flag: "report-id", group: "Kind-Specific IDs", descr: "Report ID; required when kind=report (discover with catalog list --kind report)"},
+		{field: "WatchlistID", flag: "watchlist-id", group: "Kind-Specific IDs", descr: "Watchlist ID; required when kind=watchlist (discover with catalog list --kind watchlist)"},
+		{field: "CoachScreenID", flag: "coach-screen-id", group: "Kind-Specific IDs", descr: "Coach screen ID; required when kind=coach_screen (discover with catalog list --kind coach_screen)"},
+		{field: "Limit", flag: "limit", group: "Pagination", descr: "Maximum number of results to return", defaultValue: "50"},
+		{field: "Offset", flag: "offset", group: "Pagination", descr: "Number of results to skip for pagination"},
+		{field: "Fields", flag: "fields", group: "Filtering & Projection", descr: "Project specific result fields, such as symbol, price, composite_rating, eps_rating, rs_rating"},
+		{field: "ExcludeSPACs", flag: "exclude-spacs", group: "Filtering & Projection", descr: "Exclude SPAC/blank-check entries from results"},
 	}
 
 	for _, tt := range tests {
@@ -385,6 +387,7 @@ func TestCatalogRunStructTags(t *testing.T) {
 			f, ok := typ.FieldByName(tt.field)
 			require.True(t, ok, "field %s should exist", tt.field)
 			assert.Equal(t, tt.flag, f.Tag.Get("flag"))
+			assert.Equal(t, tt.group, f.Tag.Get("flaggroup"))
 			assert.Equal(t, tt.descr, f.Tag.Get("flagdescr"))
 			assert.Equal(t, tt.defaultValue, f.Tag.Get("default"))
 		})
@@ -395,6 +398,27 @@ func TestCatalogRunStructTags(t *testing.T) {
 			f, ok := typ.FieldByName(field)
 			require.True(t, ok, "field %s should exist", field)
 			assert.Empty(t, f.Tag.Get("flag"), "pointer field should stay untagged")
+		})
+	}
+}
+
+func TestCatalogRunManualFilterFlags(t *testing.T) {
+	t.Parallel()
+
+	cmd := newCatalogRunCmd()
+	tests := []struct {
+		name  string
+		descr string
+	}{
+		{name: "min-composite", descr: "Minimum composite rating for report/watchlist rows (0-99); omitted when unset"},
+		{name: "min-rs", descr: "Minimum RS rating for report/watchlist rows (0-99); omitted when unset"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flag := cmd.Flags().Lookup(tt.name)
+			require.NotNil(t, flag)
+			assert.Equal(t, tt.descr, flag.Usage)
+			assert.Equal(t, []string{"Filtering & Projection"}, flag.Annotations[structcliFlagGroupAnnotation])
 		})
 	}
 }
@@ -664,8 +688,8 @@ func TestCatalogRunOptionsFromCommand(t *testing.T) {
 		opts := &CatalogRunOptions{}
 		cmd := &cobra.Command{Use: "test"}
 		require.NoError(t, structcli.Bind(cmd, opts))
-		cmd.Flags().Int("min-composite", 0, "Minimum composite rating filter (0-99)")
-		cmd.Flags().Int("min-rs", 0, "Minimum RS rating filter (0-99)")
+		cmd.Flags().Int("min-composite", 0, "Minimum composite rating for report/watchlist rows (0-99); omitted when unset")
+		cmd.Flags().Int("min-rs", 0, "Minimum RS rating for report/watchlist rows (0-99); omitted when unset")
 
 		require.NoError(t, cmd.ParseFlags([]string{"--min-composite", "0"}))
 		opts.FromCommand(cmd)
@@ -680,8 +704,8 @@ func TestCatalogRunOptionsFromCommand(t *testing.T) {
 		opts := &CatalogRunOptions{}
 		cmd := &cobra.Command{Use: "test"}
 		require.NoError(t, structcli.Bind(cmd, opts))
-		cmd.Flags().Int("min-composite", 0, "Minimum composite rating filter (0-99)")
-		cmd.Flags().Int("min-rs", 0, "Minimum RS rating filter (0-99)")
+		cmd.Flags().Int("min-composite", 0, "Minimum composite rating for report/watchlist rows (0-99); omitted when unset")
+		cmd.Flags().Int("min-rs", 0, "Minimum RS rating for report/watchlist rows (0-99); omitted when unset")
 
 		require.NoError(t, cmd.ParseFlags([]string{}))
 		opts.FromCommand(cmd)

--- a/cmd/chart.go
+++ b/cmd/chart.go
@@ -36,8 +36,8 @@ downstream renderer understands the format.`,
 
 // ChartMarkupsOptions holds flags for the chart markups command.
 type ChartMarkupsOptions struct {
-	Frequency models.Frequency     `flag:"frequency" flagdescr:"Chart frequency: DAILY or WEEKLY" default:"DAILY"`
-	SortDir   models.SortDirection `flag:"sort-dir" flagdescr:"Sort direction: ASC or DESC" default:"ASC"`
+	Frequency models.Frequency     `flag:"frequency" flaggroup:"Options" flagdescr:"Chart candle frequency for markup lookup (DAILY or WEEKLY)" default:"DAILY"`
+	SortDir   models.SortDirection `flag:"sort-dir" flaggroup:"Options" flagdescr:"Sort direction for markup annotations (ASC or DESC)" default:"ASC"`
 }
 
 func newChartMarkupsCmd() *cobra.Command {
@@ -83,11 +83,11 @@ const defaultExchangeName = "NYSE"
 // Lookback stays string (not models.Lookback) because it is optional with no default;
 // structcli's enum decoder rejects empty string for registered enums.
 type ChartHistoryOptions struct {
-	StartDate string        `flag:"start-date" flagdescr:"Start date (YYYY-MM-DD), mutually exclusive with --lookback"`
-	EndDate   string        `flag:"end-date" flagdescr:"End date (YYYY-MM-DD), mutually exclusive with --lookback"`
-	Lookback  string        `flag:"lookback" flagdescr:"Lookback period: 1W, 1M, 3M, 6M, 1Y, YTD"`
-	Period    models.Period `flag:"period" flagdescr:"Data period: daily or weekly" default:"daily"`
-	Benchmark string        `flag:"benchmark" flagdescr:"Benchmark symbol for relative strength"`
+	StartDate string        `flag:"start-date" flaggroup:"Date Range" flagdescr:"Start date in YYYY-MM-DD format; requires --end-date and is mutually exclusive with --lookback"`
+	EndDate   string        `flag:"end-date" flaggroup:"Date Range" flagdescr:"End date in YYYY-MM-DD format; requires --start-date and is mutually exclusive with --lookback"`
+	Lookback  string        `flag:"lookback" flaggroup:"Date Range" flagdescr:"Relative lookback period (1W, 1M, 3M, 6M, 1Y, YTD); mutually exclusive with --start-date/--end-date"`
+	Period    models.Period `flag:"period" flaggroup:"Options" flagdescr:"Data period granularity (daily or weekly)" default:"daily"`
+	Benchmark string        `flag:"benchmark" flaggroup:"Options" flagdescr:"Benchmark symbol for relative strength comparison"`
 }
 
 // Validate checks mutual exclusion and required-field constraints for chart history flags.

--- a/cmd/chart_test.go
+++ b/cmd/chart_test.go
@@ -279,8 +279,12 @@ func TestChartMarkupsStructTags(t *testing.T) {
 		wantType reflect.Type
 	}{
 		{"Frequency", "flag", "frequency", reflect.TypeFor[models.Frequency]()},
+		{"Frequency", "flaggroup", "Options", reflect.TypeFor[models.Frequency]()},
+		{"Frequency", "flagdescr", "Chart candle frequency for markup lookup (DAILY or WEEKLY)", reflect.TypeFor[models.Frequency]()},
 		{"Frequency", "default", "DAILY", reflect.TypeFor[models.Frequency]()},
 		{"SortDir", "flag", "sort-dir", reflect.TypeFor[models.SortDirection]()},
+		{"SortDir", "flaggroup", "Options", reflect.TypeFor[models.SortDirection]()},
+		{"SortDir", "flagdescr", "Sort direction for markup annotations (ASC or DESC)", reflect.TypeFor[models.SortDirection]()},
 		{"SortDir", "default", "ASC", reflect.TypeFor[models.SortDirection]()},
 	}
 
@@ -308,11 +312,21 @@ func TestChartHistoryStructTags(t *testing.T) {
 		wantType reflect.Type
 	}{
 		{"StartDate", "flag", "start-date", reflect.TypeFor[string]()},
+		{"StartDate", "flaggroup", "Date Range", reflect.TypeFor[string]()},
+		{"StartDate", "flagdescr", "Start date in YYYY-MM-DD format; requires --end-date and is mutually exclusive with --lookback", reflect.TypeFor[string]()},
 		{"EndDate", "flag", "end-date", reflect.TypeFor[string]()},
+		{"EndDate", "flaggroup", "Date Range", reflect.TypeFor[string]()},
+		{"EndDate", "flagdescr", "End date in YYYY-MM-DD format; requires --start-date and is mutually exclusive with --lookback", reflect.TypeFor[string]()},
 		{"Lookback", "flag", "lookback", reflect.TypeFor[string]()},
+		{"Lookback", "flaggroup", "Date Range", reflect.TypeFor[string]()},
+		{"Lookback", "flagdescr", "Relative lookback period (1W, 1M, 3M, 6M, 1Y, YTD); mutually exclusive with --start-date/--end-date", reflect.TypeFor[string]()},
 		{"Period", "flag", "period", reflect.TypeFor[models.Period]()},
+		{"Period", "flaggroup", "Options", reflect.TypeFor[models.Period]()},
+		{"Period", "flagdescr", "Data period granularity (daily or weekly)", reflect.TypeFor[models.Period]()},
 		{"Period", "default", "daily", reflect.TypeFor[models.Period]()},
 		{"Benchmark", "flag", "benchmark", reflect.TypeFor[string]()},
+		{"Benchmark", "flaggroup", "Options", reflect.TypeFor[string]()},
+		{"Benchmark", "flagdescr", "Benchmark symbol for relative strength comparison", reflect.TypeFor[string]()},
 	}
 
 	rt := reflect.TypeFor[ChartHistoryOptions]()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,8 +32,8 @@ var clientKey = clientKeyType{}
 
 // RootOptions holds persistent flag values for the root command.
 type RootOptions struct {
-	CookieDB string `flag:"cookie-db" flagdescr:"Path to Firefox cookie database file" flagenv:"true"`
-	Verbose  bool   `flag:"verbose" flagshort:"v" flagdescr:"Enable verbose logging" flagenv:"true"`
+	CookieDB string `flag:"cookie-db" flaggroup:"Authentication & Logging" flagdescr:"Path to Firefox cookies.sqlite file; omit to auto-discover Firefox profiles" flagenv:"true"`
+	Verbose  bool   `flag:"verbose" flagshort:"v" flaggroup:"Authentication & Logging" flagdescr:"Enable verbose logging for auth and API requests" flagenv:"true"`
 }
 
 // rootOpts is the package-level instance of RootOptions, initialized by init().

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -24,6 +25,31 @@ func TestRootJSONSchema(t *testing.T) {
 	assert.Contains(t, schema, `"MARKETSURGE_AGENT_COOKIE_DB"`)
 	assert.Contains(t, schema, `"MARKETSURGE_AGENT_VERBOSE"`)
 	assert.Contains(t, schema, `"x-structcli-config-flag": "config"`)
+}
+
+func TestRootOptionsStructTags(t *testing.T) {
+	t.Parallel()
+
+	typ := reflect.TypeFor[RootOptions]()
+	tests := []struct {
+		field string
+		flag  string
+		group string
+		descr string
+	}{
+		{field: "CookieDB", flag: "cookie-db", group: "Authentication & Logging", descr: "Path to Firefox cookies.sqlite file; omit to auto-discover Firefox profiles"},
+		{field: "Verbose", flag: "verbose", group: "Authentication & Logging", descr: "Enable verbose logging for auth and API requests"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.field, func(t *testing.T) {
+			f, ok := typ.FieldByName(tt.field)
+			require.True(t, ok, "field %s should exist", tt.field)
+			assert.Equal(t, tt.flag, f.Tag.Get("flag"), "flag tag")
+			assert.Equal(t, tt.group, f.Tag.Get("flaggroup"), "flaggroup tag")
+			assert.Equal(t, tt.descr, f.Tag.Get("flagdescr"), "flagdescr tag")
+			assert.Equal(t, "true", f.Tag.Get("flagenv"), "flagenv tag")
+		})
+	}
 }
 
 func TestRootDebugOptions(t *testing.T) {

--- a/cmd/stock.go
+++ b/cmd/stock.go
@@ -61,10 +61,10 @@ type AnalysisResult struct {
 
 // StockAnalyzeOptions holds the options for the stock analyze command.
 type StockAnalyzeOptions struct {
-	Tickers []string `flag:"tickers" flagshort:"t" flagdescr:"Additional stock symbols to analyze"`
-	Compact bool     `flag:"compact" flagdescr:"Use compact output format"`
-	Flat    bool     `flag:"flat" flagdescr:"Use flat output format"`
-	Summary bool     `flag:"summary" flagdescr:"Include summary statistics"`
+	Tickers []string `flag:"tickers" flagshort:"t" flaggroup:"Input" flagdescr:"Additional stock symbols to analyze; accepts comma-separated or repeated values"`
+	Compact bool     `flag:"compact" flaggroup:"Output Format" flagdescr:"Remove duplicate formatted string fields while keeping raw numeric values"`
+	Flat    bool     `flag:"flat" flaggroup:"Output Format" flagdescr:"Flatten nested analysis fields into single-level JSON keys"`
+	Summary bool     `flag:"summary" flaggroup:"Output Format" flagdescr:"Return compact screening objects for ranking many symbols"`
 }
 
 // MergeSymbols merges positional arguments with --tickers flag values, deduplicating and trimming whitespace.

--- a/cmd/stock_test.go
+++ b/cmd/stock_test.go
@@ -279,19 +279,21 @@ func TestStockAnalyzeStructTags(t *testing.T) {
 		field    string
 		flag     string
 		short    string
+		group    string
 		descr    string
 		hasShort bool
 	}{
-		{field: "Tickers", flag: "tickers", short: "t", descr: "Additional stock symbols to analyze", hasShort: true},
-		{field: "Compact", flag: "compact", descr: "Use compact output format"},
-		{field: "Flat", flag: "flat", descr: "Use flat output format"},
-		{field: "Summary", flag: "summary", descr: "Include summary statistics"},
+		{field: "Tickers", flag: "tickers", short: "t", group: "Input", descr: "Additional stock symbols to analyze; accepts comma-separated or repeated values", hasShort: true},
+		{field: "Compact", flag: "compact", group: "Output Format", descr: "Remove duplicate formatted string fields while keeping raw numeric values"},
+		{field: "Flat", flag: "flat", group: "Output Format", descr: "Flatten nested analysis fields into single-level JSON keys"},
+		{field: "Summary", flag: "summary", group: "Output Format", descr: "Return compact screening objects for ranking many symbols"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.field, func(t *testing.T) {
 			f, ok := typ.FieldByName(tt.field)
 			require.True(t, ok, "field %s should exist", tt.field)
 			assert.Equal(t, tt.flag, f.Tag.Get("flag"), "flag tag")
+			assert.Equal(t, tt.group, f.Tag.Get("flaggroup"), "flaggroup tag")
 			assert.Equal(t, tt.descr, f.Tag.Get("flagdescr"), "flagdescr tag")
 			if tt.hasShort {
 				assert.Equal(t, tt.short, f.Tag.Get("flagshort"), "flagshort tag")


### PR DESCRIPTION
## Summary
- Add structcli flag groups and richer descriptions so `--jsonschema=tree` and MCP metadata are easier for agents to use.
- Document `--jsonschema=tree` as the preferred LLM schema source while preserving command-level validation for conditional/domain errors.
- Add tests for schema tags and manually registered catalog filter metadata.

## Verification
- `go run ./cmd/marketsurge-agent --jsonschema=tree` plus schema metadata assertions
- `go test ./cmd -run 'Test(RootOptionsStructTags|CatalogRunManualFilterFlags|CatalogRunStructTags)'`
- `go test -v -race -coverprofile=coverage.out ./...`
- `golangci-lint run ./...`
- `go build ./cmd/marketsurge-agent`

CodeRabbit local review skipped by request.