### PR TITLE
feat(cmd): expose symbol inputs as flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,14 @@ Without `--config`, structcli searches its default config locations for `config.
 # Get stock data for a single symbol
 marketsurge-agent stock get AAPL
 
+# Equivalent schema-visible flag form for agents and MCP clients
+marketsurge-agent stock get --symbol AAPL
+
 # Analyze multiple symbols concurrently
 marketsurge-agent stock analyze AAPL MSFT NVDA GOOG
 
 # Analyze a comma-separated batch and remove formatted duplicate fields
-marketsurge-agent stock analyze --tickers AAPL,MSFT,NVDA --compact
+marketsurge-agent stock analyze --symbols AAPL,MSFT,NVDA --compact
 
 # Return screening fields for ranking many candidates
 marketsurge-agent stock analyze --summary AAPL MSFT NVDA
@@ -79,7 +82,7 @@ marketsurge-agent ownership get AMZN
 marketsurge-agent rs-history get META NVDA
 
 # Chart price history (daily, last 3 months)
-marketsurge-agent chart history AAPL --lookback 3M
+marketsurge-agent chart history --symbol AAPL --lookback 3M
 
 # Chart markups and annotations
 marketsurge-agent chart markups AAPL
@@ -119,13 +122,13 @@ Errors follow the same pattern:
 
 | Command | Description |
 |---|---|
-| `stock get <symbol>` | Stock data (ratings, pricing, financials) |
-| `stock analyze [symbols...]` | Concurrent single-symbol or multi-symbol analysis with optional compact, flat, summary, and comma-separated batch modes |
-| `fundamental get <symbol>` | Fundamental analysis data |
-| `ownership get <symbol>` | Institutional ownership |
-| `rs-history get [symbols...]` | Relative strength rating history for one or more symbols |
-| `chart history <symbol>` | Price history (daily or weekly) |
-| `chart markups <symbol>` | Chart annotations and markups |
+| `stock get <symbol>` / `stock get --symbol SYMBOL` | Stock data (ratings, pricing, financials) |
+| `stock analyze [symbols...]` / `stock analyze --symbols SYMBOLS` | Concurrent single-symbol or multi-symbol analysis with optional compact, flat, summary, and comma-separated batch modes |
+| `fundamental get <symbol>` / `fundamental get --symbol SYMBOL` | Fundamental analysis data |
+| `ownership get <symbol>` / `ownership get --symbol SYMBOL` | Institutional ownership |
+| `rs-history get [symbols...]` / `rs-history get --symbols SYMBOLS` | Relative strength rating history for one or more symbols |
+| `chart history <symbol>` / `chart history --symbol SYMBOL` | Price history (daily or weekly) |
+| `chart markups <symbol>` / `chart markups --symbol SYMBOL` | Chart annotations and markups |
 | `catalog list` | List watchlists, screens, reports |
 | `catalog run` | Run a watchlist, coach screen, or report |
 | `completion <shell>` | Generate shell completion script (bash, zsh, fish, powershell) |
@@ -169,17 +172,18 @@ marketsurge-agent --version
 `stock analyze` supports output modes designed for AI agents and batch comparison workflows:
 
 ```bash
-marketsurge-agent stock analyze --tickers AAPL,MSFT,NVDA --compact --flat
+marketsurge-agent stock analyze --symbols AAPL,MSFT,NVDA --compact --flat
 ```
 
-- `--tickers AAPL,MSFT,NVDA` analyzes comma-separated symbols in one command. Positional symbols still work and can be combined with `--tickers`.
+- `--symbols AAPL,MSFT,NVDA` analyzes comma-separated symbols in one command. Positional symbols still work and can be combined with `--symbols`.
+- `--tickers AAPL,MSFT,NVDA` remains supported as a backward-compatible alias for `stock analyze`.
 - `--compact` removes duplicate formatted string fields such as `market_cap_formatted`, while keeping raw numeric values.
 - `--summary` returns one small screening object per symbol with rankings, signal flags, base details, liquidity, volatility, and ownership fields. Response metadata includes `mode: "summary"`.
 - `--flat` flattens each analysis result inside the standard JSON envelope, for example `stock.pricing.market_cap` becomes `pricing_market_cap`.
 
 `stock analyze` also includes MarketSurge technical context for chart-driven screening: `stock.base_pattern` summarizes the current base with pattern type, base stage, pivot price, base length, depth, and volume at pivot; `stock.signals` reports blue dot and ant signal flags when the API provides them.
 
-`rs-history get` accepts multiple symbols in one request. Multi-symbol output uses a `data` object keyed by ticker so agents can compare RS trends without shell loops.
+`rs-history get` accepts multiple symbols in one request through positional arguments or `--symbols`. Multi-symbol output uses a `data` object keyed by ticker so agents can compare RS trends without shell loops.
 
 ### Schema discovery
 

--- a/cmd/AGENTS.md
+++ b/cmd/AGENTS.md
@@ -46,6 +46,8 @@ The root command enables structcli's stdio MCP server with `structcli.WithMCP()`
 
 Shell completion subcommands are excluded from MCP tool discovery because they are not useful agent-callable API tools. Keep the MCP tool list focused on MarketSurge data commands.
 
+MCP argument conversion maps tool arguments to flags, not positional arguments. Any API command that requires stock symbols must expose those symbols through schema-visible structcli flags (`--symbol` for single-symbol commands, `--symbols` for multi-symbol commands) while preserving positional arguments for shell compatibility.
+
 ### Test pattern
 
 Tests call constructors directly (not package-level vars) and inject client via context:
@@ -78,6 +80,7 @@ Commands use option structs with structcli struct tags to encapsulate flags and 
 
 ```go
 type ChartMarkupsOptions struct {
+    Symbol    string               `flag:"symbol" flagshort:"s" flaggroup:"Input" flagdescr:"Stock symbol to fetch"`
     Frequency models.Frequency    `flag:"frequency" default:"DAILY" flagdescr:"Chart frequency"`
     SortDir   models.SortDirection `flag:"sort-dir" default:"ASC" flagdescr:"Sort direction"`
 }
