### PR TITLE
feat(cmd): make jsonschema full tree by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,12 @@ structcli.Bind(rootCmd, rootOpts)
 structcli.Setup(rootCmd,
     structcli.WithAppName("marketsurge-agent"),
     structcli.WithConfig(config.Options{ValidateKeys: true}),
-    structcli.WithJSONSchema(),
+    structcli.WithJSONSchema(jsonschema.Options{
+        SchemaOpts: []jsonschema.Opt{
+            jsonschema.WithFullTree(),
+            jsonschema.WithEnumInDescription(),
+        },
+    }),
     structcli.WithFlagErrors(),
     structcli.WithHelpTopics(helptopics.Options{ReferenceSection: true}),
     structcli.WithDebug(debug.Options{Exit: true}),
@@ -102,7 +107,8 @@ structcli.Setup(rootCmd,
 Key behaviors:
 - `WithAppName("marketsurge-agent")` sets the structcli env prefix to `MARKETSURGE_AGENT` and propagates the app name to config/debug helpers
 - `WithConfig()` adds the persistent `--config` flag, auto-loads config before structcli unmarshals options, and honors `MARKETSURGE_AGENT_CONFIG`
-- `--jsonschema` prints a machine-readable JSON schema for all flags and exits without auth
+- `--jsonschema` prints the full command tree JSON schema and exits without auth
+- `--jsonschema=tree` remains supported and returns the same full-tree schema for scripts that already request it
 - `--mcp` runs a stdio Model Context Protocol server; `initialize` and `tools/list` discovery do not require auth, while `tools/call` for API commands uses the normal Firefox cookie auth chain; shell completion subcommands are excluded from the MCP tool list
 - `--debug-options` prints resolved flag values and exits (requires `Exit: true` in debug options)
 - `env-vars` and `config-keys` are built-in help topics (e.g., `marketsurge-agent help env-vars`)
@@ -133,15 +139,18 @@ Typed string enums are registered with structcli so flag validation and schema g
 
 ### Schema fidelity for LLM agents
 
-LLM agents should prefer the full command tree schema:
+LLM agents should use the full command tree schema:
 
 ```bash
 marketsurge-agent --jsonschema=tree
 ```
 
+Bare `--jsonschema` returns the same full-tree JSON array by default. The explicit `=tree` form is kept for compatibility with scripts and prompts that already request it.
+
 Schema tags should make command selection and flag filling obvious:
 - Use `flaggroup:` for logical groups such as `Date Range`, `Output Format`, `Pagination`, and `Filtering & Projection`
 - Use `flagdescr:` to document conditional requirements and examples, especially when a flag is only required for one mode
+- Registered enum values appear in both machine-readable `enum` arrays and the preserved `{value1,value2}` text in descriptions because the root setup enables `jsonschema.WithEnumInDescription()`
 - Keep conditional and domain-specific requirements in `Validate()` when they need the CLI's JSON error envelope and MarketSurge exit codes
 - Do not mark chart history date fields or catalog ID fields with `flagrequired`, because their requirements depend on other flags
 

--- a/README.md
+++ b/README.md
@@ -140,10 +140,10 @@ Errors follow the same pattern:
 # Generate shell completion (bash, zsh, fish, powershell)
 marketsurge-agent completion zsh > ~/.zsh/completions/_marketsurge-agent
 
-# Print machine-readable JSON schema for the current command
+# Print the full command tree JSON schema for LLM tool definitions
 marketsurge-agent --jsonschema
 
-# Print the full command tree schema for LLM tool definitions
+# Explicit full-tree mode, kept for scripts that already request it
 marketsurge-agent --jsonschema=tree
 
 # Run as an MCP server over stdio for agent tool discovery and calls
@@ -187,12 +187,14 @@ marketsurge-agent stock analyze --symbols AAPL,MSFT,NVDA --compact --flat
 
 ### Schema discovery
 
-`--jsonschema` prints a machine-readable JSON schema for the current command and exits without making any API calls. For LLM tool definitions, prefer `--jsonschema=tree` so the agent sees every subcommand plus flag groups, enum values, defaults, environment bindings, and descriptions in one response:
+`--jsonschema` prints a machine-readable JSON schema for the full command tree and exits without making any API calls. Agents see every subcommand plus flag groups, enum values, defaults, environment bindings, and descriptions in one response. `--jsonschema=tree` remains supported and returns the same full-tree contract for scripts that already request it:
 
 ```bash
 marketsurge-agent --jsonschema
 marketsurge-agent --jsonschema=tree
 ```
+
+The schema is a JSON array. Each entry is one command schema with `title`, `description`, `properties`, `x-structcli-groups`, `x-structcli-env-prefix`, and `x-structcli-config-flag` metadata. Enum flags expose both machine-readable `enum` arrays and the original enum tokens in their descriptions, for example `{DAILY,WEEKLY}` or `{daily,weekly}`.
 
 Required and conditional inputs are documented in flag descriptions. Some rules are intentionally validated by the command instead of structcli tags so errors keep the normal JSON envelope and MarketSurge exit codes, for example `chart history` requires either `--lookback` or `--start-date/--end-date`, and `catalog run` requires the ID flag that matches `--kind`.
 

--- a/cmd/AGENTS.md
+++ b/cmd/AGENTS.md
@@ -48,6 +48,12 @@ Shell completion subcommands are excluded from MCP tool discovery because they a
 
 MCP argument conversion maps tool arguments to flags, not positional arguments. Any API command that requires stock symbols must expose those symbols through schema-visible structcli flags (`--symbol` for single-symbol commands, `--symbols` for multi-symbol commands) while preserving positional arguments for shell compatibility.
 
+### JSON schema behavior
+
+The root command enables structcli JSON schema output with `jsonschema.WithFullTree()` and `jsonschema.WithEnumInDescription()`. Bare `--jsonschema` and explicit `--jsonschema=tree` both return the full command tree as a JSON array, which lets LLM agents discover every runnable command in one call.
+
+Enum-backed flags should keep typed enum fields when a non-empty default exists. The schema exposes those values through machine-readable `enum` arrays and keeps the `{value1,value2}` text in descriptions for prompt readability. Optional enum-like fields with no default, such as `ChartHistoryOptions.Lookback`, must stay `string` and document valid values in `flagdescr` so command validation can return domain `ValidationError` envelopes.
+
 ### Test pattern
 
 Tests call constructors directly (not package-level vars) and inject client via context:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ import (
 	"github.com/leodido/structcli/config"
 	"github.com/leodido/structcli/debug"
 	"github.com/leodido/structcli/helptopics"
+	"github.com/leodido/structcli/jsonschema"
 	structclimcp "github.com/leodido/structcli/mcp"
 	"github.com/spf13/cobra"
 
@@ -110,7 +111,12 @@ func init() {
 	if err := structcli.Setup(rootCmd,
 		structcli.WithAppName("marketsurge-agent"),
 		structcli.WithConfig(config.Options{ValidateKeys: true}),
-		structcli.WithJSONSchema(),
+		structcli.WithJSONSchema(jsonschema.Options{
+			SchemaOpts: []jsonschema.Opt{
+				jsonschema.WithFullTree(),
+				jsonschema.WithEnumInDescription(),
+			},
+		}),
 		structcli.WithFlagErrors(),
 		structcli.WithHelpTopics(helptopics.Options{ReferenceSection: true}),
 		structcli.WithDebug(debug.Options{Exit: true}),

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -19,12 +19,81 @@ func TestRootJSONSchema(t *testing.T) {
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(output))
 
-	schema := string(output)
-	assert.True(t, strings.Contains(schema, `"$schema"`) || strings.Contains(schema, `"properties"`))
-	assert.Contains(t, schema, `"x-structcli-env-prefix": "MARKETSURGE_AGENT"`)
-	assert.Contains(t, schema, `"MARKETSURGE_AGENT_COOKIE_DB"`)
-	assert.Contains(t, schema, `"MARKETSURGE_AGENT_VERBOSE"`)
-	assert.Contains(t, schema, `"x-structcli-config-flag": "config"`)
+	schemas := parseJSONSchemas(t, output)
+	require.Greater(t, len(schemas), 1, "bare --jsonschema should return the full command tree")
+
+	rootSchema := schemaByTitle(t, schemas, "marketsurge-agent")
+	assert.Contains(t, rootSchema, `"x-structcli-env-prefix": "MARKETSURGE_AGENT"`)
+	assert.Contains(t, rootSchema, `"MARKETSURGE_AGENT_COOKIE_DB"`)
+	assert.Contains(t, rootSchema, `"MARKETSURGE_AGENT_VERBOSE"`)
+	assert.Contains(t, rootSchema, `"x-structcli-config-flag": "config"`)
+
+	schemaByTitle(t, schemas, "marketsurge-agent stock analyze")
+	schemaByTitle(t, schemas, "marketsurge-agent chart history")
+	schemaByTitle(t, schemas, "marketsurge-agent catalog run")
+}
+
+func TestRootJSONSchemaTreeMatchesDefault(t *testing.T) {
+	defaultCmd := rootExecCommand(t, "--jsonschema")
+	defaultOutput, err := defaultCmd.CombinedOutput()
+	require.NoError(t, err, string(defaultOutput))
+
+	treeCmd := rootExecCommand(t, "--jsonschema=tree")
+	treeOutput, err := treeCmd.CombinedOutput()
+	require.NoError(t, err, string(treeOutput))
+
+	assert.JSONEq(t, string(defaultOutput), string(treeOutput))
+}
+
+func TestRootJSONSchemaIncludesEnumDescriptions(t *testing.T) {
+	cmd := rootExecCommand(t, "--jsonschema")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	schemas := parseJSONSchemas(t, output)
+	chartMarkups := schemaMapByTitle(t, schemas, "marketsurge-agent chart markups")
+	frequency := schemaProperty(t, chartMarkups, "frequency")
+	assert.Equal(t, []any{"DAILY", "WEEKLY"}, frequency["enum"])
+	assert.Contains(t, frequency["description"], "Chart candle frequency for markup lookup")
+	assert.Contains(t, frequency["description"], "{DAILY,WEEKLY}")
+	sortDir := schemaProperty(t, chartMarkups, "sort-dir")
+	assert.Equal(t, []any{"ASC", "DESC"}, sortDir["enum"])
+	assert.Contains(t, sortDir["description"], "Sort direction for markup annotations")
+	assert.Contains(t, sortDir["description"], "{ASC,DESC}")
+
+	chartHistory := schemaMapByTitle(t, schemas, "marketsurge-agent chart history")
+	lookback := schemaProperty(t, chartHistory, "lookback")
+	assert.Contains(t, lookback["description"], "Relative lookback period")
+	assert.Contains(t, lookback["description"], "1W, 1M, 3M, 6M, 1Y, YTD")
+	period := schemaProperty(t, chartHistory, "period")
+	assert.Equal(t, []any{"daily", "weekly"}, period["enum"])
+	assert.Contains(t, period["description"], "Data period granularity")
+	assert.Contains(t, period["description"], "{daily,weekly}")
+	assert.Equal(t, "daily", period["default"])
+}
+
+func TestRootJSONSchemaIncludesAgentMetadata(t *testing.T) {
+	cmd := rootExecCommand(t, "--jsonschema")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	schemas := parseJSONSchemas(t, output)
+	stockAnalyze := schemaByTitle(t, schemas, "marketsurge-agent stock analyze")
+	assert.Contains(t, stockAnalyze, "one or more")
+	assert.Contains(t, stockAnalyze, `"x-structcli-group": "Input"`)
+	assert.Contains(t, stockAnalyze, `"x-structcli-group": "Output Format"`)
+	assert.Contains(t, stockAnalyze, "symbols to analyze")
+
+	catalogRun := schemaByTitle(t, schemas, "marketsurge-agent catalog run")
+	assert.Contains(t, catalogRun, `"x-structcli-group": "Catalog Selection"`)
+	assert.Contains(t, catalogRun, `"x-structcli-group": "Kind-Specific IDs"`)
+	assert.Contains(t, catalogRun, "required when kind=report")
+	assert.Contains(t, catalogRun, "required when kind=watchlist")
+	catalogRunSchema := schemaMapByTitle(t, schemas, "marketsurge-agent catalog run")
+	kind := schemaProperty(t, catalogRunSchema, "kind")
+	assert.Contains(t, kind["description"], "Required catalog kind to run")
+	assert.Contains(t, kind["description"], "watchlist, report, coach_screen")
+	assert.Contains(t, kind["description"], "screens are list-only")
 }
 
 func TestRootOptionsStructTags(t *testing.T) {
@@ -258,4 +327,44 @@ func decodeMCPResponses(t *testing.T, output []byte) []mcpResponse {
 		responses = append(responses, response)
 	}
 	return responses
+}
+
+func parseJSONSchemas(t *testing.T, output []byte) []map[string]any {
+	t.Helper()
+
+	var schemas []map[string]any
+	require.NoError(t, json.Unmarshal(output, &schemas), string(output))
+	require.NotEmpty(t, schemas)
+	return schemas
+}
+
+func schemaByTitle(t *testing.T, schemas []map[string]any, title string) string {
+	t.Helper()
+
+	schema := schemaMapByTitle(t, schemas, title)
+	encoded, err := json.MarshalIndent(schema, "", "  ")
+	require.NoError(t, err)
+	return string(encoded)
+}
+
+func schemaMapByTitle(t *testing.T, schemas []map[string]any, title string) map[string]any {
+	t.Helper()
+
+	for _, schema := range schemas {
+		if schema["title"] == title {
+			return schema
+		}
+	}
+	require.Failf(t, "schema title not found", "missing %q", title)
+	return nil
+}
+
+func schemaProperty(t *testing.T, schema map[string]any, name string) map[string]any {
+	t.Helper()
+
+	properties, ok := schema["properties"].(map[string]any)
+	require.True(t, ok, "schema should have properties")
+	property, ok := properties[name].(map[string]any)
+	require.True(t, ok, "schema should have property %q", name)
+	return property
 }


### PR DESCRIPTION
## Summary
- Make bare `--jsonschema` emit the full command tree so LLM agents can discover every command in one call.
- Keep `--jsonschema=tree` equivalent for existing scripts and preserve enum tokens in descriptions alongside schema `enum` arrays.
- Add schema contract tests and update README/AGENTS guidance.

## Verification
- `go test ./cmd`
- `make lint`
- LSP diagnostics: 0 diagnostics for `cmd`
- `make test`
- `make build`
- Live smoke checks: `--jsonschema`, `stock get AAPL`, `fundamental get MSFT`, `ownership get NVDA`, `stock analyze --tickers AAPL,MSFT --compact`, `chart history AAPL --lookback 3M`