@@ -87,8 +90,12 @@ func newChartMarkupsCmd() *cobra.Command {
     cmd := &cobra.Command{
         Use:   "markups <symbol>",
         Short: "Get chart markup data for a symbol",
+        Args:  cobra.ArbitraryArgs,
         RunE: func(cmd *cobra.Command, args []string) error {
-            symbol := args[0]
+            symbol, err := resolveSingleSymbol(args, opts.Symbol)
+            if err != nil {
+                return err
+            }
             c := ClientFromContext(cmd.Context())
             data, err := c.GetChartMarkups(cmd.Context(), symbol, string(opts.Frequency), string(opts.SortDir))
             if err != nil {
@@ -128,6 +135,12 @@ This is the only place where `cmd.Flags().GetXxx()` is acceptable in RunE.
 **Optional enum fields:**
 
 Fields with no `default:` struct tag must stay `string` type. structcli rejects an empty string for a registered enum during unmarshal, before `Validate()` can return a typed `ValidationError`. Only use typed enum fields when a non-empty default is always present (e.g., `Frequency`, `SortDir`, `Period`). Fields like `Lookback` stay `string` with manual validation.
+
+### Schema-visible symbol flags
+
+Use `newSymbolCmd()` for single-symbol commands. It exposes `--symbol/-s` through structcli and still accepts one positional `<symbol>` for shell users. Commands with their own option structs, such as `chart history` and `chart markups`, add a `Symbol string` field with the same `flag:"symbol"` tags and call `resolveSingleSymbol(args, opts.Symbol)`.
+
+Use `--symbols/-s` for multi-symbol commands. Merge positional symbols and flag values with `mergeSymbolInputs()` so repeated flags, comma-separated values, and positional arguments deduplicate consistently.
 
 ## Adding a new command
 

--- a/cmd/chart.go
+++ b/cmd/chart.go
@@ -36,6 +36,7 @@ downstream renderer understands the format.`,
 
 // ChartMarkupsOptions holds flags for the chart markups command.
 type ChartMarkupsOptions struct {
+	Symbol    string               `flag:"symbol" flagshort:"s" flaggroup:"Input" flagdescr:"Stock symbol to fetch, for example AAPL; positional <symbol> remains supported for shell use"`
 	Frequency models.Frequency     `flag:"frequency" flaggroup:"Options" flagdescr:"Chart candle frequency for markup lookup (DAILY or WEEKLY)" default:"DAILY"`
 	SortDir   models.SortDirection `flag:"sort-dir" flaggroup:"Options" flagdescr:"Sort direction for markup annotations (ASC or DESC)" default:"ASC"`
 }
@@ -54,9 +55,12 @@ Flags:
 
 Markup data is opaque serialized chart data. Do not parse it unless
 a downstream MarketSurge-specific renderer understands the format.`,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			symbol := args[0]
+			symbol, err := resolveSingleSymbol(args, opts.Symbol)
+			if err != nil {
+				return err
+			}
 			c := ClientFromContext(cmd.Context())
 			data, err := c.GetChartMarkups(cmd.Context(), symbol, string(opts.Frequency), string(opts.SortDir))
 			if err != nil {
@@ -83,6 +87,7 @@ const defaultExchangeName = "NYSE"
 // Lookback stays string (not models.Lookback) because it is optional with no default;
 // structcli's enum decoder rejects empty string for registered enums.
 type ChartHistoryOptions struct {
+	Symbol    string        `flag:"symbol" flagshort:"s" flaggroup:"Input" flagdescr:"Stock symbol to fetch, for example AAPL; positional <symbol> remains supported for shell use"`
 	StartDate string        `flag:"start-date" flaggroup:"Date Range" flagdescr:"Start date in YYYY-MM-DD format; requires --end-date and is mutually exclusive with --lookback"`
 	EndDate   string        `flag:"end-date" flaggroup:"Date Range" flagdescr:"End date in YYYY-MM-DD format; requires --start-date and is mutually exclusive with --lookback"`
 	Lookback  string        `flag:"lookback" flaggroup:"Date Range" flagdescr:"Relative lookback period (1W, 1M, 3M, 6M, 1Y, YTD); mutually exclusive with --start-date/--end-date"`
@@ -156,9 +161,12 @@ Other flags:
 
 Output: time_series.data_points with OHLCV fields, quote, exchange,
 market state, and optional benchmark candles.`,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			symbol := args[0]
+			symbol, err := resolveSingleSymbol(args, opts.Symbol)
+			if err != nil {
+				return err
+			}
 
 			if errs := opts.Validate(cmd.Context()); errs != nil {
 				return errs[0]

--- a/cmd/chart_test.go
+++ b/cmd/chart_test.go
@@ -26,6 +26,18 @@ func TestChartMarkupsSuccess(t *testing.T) {
 	assertSymbolMeta(t, result, "AAPL")
 }
 
+func TestChartMarkupsSymbolFlag(t *testing.T) {
+	t.Parallel()
+	server := jsonServer(chartMarkupsFixture())
+	defer server.Close()
+	c := testClient(t, server)
+
+	output, err := executeChartCmd(t, c, "markups", "--symbol", "AAPL")
+	require.NoError(t, err)
+	result := parseJSONEnvelope(t, output)
+	assertSymbolMeta(t, result, "AAPL")
+}
+
 func TestChartMarkupsWithFlags(t *testing.T) {
 	t.Parallel()
 	server := jsonServer(chartMarkupsFixture())
@@ -70,6 +82,19 @@ func TestChartHistorySuccessWithLookback(t *testing.T) {
 		"history", "--lookback", "3M", "AAPL")
 	require.NoError(t, err)
 	parseJSONEnvelope(t, output)
+}
+
+func TestChartHistorySymbolFlag(t *testing.T) {
+	t.Parallel()
+	server := jsonServer(chartResponseFixture())
+	defer server.Close()
+	c := testClient(t, server)
+
+	output, err := executeChartCmd(t, c,
+		"history", "--symbol", "AAPL", "--lookback", "3M")
+	require.NoError(t, err)
+	result := parseJSONEnvelope(t, output)
+	assertSymbolMeta(t, result, "AAPL")
 }
 
 func TestChartHistorySymbolNotFound(t *testing.T) {
@@ -278,6 +303,10 @@ func TestChartMarkupsStructTags(t *testing.T) {
 		value    string
 		wantType reflect.Type
 	}{
+		{"Symbol", "flag", "symbol", reflect.TypeFor[string]()},
+		{"Symbol", "flagshort", "s", reflect.TypeFor[string]()},
+		{"Symbol", "flaggroup", "Input", reflect.TypeFor[string]()},
+		{"Symbol", "flagdescr", "Stock symbol to fetch, for example AAPL; positional <symbol> remains supported for shell use", reflect.TypeFor[string]()},
 		{"Frequency", "flag", "frequency", reflect.TypeFor[models.Frequency]()},
 		{"Frequency", "flaggroup", "Options", reflect.TypeFor[models.Frequency]()},
 		{"Frequency", "flagdescr", "Chart candle frequency for markup lookup (DAILY or WEEKLY)", reflect.TypeFor[models.Frequency]()},
@@ -311,6 +340,10 @@ func TestChartHistoryStructTags(t *testing.T) {
 		value    string
 		wantType reflect.Type
 	}{
+		{"Symbol", "flag", "symbol", reflect.TypeFor[string]()},
+		{"Symbol", "flagshort", "s", reflect.TypeFor[string]()},
+		{"Symbol", "flaggroup", "Input", reflect.TypeFor[string]()},
+		{"Symbol", "flagdescr", "Stock symbol to fetch, for example AAPL; positional <symbol> remains supported for shell use", reflect.TypeFor[string]()},
 		{"StartDate", "flag", "start-date", reflect.TypeFor[string]()},
 		{"StartDate", "flaggroup", "Date Range", reflect.TypeFor[string]()},
 		{"StartDate", "flagdescr", "Start date in YYYY-MM-DD format; requires --end-date and is mutually exclusive with --lookback", reflect.TypeFor[string]()},
@@ -351,14 +384,6 @@ func TestChartHistoryStructTags(t *testing.T) {
 func executeChartCmd(t *testing.T, c *client.Client, args ...string) (string, error) {
 	t.Helper()
 	cmd := newChartCmd()
-	ctx := ContextWithClient(context.Background(), c)
-	cmd.SetContext(ctx)
-	for _, child := range cmd.Commands() {
-		childCtx := child.Context()
-		if childCtx == nil {
-			childCtx = ctx
-		}
-		child.SetContext(ContextWithClient(childCtx, c))
-	}
+	setClientContext(cmd, ContextWithClient(context.Background(), c), c)
 	return executeCommand(t, cmd, args...)
 }

--- a/cmd/fundamental_test.go
+++ b/cmd/fundamental_test.go
@@ -21,6 +21,18 @@ func TestFundamentalGetSuccess(t *testing.T) {
 	assertSymbolMeta(t, result, "AAPL")
 }
 
+func TestFundamentalGetSymbolFlag(t *testing.T) {
+	t.Parallel()
+	server := jsonServer(stockResponseFixture())
+	defer server.Close()
+	c := testClient(t, server)
+
+	output, err := executeCommandWithClient(t, newFundamentalCmd(), c, "get", "--symbol", "AAPL")
+	require.NoError(t, err)
+	result := parseJSONEnvelope(t, output)
+	assertSymbolMeta(t, result, "AAPL")
+}
+
 func TestFundamentalGetSymbolNotFound(t *testing.T) {
 	t.Parallel()
 	server := jsonServer(emptyMarketDataFixture())

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -39,8 +39,20 @@ func executeCommand(t *testing.T, cmd *cobra.Command, args ...string) (string, e
 // executeCommandWithClient runs a cobra command with a client injected into the context.
 func executeCommandWithClient(t *testing.T, cmd *cobra.Command, c *client.Client, args ...string) (string, error) {
 	t.Helper()
-	cmd.SetContext(ContextWithClient(context.Background(), c))
+	setClientContext(cmd, ContextWithClient(context.Background(), c), c)
 	return executeCommand(t, cmd, args...)
+}
+
+// setClientContext layers the test client onto every command context.
+func setClientContext(cmd *cobra.Command, fallback context.Context, c *client.Client) {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = fallback
+	}
+	cmd.SetContext(ContextWithClient(ctx, c))
+	for _, child := range cmd.Commands() {
+		setClientContext(child, fallback, c)
+	}
 }
 
 // parseJSONEnvelope unmarshals output into a map and asserts it contains data and metadata keys.

--- a/cmd/ownership_test.go
+++ b/cmd/ownership_test.go
@@ -21,6 +21,18 @@ func TestOwnershipGetSuccess(t *testing.T) {
 	assertSymbolMeta(t, result, "AAPL")
 }
 
+func TestOwnershipGetSymbolFlag(t *testing.T) {
+	t.Parallel()
+	server := jsonServer(stockResponseFixture())
+	defer server.Close()
+	c := testClient(t, server)
+
+	output, err := executeCommandWithClient(t, newOwnershipCmd(), c, "get", "--symbol", "AAPL")
+	require.NoError(t, err)
+	result := parseJSONEnvelope(t, output)
+	assertSymbolMeta(t, result, "AAPL")
+}
+
 func TestOwnershipGetSymbolNotFound(t *testing.T) {
 	t.Parallel()
 	server := jsonServer(emptyMarketDataFixture())

--- a/cmd/rs_history.go
+++ b/cmd/rs_history.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/leodido/structcli"
 	"github.com/spf13/cobra"
 
+	mserrors "github.com/major/marketsurge-agent/internal/errors"
 	"github.com/major/marketsurge-agent/internal/models"
 	"github.com/major/marketsurge-agent/internal/output"
 )
@@ -37,30 +39,36 @@ checking divergence or confirmation.`,
 }
 
 func newRSHistoryGetCmd() *cobra.Command {
-	return &cobra.Command{
+	opts := &RSHistoryGetOptions{}
+	cmd := &cobra.Command{
 		Use:   "get <symbol> [symbol...]",
 		Short: "Get RS rating history for one or more symbols",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			symbols := opts.ResolveSymbols(args)
+			if len(symbols) == 0 {
+				return mserrors.NewValidationError("at least one symbol is required; pass --symbols AAPL,MSFT or positional symbols", nil)
+			}
+
 			ctx := cmd.Context()
 			c := ClientFromContext(ctx)
 
-			if len(args) == 1 {
-				data, err := c.GetRSRatingHistory(ctx, args[0])
+			if len(symbols) == 1 {
+				data, err := c.GetRSRatingHistory(ctx, symbols[0])
 				if err != nil {
 					return err
 				}
-				return output.WriteSuccess(cmd.OutOrStdout(), data, output.SymbolMeta(args[0]))
+				return output.WriteSuccess(cmd.OutOrStdout(), data, output.SymbolMeta(symbols[0]))
 			}
 
-			histories, err := c.GetRSRatingHistories(ctx, args)
+			histories, err := c.GetRSRatingHistories(ctx, symbols)
 			if err != nil {
 				return err
 			}
 
-			data, errs := orderedRSHistoryData(args, histories)
+			data, errs := orderedRSHistoryData(symbols, histories)
 			meta := map[string]any{
-				"symbols":   args,
+				"symbols":   symbols,
 				"timestamp": time.Now().UTC().Format(time.RFC3339),
 			}
 			if len(data) == 0 {
@@ -72,6 +80,20 @@ func newRSHistoryGetCmd() *cobra.Command {
 			return output.WriteSuccess(cmd.OutOrStdout(), data, meta)
 		},
 	}
+	if err := structcli.Bind(cmd, opts); err != nil {
+		panic(err)
+	}
+	return cmd
+}
+
+// RSHistoryGetOptions holds flags for the RS history get command.
+type RSHistoryGetOptions struct {
+	Symbols []string `flag:"symbols" flagshort:"s" flaggroup:"Input" flagdescr:"Stock symbols to fetch, for example AAPL,MSFT; accepts comma-separated or repeated values; positional symbols remain supported for shell use"`
+}
+
+// ResolveSymbols merges positional arguments with --symbols values.
+func (o *RSHistoryGetOptions) ResolveSymbols(args []string) []string {
+	return mergeSymbolInputs(args, o.Symbols)
 }
 
 func orderedRSHistoryData(symbols []string, histories map[string]*models.RSRatingHistory) (data map[string]*models.RSRatingHistory, errs []string) {

--- a/cmd/rs_history_test.go
+++ b/cmd/rs_history_test.go
@@ -22,6 +22,22 @@ func TestRSHistoryGetSuccess(t *testing.T) {
 	assertSymbolMeta(t, result, "AAPL")
 }
 
+func TestRSHistoryGetSymbolsFlag(t *testing.T) {
+	t.Parallel()
+	server := jsonServer(rsHistoryMultiResponseFixture())
+	defer server.Close()
+	c := testClient(t, server)
+
+	output, err := executeCommandWithClient(t, newRSHistoryCmd(), c, "get", "--symbols", "AAPL,MSFT")
+	require.NoError(t, err)
+
+	result := parseJSONEnvelope(t, output)
+	data, ok := result["data"].(map[string]any)
+	require.True(t, ok, "multi-symbol RS history should be keyed by symbol")
+	assert.Contains(t, data, "AAPL")
+	assert.Contains(t, data, "MSFT")
+}
+
 func TestRSHistoryGetMultiSymbol(t *testing.T) {
 	t.Parallel()
 	server := jsonServer(rsHistoryMultiResponseFixture())

--- a/cmd/stock.go
+++ b/cmd/stock.go
@@ -31,7 +31,7 @@ base patterns, and signal flags.
   One-symbol quote/ratings/base    stock get AAPL
   Complete research packet         stock analyze AAPL
   Compare many candidates          stock analyze --summary AAPL NVDA TSLA
-  Batch from a generated list      stock analyze --tickers AAPL,NVDA --compact
+  Batch from a generated list      stock analyze --symbols AAPL,NVDA --compact
   Parser wants one-level keys      stock analyze AAPL --flat
 
 Use "stock get" for targeted current stock data when fundamentals and
@@ -61,35 +61,16 @@ type AnalysisResult struct {
 
 // StockAnalyzeOptions holds the options for the stock analyze command.
 type StockAnalyzeOptions struct {
+	Symbols []string `flag:"symbols" flagshort:"s" flaggroup:"Input" flagdescr:"Stock symbols to analyze, for example AAPL,MSFT; accepts comma-separated or repeated values; positional symbols remain supported for shell use"`
 	Tickers []string `flag:"tickers" flagshort:"t" flaggroup:"Input" flagdescr:"Additional stock symbols to analyze; accepts comma-separated or repeated values"`
 	Compact bool     `flag:"compact" flaggroup:"Output Format" flagdescr:"Remove duplicate formatted string fields while keeping raw numeric values"`
 	Flat    bool     `flag:"flat" flaggroup:"Output Format" flagdescr:"Flatten nested analysis fields into single-level JSON keys"`
 	Summary bool     `flag:"summary" flaggroup:"Output Format" flagdescr:"Return compact screening objects for ranking many symbols"`
 }
 
-// MergeSymbols merges positional arguments with --tickers flag values, deduplicating and trimming whitespace.
+// MergeSymbols merges positional arguments with --symbols and --tickers flag values, deduplicating and trimming whitespace.
 func (o *StockAnalyzeOptions) MergeSymbols(args []string) []string {
-	symbols := make([]string, 0, len(args)+len(o.Tickers))
-	seen := make(map[string]struct{}, len(args)+len(o.Tickers))
-	addSymbol := func(symbol string) {
-		trimmed := strings.TrimSpace(symbol)
-		if trimmed == "" {
-			return
-		}
-		if _, ok := seen[trimmed]; ok {
-			return
-		}
-		seen[trimmed] = struct{}{}
-		symbols = append(symbols, trimmed)
-	}
-
-	for _, symbol := range args {
-		addSymbol(symbol)
-	}
-	for _, symbol := range o.Tickers {
-		addSymbol(symbol)
-	}
-	return symbols
+	return mergeSymbolInputs(args, o.Symbols, o.Tickers)
 }
 
 func newStockAnalyzeCmd() *cobra.Command {
@@ -98,8 +79,8 @@ func newStockAnalyzeCmd() *cobra.Command {
 		Use:   "analyze [symbol...]",
 		Short: "Analyze one or more stock symbols",
 		Long: `Fetches stock, fundamentals, and ownership concurrently for one or more
-symbols. Accepts positional symbols and --tickers comma-separated symbols
-together. Multi-symbol requests are concurrent and can return partial
+symbols. Accepts positional symbols, --symbols values, and backward-compatible
+--tickers values together. Multi-symbol requests are concurrent and can return partial
 results when only some symbols or subresources fail.
 
 Flags:

--- a/cmd/stock_test.go
+++ b/cmd/stock_test.go
@@ -28,6 +28,18 @@ func TestStockGetSuccess(t *testing.T) {
 	assertSymbolMeta(t, result, "AAPL")
 }
 
+func TestStockGetSymbolFlag(t *testing.T) {
+	t.Parallel()
+	server := jsonServer(stockResponseFixture())
+	defer server.Close()
+	c := testClient(t, server)
+
+	output, err := executeCommandWithClient(t, newStockCmd(), c, "get", "--symbol", "AAPL")
+	require.NoError(t, err)
+	result := parseJSONEnvelope(t, output)
+	assertSymbolMeta(t, result, "AAPL")
+}
+
 func TestStockGetSymbolNotFound(t *testing.T) {
 	t.Parallel()
 	server := jsonServer(emptyMarketDataFixture())
@@ -176,6 +188,25 @@ func TestStockAnalyzeTickersFlag(t *testing.T) {
 	assert.Equal(t, []any{"AAPL", "MSFT"}, symbols)
 }
 
+func TestStockAnalyzeSymbolsFlag(t *testing.T) {
+	t.Parallel()
+	server := jsonServer(stockResponseFixture())
+	defer server.Close()
+	c := testClient(t, server)
+
+	output, err := executeStockAnalyze(t, c, "analyze", "--symbols", "AAPL, MSFT")
+	require.NoError(t, err)
+
+	result := parseJSONEnvelope(t, output)
+	data, ok := result["data"].([]any)
+	require.True(t, ok, "--symbols should return multi-symbol data as an array")
+	assert.Len(t, data, 2)
+
+	meta, _ := result["metadata"].(map[string]any)
+	symbols, _ := meta["symbols"].([]any)
+	assert.Equal(t, []any{"AAPL", "MSFT"}, symbols)
+}
+
 func TestStockAnalyzeCompactOutput(t *testing.T) {
 	t.Parallel()
 	server := jsonServer(stockResponseFixture())
@@ -283,6 +314,7 @@ func TestStockAnalyzeStructTags(t *testing.T) {
 		descr    string
 		hasShort bool
 	}{
+		{field: "Symbols", flag: "symbols", short: "s", group: "Input", descr: "Stock symbols to analyze, for example AAPL,MSFT; accepts comma-separated or repeated values; positional symbols remain supported for shell use", hasShort: true},
 		{field: "Tickers", flag: "tickers", short: "t", group: "Input", descr: "Additional stock symbols to analyze; accepts comma-separated or repeated values", hasShort: true},
 		{field: "Compact", flag: "compact", group: "Output Format", descr: "Remove duplicate formatted string fields while keeping raw numeric values"},
 		{field: "Flat", flag: "flat", group: "Output Format", descr: "Flatten nested analysis fields into single-level JSON keys"},
@@ -307,23 +339,69 @@ func TestStockAnalyzeMergeSymbols(t *testing.T) {
 
 	tests := []struct {
 		name    string
+		symbols []string
 		tickers []string
 		args    []string
 		want    []string
 	}{
 		{name: "positional only", args: []string{"AAPL"}, want: []string{"AAPL"}},
+		{name: "symbols only", symbols: []string{"AAPL,MSFT"}, want: []string{"AAPL", "MSFT"}},
 		{name: "tickers only", tickers: []string{"MSFT"}, want: []string{"MSFT"}},
-		{name: "both merged", tickers: []string{"MSFT"}, args: []string{"AAPL"}, want: []string{"AAPL", "MSFT"}},
+		{name: "all merged", symbols: []string{"MSFT"}, tickers: []string{"NVDA"}, args: []string{"AAPL"}, want: []string{"AAPL", "MSFT", "NVDA"}},
 		{name: "deduplicates", tickers: []string{"AAPL"}, args: []string{"AAPL"}, want: []string{"AAPL"}},
 		{name: "trims whitespace", tickers: []string{" MSFT "}, args: []string{" AAPL "}, want: []string{"AAPL", "MSFT"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			opts := &StockAnalyzeOptions{Tickers: tt.tickers}
+			opts := &StockAnalyzeOptions{Symbols: tt.symbols, Tickers: tt.tickers}
 			got := opts.MergeSymbols(tt.args)
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestResolveSingleSymbol(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		args       []string
+		symbolFlag string
+		want       string
+		wantErr    bool
+	}{
+		{name: "flag only", symbolFlag: "AAPL", want: "AAPL"},
+		{name: "positional only", args: []string{"MSFT"}, want: "MSFT"},
+		{name: "matching flag and positional", args: []string{"AAPL"}, symbolFlag: "AAPL", want: "AAPL"},
+		{name: "trims whitespace", args: []string{" MSFT "}, symbolFlag: "  ", want: "MSFT"},
+		{name: "missing symbol", wantErr: true},
+		{name: "conflicting flag and positional", args: []string{"MSFT"}, symbolFlag: "AAPL", wantErr: true},
+		{name: "too many positional", args: []string{"AAPL", "MSFT"}, wantErr: true},
+		{name: "empty flag and empty positional", args: []string{"  "}, symbolFlag: " ", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveSingleSymbol(tt.args, tt.symbolFlag)
+			if tt.wantErr {
+				require.Error(t, err)
+				var verr *mserrors.ValidationError
+				assert.ErrorAs(t, err, &verr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMultiSymbolOptionsResolveSymbols(t *testing.T) {
+	t.Parallel()
+
+	opts := &MultiSymbolOptions{Symbols: []string{" MSFT,NVDA ", "AAPL"}}
+	got := opts.ResolveSymbols([]string{"AAPL", "TSLA"}, []string{"NVDA,AMD"})
+
+	assert.Equal(t, []string{"AAPL", "TSLA", "MSFT", "NVDA", "AMD"}, got)
 }
 
 func TestStockAnalyzeMissingSymbol(t *testing.T) {
@@ -358,15 +436,7 @@ func TestStockAnalyzeTotalFailure(t *testing.T) {
 func executeStockAnalyze(t *testing.T, c *client.Client, args ...string) (string, error) {
 	t.Helper()
 	cmd := newStockCmd()
-	ctx := ContextWithClient(context.Background(), c)
-	cmd.SetContext(ctx)
-	for _, child := range cmd.Commands() {
-		childCtx := child.Context()
-		if childCtx == nil {
-			childCtx = ctx
-		}
-		child.SetContext(ContextWithClient(childCtx, c))
-	}
+	setClientContext(cmd, ContextWithClient(context.Background(), c), c)
 	return executeCommand(t, cmd, args...)
 }
 

--- a/cmd/symbol.go
+++ b/cmd/symbol.go
@@ -3,24 +3,105 @@ package cmd
 
 import (
 	"context"
+	"strings"
 
+	"github.com/leodido/structcli"
 	"github.com/spf13/cobra"
 
+	mserrors "github.com/major/marketsurge-agent/internal/errors"
 	"github.com/major/marketsurge-agent/internal/output"
 )
 
 // symbolFetcher retrieves data for a single symbol from the MarketSurge API.
 type symbolFetcher func(ctx context.Context, symbol string) (any, error)
 
+// SymbolOptions holds schema-visible symbol input for single-symbol commands.
+type SymbolOptions struct {
+	Symbol string `flag:"symbol" flagshort:"s" flaggroup:"Input" flagdescr:"Stock symbol to fetch, for example AAPL; positional <symbol> remains supported for shell use"`
+}
+
+// ResolveSymbol returns the symbol from --symbol or one positional argument.
+func (o *SymbolOptions) ResolveSymbol(args []string) (string, error) {
+	return resolveSingleSymbol(args, o.Symbol)
+}
+
+// resolveSingleSymbol returns the symbol from a flag value or one positional argument.
+func resolveSingleSymbol(args []string, symbolFlag string) (string, error) {
+	if len(args) > 1 {
+		return "", mserrors.NewValidationError("expected at most one positional symbol; pass --symbol AAPL or positional AAPL", nil)
+	}
+
+	flagSymbol := strings.TrimSpace(symbolFlag)
+	positionalSymbol := ""
+	if len(args) == 1 {
+		positionalSymbol = strings.TrimSpace(args[0])
+	}
+
+	if flagSymbol != "" && positionalSymbol != "" && flagSymbol != positionalSymbol {
+		return "", mserrors.NewValidationError("cannot use different values for --symbol and positional <symbol>", nil)
+	}
+	if flagSymbol != "" {
+		return flagSymbol, nil
+	}
+	if positionalSymbol != "" {
+		return positionalSymbol, nil
+	}
+	return "", mserrors.NewValidationError("symbol is required; pass --symbol AAPL or positional AAPL", nil)
+}
+
+// MultiSymbolOptions holds schema-visible symbol input for multi-symbol commands.
+type MultiSymbolOptions struct {
+	Symbols []string `flag:"symbols" flagshort:"s" flaggroup:"Input" flagdescr:"Stock symbols to fetch, for example AAPL,MSFT; accepts comma-separated or repeated values; positional symbols remain supported for shell use"`
+}
+
+// ResolveSymbols merges positional arguments with --symbols values, deduplicating and trimming whitespace.
+func (o *MultiSymbolOptions) ResolveSymbols(args []string, extraGroups ...[]string) []string {
+	groups := make([][]string, 0, 2+len(extraGroups))
+	groups = append(groups, args, o.Symbols)
+	groups = append(groups, extraGroups...)
+	return mergeSymbolInputs(groups...)
+}
+
+// mergeSymbolInputs merges symbol groups while preserving first-seen order.
+func mergeSymbolInputs(groups ...[]string) []string {
+	capacity := 0
+	for _, group := range groups {
+		capacity += len(group)
+	}
+
+	symbols := make([]string, 0, capacity)
+	seen := make(map[string]struct{}, capacity)
+	for _, group := range groups {
+		for _, value := range group {
+			for symbol := range strings.SplitSeq(value, ",") {
+				trimmed := strings.TrimSpace(symbol)
+				if trimmed == "" {
+					continue
+				}
+				if _, ok := seen[trimmed]; ok {
+					continue
+				}
+				seen[trimmed] = struct{}{}
+				symbols = append(symbols, trimmed)
+			}
+		}
+	}
+	return symbols
+}
+
 // newSymbolCmd builds a cobra command that fetches data for a single symbol.
 // It handles argument validation, calls the fetcher, and writes the JSON envelope.
 func newSymbolCmd(use, short string, fetch symbolFetcher) *cobra.Command {
-	return &cobra.Command{
+	opts := &SymbolOptions{}
+	cmd := &cobra.Command{
 		Use:   use + " <symbol>",
 		Short: short,
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			symbol := args[0]
+			symbol, err := opts.ResolveSymbol(args)
+			if err != nil {
+				return err
+			}
 			data, err := fetch(cmd.Context(), symbol)
 			if err != nil {
 				return err
@@ -28,4 +109,8 @@ func newSymbolCmd(use, short string, fetch symbolFetcher) *cobra.Command {
 			return output.WriteSuccess(cmd.OutOrStdout(), data, output.SymbolMeta(symbol))
 		},
 	}
+	if err := structcli.Bind(cmd, opts); err != nil {
+		panic(err)
+	}
+	return cmd
 }


### PR DESCRIPTION
## Summary
- Add schema-visible `--symbol` and `--symbols` flags for symbol-based commands so MCP and schema-driven agents can call them without positional arguments.
- Preserve existing positional usage and `stock analyze --tickers` compatibility while sharing symbol parsing and validation helpers.
- Update README and cmd package guidance, plus tests for flag paths and resolver edge cases.

## Verification
- `go test ./cmd`
- `make lint`
- `make test`
- `make build`
- LSP diagnostics on `cmd`: 0 diagnostics
- Live smoke commands: `stock get --symbol AAPL`, `fundamental get --symbol MSFT`, `ownership get --symbol NVDA`, `stock analyze --symbols AAPL,MSFT --compact`, `rs-history get --symbols AAPL,MSFT`, `chart history --symbol AAPL --lookback 3M`