### PR TITLE
feat(cmd): add schema-visible examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,8 +149,9 @@ Bare `--jsonschema` returns the same full-tree JSON array by default. The explic
 
 Schema tags should make command selection and flag filling obvious:
 - Use `flaggroup:` for logical groups such as `Date Range`, `Output Format`, `Pagination`, and `Filtering & Projection`
-- Use `flagdescr:` to document conditional requirements and examples, especially when a flag is only required for one mode
+- Use `flagdescr:` to document conditional requirements and concrete examples, especially when a flag is only required for one mode
 - Registered enum values appear in both machine-readable `enum` arrays and the preserved `{value1,value2}` text in descriptions because the root setup enables `jsonschema.WithEnumInDescription()`
+- Keep complete invocation examples in complex command `Long` descriptions and per-flag examples in `flagdescr`, because structcli's JSON Schema output carries those descriptions
 - Keep conditional and domain-specific requirements in `Validate()` when they need the CLI's JSON error envelope and MarketSurge exit codes
 - Do not mark chart history date fields or catalog ID fields with `flagrequired`, because their requirements depend on other flags
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ marketsurge-agent --jsonschema=tree
 
 The schema is a JSON array. Each entry is one command schema with `title`, `description`, `properties`, `x-structcli-groups`, `x-structcli-env-prefix`, and `x-structcli-config-flag` metadata. Enum flags expose both machine-readable `enum` arrays and the original enum tokens in their descriptions, for example `{DAILY,WEEKLY}` or `{daily,weekly}`.
 
-Required and conditional inputs are documented in flag descriptions. Some rules are intentionally validated by the command instead of structcli tags so errors keep the normal JSON envelope and MarketSurge exit codes, for example `chart history` requires either `--lookback` or `--start-date/--end-date`, and `catalog run` requires the ID flag that matches `--kind`.
+Required and conditional inputs are documented in flag descriptions with concrete examples. Some rules are intentionally validated by the command instead of structcli tags so errors keep the normal JSON envelope and MarketSurge exit codes, for example `chart history` requires either `--lookback` or `--start-date/--end-date`, and `catalog run` requires the ID flag that matches `--kind`. Complex command descriptions and flag descriptions include copyable valid invocation shapes so LLM agents can infer usable calls from schema output.
 
 Each command also carries a detailed `--help` description covering inputs, outputs, and gotchas. The `env-vars` and `config-keys` help topics list every supported environment variable and config file key:
 

--- a/cmd/AGENTS.md
+++ b/cmd/AGENTS.md
@@ -159,3 +159,9 @@ Use `--symbols/-s` for multi-symbol commands. Merge positional symbols and flag 
 7. Add tests in `cmd/<group>_test.go`
 
 Use `flaggroup:` on every non-trivial flag so `--jsonschema=tree` and MCP tool metadata are useful to LLM agents. Prefer `Validate()` over `flagrequired:"true"` for conditional requirements or domain errors that must preserve the JSON error envelope and MarketSurge exit codes.
+
+For complex modes, put copyable examples where schema generators can see them:
+
+- Put complete invocation examples in command `Long` descriptions for schema output; Cobra `Example` is useful for help/generation consumers but is not emitted by structcli's draft JSON Schema conversion.
+- Include short examples in `flagdescr` for conditional flags, for example date range pairs and `catalog run --kind` plus matching ID flag combinations.
+- Do not use presets just to document examples. Presets create real CLI alias flags, so reserve them for deliberate UX changes.

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -104,13 +104,13 @@ Workflow:
 
 // CatalogRunOptions holds flags for the catalog run command.
 type CatalogRunOptions struct {
-	Kind          models.CatalogKind `flag:"kind" flaggroup:"Catalog Selection" flagdescr:"Required catalog kind to run (watchlist, report, coach_screen); screens are list-only" flagcustom:"true"`
-	ReportID      int                `flag:"report-id" flaggroup:"Kind-Specific IDs" flagdescr:"Report ID; required when kind=report (discover with catalog list --kind report)"`
-	WatchlistID   int64              `flag:"watchlist-id" flaggroup:"Kind-Specific IDs" flagdescr:"Watchlist ID; required when kind=watchlist (discover with catalog list --kind watchlist)"`
-	CoachScreenID string             `flag:"coach-screen-id" flaggroup:"Kind-Specific IDs" flagdescr:"Coach screen ID; required when kind=coach_screen (discover with catalog list --kind coach_screen)"`
+	Kind          models.CatalogKind `flag:"kind" flaggroup:"Catalog Selection" flagdescr:"Required catalog kind to run: watchlist uses --watchlist-id, report uses --report-id, coach_screen uses --coach-screen-id; screens are list-only. Example report: --kind report --report-id 124" flagcustom:"true"`
+	ReportID      int                `flag:"report-id" flaggroup:"Kind-Specific IDs" flagdescr:"Report ID; required when kind=report. Example report run: --kind report --report-id 124"`
+	WatchlistID   int64              `flag:"watchlist-id" flaggroup:"Kind-Specific IDs" flagdescr:"Watchlist ID; required when kind=watchlist. Example watchlist run: --kind watchlist --watchlist-id 99"`
+	CoachScreenID string             `flag:"coach-screen-id" flaggroup:"Kind-Specific IDs" flagdescr:"Coach screen ID; required when kind=coach_screen. Example coach screen run: --kind coach_screen --coach-screen-id screen-1"`
 	Limit         int                `flag:"limit" flaggroup:"Pagination" flagdescr:"Maximum number of results to return" default:"50"`
 	Offset        int                `flag:"offset" flaggroup:"Pagination" flagdescr:"Number of results to skip for pagination"`
-	Fields        []string           `flag:"fields" flaggroup:"Filtering & Projection" flagdescr:"Project specific result fields, such as symbol, price, composite_rating, eps_rating, rs_rating"`
+	Fields        []string           `flag:"fields" flaggroup:"Filtering & Projection" flagdescr:"Project specific result fields; accepts repeated --fields flags or comma-separated values. Examples: --fields symbol --fields price, or --fields symbol,price,composite_rating. Common fields: symbol, price, composite_rating, eps_rating, rs_rating, acc_dis_rating, smr_rating, industry_name, market_cap, volume_dollar_avg_50d"`
 	MinComposite  *int
 	MinRS         *int
 	ExcludeSPACs  bool `flag:"exclude-spacs" flaggroup:"Filtering & Projection" flagdescr:"Exclude SPAC/blank-check entries from results"`
@@ -190,6 +190,9 @@ func newCatalogRunCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Run a catalog report, watchlist, or coach screen",
+		Example: `  marketsurge-agent catalog run --kind report --report-id 124 --fields symbol,price,composite_rating
+  marketsurge-agent catalog run --kind watchlist --watchlist-id 99 --limit 25 --exclude-spacs
+  marketsurge-agent catalog run --kind coach_screen --coach-screen-id screen-1 --limit 10`,
 		Long: `Runs a catalog entry and returns its contents.
 
 Required by kind:
@@ -200,6 +203,12 @@ Required by kind:
   report         --report-id            Yes
   coach_screen   --coach-screen-id      Yes
   screen         (none)                 No, list only
+
+Examples:
+
+  catalog run --kind report --report-id 124 --fields symbol,price,composite_rating
+  catalog run --kind watchlist --watchlist-id 99 --limit 25 --exclude-spacs
+  catalog run --kind coach_screen --coach-screen-id screen-1 --limit 10
 
 Useful flags:
 
@@ -234,8 +243,8 @@ not behave like report or watchlist rows.`,
 	if err := structcli.Bind(cmd, opts); err != nil {
 		panic(err)
 	}
-	cmd.Flags().Int("min-composite", 0, "Minimum composite rating for report/watchlist rows (0-99); omitted when unset")
-	cmd.Flags().Int("min-rs", 0, "Minimum RS rating for report/watchlist rows (0-99); omitted when unset")
+	cmd.Flags().Int("min-composite", 0, "Minimum composite rating for report/watchlist rows (0-99); omitted when unset. Example: --min-composite 90")
+	cmd.Flags().Int("min-rs", 0, "Minimum RS rating for report/watchlist rows (0-99); omitted when unset. Example: --min-rs 80")
 	for _, name := range []string{"min-composite", "min-rs"} {
 		if err := cmd.Flags().SetAnnotation(name, structcliFlagGroupAnnotation, []string{"Filtering & Projection"}); err != nil {
 			panic(err)

--- a/cmd/catalog_test.go
+++ b/cmd/catalog_test.go
@@ -372,13 +372,13 @@ func TestCatalogRunStructTags(t *testing.T) {
 		descr        string
 		defaultValue string
 	}{
-		{field: "Kind", flag: "kind", group: "Catalog Selection", descr: "Required catalog kind to run (watchlist, report, coach_screen); screens are list-only"},
-		{field: "ReportID", flag: "report-id", group: "Kind-Specific IDs", descr: "Report ID; required when kind=report (discover with catalog list --kind report)"},
-		{field: "WatchlistID", flag: "watchlist-id", group: "Kind-Specific IDs", descr: "Watchlist ID; required when kind=watchlist (discover with catalog list --kind watchlist)"},
-		{field: "CoachScreenID", flag: "coach-screen-id", group: "Kind-Specific IDs", descr: "Coach screen ID; required when kind=coach_screen (discover with catalog list --kind coach_screen)"},
+		{field: "Kind", flag: "kind", group: "Catalog Selection", descr: "Required catalog kind to run: watchlist uses --watchlist-id, report uses --report-id, coach_screen uses --coach-screen-id; screens are list-only. Example report: --kind report --report-id 124"},
+		{field: "ReportID", flag: "report-id", group: "Kind-Specific IDs", descr: "Report ID; required when kind=report. Example report run: --kind report --report-id 124"},
+		{field: "WatchlistID", flag: "watchlist-id", group: "Kind-Specific IDs", descr: "Watchlist ID; required when kind=watchlist. Example watchlist run: --kind watchlist --watchlist-id 99"},
+		{field: "CoachScreenID", flag: "coach-screen-id", group: "Kind-Specific IDs", descr: "Coach screen ID; required when kind=coach_screen. Example coach screen run: --kind coach_screen --coach-screen-id screen-1"},
 		{field: "Limit", flag: "limit", group: "Pagination", descr: "Maximum number of results to return", defaultValue: "50"},
 		{field: "Offset", flag: "offset", group: "Pagination", descr: "Number of results to skip for pagination"},
-		{field: "Fields", flag: "fields", group: "Filtering & Projection", descr: "Project specific result fields, such as symbol, price, composite_rating, eps_rating, rs_rating"},
+		{field: "Fields", flag: "fields", group: "Filtering & Projection", descr: "Project specific result fields; accepts repeated --fields flags or comma-separated values. Examples: --fields symbol --fields price, or --fields symbol,price,composite_rating. Common fields: symbol, price, composite_rating, eps_rating, rs_rating, acc_dis_rating, smr_rating, industry_name, market_cap, volume_dollar_avg_50d"},
 		{field: "ExcludeSPACs", flag: "exclude-spacs", group: "Filtering & Projection", descr: "Exclude SPAC/blank-check entries from results"},
 	}
 
@@ -410,8 +410,8 @@ func TestCatalogRunManualFilterFlags(t *testing.T) {
 		name  string
 		descr string
 	}{
-		{name: "min-composite", descr: "Minimum composite rating for report/watchlist rows (0-99); omitted when unset"},
-		{name: "min-rs", descr: "Minimum RS rating for report/watchlist rows (0-99); omitted when unset"},
+		{name: "min-composite", descr: "Minimum composite rating for report/watchlist rows (0-99); omitted when unset. Example: --min-composite 90"},
+		{name: "min-rs", descr: "Minimum RS rating for report/watchlist rows (0-99); omitted when unset. Example: --min-rs 80"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -419,6 +419,36 @@ func TestCatalogRunManualFilterFlags(t *testing.T) {
 			require.NotNil(t, flag)
 			assert.Equal(t, tt.descr, flag.Usage)
 			assert.Equal(t, []string{"Filtering & Projection"}, flag.Annotations[structcliFlagGroupAnnotation])
+		})
+	}
+}
+
+func TestCatalogRunExamples(t *testing.T) {
+	t.Parallel()
+
+	cmd := newCatalogRunCmd()
+	assert.Contains(t, cmd.Example, "marketsurge-agent catalog run --kind report --report-id 124")
+	assert.Contains(t, cmd.Example, "--kind watchlist --watchlist-id 99")
+	assert.Contains(t, cmd.Example, "--kind coach_screen --coach-screen-id screen-1")
+
+	typ := reflect.TypeFor[CatalogRunOptions]()
+	tests := []struct {
+		field string
+		want  string
+	}{
+		{field: "Kind", want: "watchlist uses --watchlist-id"},
+		{field: "Kind", want: "report uses --report-id"},
+		{field: "Kind", want: "coach_screen uses --coach-screen-id"},
+		{field: "ReportID", want: "--kind report --report-id 124"},
+		{field: "WatchlistID", want: "--kind watchlist --watchlist-id 99"},
+		{field: "CoachScreenID", want: "--kind coach_screen --coach-screen-id screen-1"},
+		{field: "Fields", want: "--fields symbol,price,composite_rating"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.field+"/"+tt.want, func(t *testing.T) {
+			field, ok := typ.FieldByName(tt.field)
+			require.True(t, ok)
+			assert.Contains(t, field.Tag.Get("flagdescr"), tt.want)
 		})
 	}
 }

--- a/cmd/chart.go
+++ b/cmd/chart.go
@@ -88,9 +88,9 @@ const defaultExchangeName = "NYSE"
 // structcli's enum decoder rejects empty string for registered enums.
 type ChartHistoryOptions struct {
 	Symbol    string        `flag:"symbol" flagshort:"s" flaggroup:"Input" flagdescr:"Stock symbol to fetch, for example AAPL; positional <symbol> remains supported for shell use"`
-	StartDate string        `flag:"start-date" flaggroup:"Date Range" flagdescr:"Start date in YYYY-MM-DD format; requires --end-date and is mutually exclusive with --lookback"`
-	EndDate   string        `flag:"end-date" flaggroup:"Date Range" flagdescr:"End date in YYYY-MM-DD format; requires --start-date and is mutually exclusive with --lookback"`
-	Lookback  string        `flag:"lookback" flaggroup:"Date Range" flagdescr:"Relative lookback period (1W, 1M, 3M, 6M, 1Y, YTD); mutually exclusive with --start-date/--end-date"`
+	StartDate string        `flag:"start-date" flaggroup:"Date Range" flagdescr:"Start date in YYYY-MM-DD format, for example 2024-01-01; must be paired with --end-date; mutually exclusive with --lookback. Example explicit range: --start-date 2024-01-01 --end-date 2024-06-30"`
+	EndDate   string        `flag:"end-date" flaggroup:"Date Range" flagdescr:"End date in YYYY-MM-DD format, for example 2024-06-30; must be paired with --start-date; mutually exclusive with --lookback. Example explicit range: --start-date 2024-01-01 --end-date 2024-06-30"`
+	Lookback  string        `flag:"lookback" flaggroup:"Date Range" flagdescr:"Relative lookback period (1W, 1M, 3M, 6M, 1Y, YTD); mutually exclusive with --start-date/--end-date. Example relative range: --lookback 3M"`
 	Period    models.Period `flag:"period" flaggroup:"Options" flagdescr:"Data period granularity (daily or weekly)" default:"daily"`
 	Benchmark string        `flag:"benchmark" flaggroup:"Options" flagdescr:"Benchmark symbol for relative strength comparison"`
 }
@@ -144,6 +144,9 @@ func newChartHistoryCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "history <symbol>",
 		Short: "Get chart history for a symbol",
+		Example: `  marketsurge-agent chart history AAPL --lookback 3M
+  marketsurge-agent chart history AAPL --start-date 2024-01-01 --end-date 2024-06-30
+  marketsurge-agent chart history AAPL --lookback 1Y --period weekly --benchmark 0S&P5`,
 		Long: `Fetches price history for a symbol. Exactly one date mode is required:
 
   Date mode           Example

--- a/cmd/chart_test.go
+++ b/cmd/chart_test.go
@@ -346,13 +346,13 @@ func TestChartHistoryStructTags(t *testing.T) {
 		{"Symbol", "flagdescr", "Stock symbol to fetch, for example AAPL; positional <symbol> remains supported for shell use", reflect.TypeFor[string]()},
 		{"StartDate", "flag", "start-date", reflect.TypeFor[string]()},
 		{"StartDate", "flaggroup", "Date Range", reflect.TypeFor[string]()},
-		{"StartDate", "flagdescr", "Start date in YYYY-MM-DD format; requires --end-date and is mutually exclusive with --lookback", reflect.TypeFor[string]()},
+		{"StartDate", "flagdescr", "Start date in YYYY-MM-DD format, for example 2024-01-01; must be paired with --end-date; mutually exclusive with --lookback. Example explicit range: --start-date 2024-01-01 --end-date 2024-06-30", reflect.TypeFor[string]()},
 		{"EndDate", "flag", "end-date", reflect.TypeFor[string]()},
 		{"EndDate", "flaggroup", "Date Range", reflect.TypeFor[string]()},
-		{"EndDate", "flagdescr", "End date in YYYY-MM-DD format; requires --start-date and is mutually exclusive with --lookback", reflect.TypeFor[string]()},
+		{"EndDate", "flagdescr", "End date in YYYY-MM-DD format, for example 2024-06-30; must be paired with --start-date; mutually exclusive with --lookback. Example explicit range: --start-date 2024-01-01 --end-date 2024-06-30", reflect.TypeFor[string]()},
 		{"Lookback", "flag", "lookback", reflect.TypeFor[string]()},
 		{"Lookback", "flaggroup", "Date Range", reflect.TypeFor[string]()},
-		{"Lookback", "flagdescr", "Relative lookback period (1W, 1M, 3M, 6M, 1Y, YTD); mutually exclusive with --start-date/--end-date", reflect.TypeFor[string]()},
+		{"Lookback", "flagdescr", "Relative lookback period (1W, 1M, 3M, 6M, 1Y, YTD); mutually exclusive with --start-date/--end-date. Example relative range: --lookback 3M", reflect.TypeFor[string]()},
 		{"Period", "flag", "period", reflect.TypeFor[models.Period]()},
 		{"Period", "flaggroup", "Options", reflect.TypeFor[models.Period]()},
 		{"Period", "flagdescr", "Data period granularity (daily or weekly)", reflect.TypeFor[models.Period]()},
@@ -372,6 +372,26 @@ func TestChartHistoryStructTags(t *testing.T) {
 			if tt.tag == "flag" {
 				assert.Equal(t, tt.wantType, f.Type, "field %s type mismatch", tt.field)
 			}
+		})
+	}
+}
+
+func TestChartHistoryExamples(t *testing.T) {
+	t.Parallel()
+
+	cmd := newChartHistoryCmd()
+	assert.Contains(t, cmd.Example, "marketsurge-agent chart history AAPL --lookback 3M")
+	assert.Contains(t, cmd.Example, "--start-date 2024-01-01 --end-date 2024-06-30")
+	assert.Contains(t, cmd.Example, "--period weekly --benchmark 0S&P5")
+
+	typ := reflect.TypeFor[ChartHistoryOptions]()
+	for _, fieldName := range []string{"StartDate", "EndDate", "Lookback"} {
+		t.Run(fieldName, func(t *testing.T) {
+			field, ok := typ.FieldByName(fieldName)
+			require.True(t, ok)
+			descr := field.Tag.Get("flagdescr")
+			assert.Contains(t, descr, "Example")
+			assert.Contains(t, descr, "--")
 		})
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -22,15 +22,15 @@ func TestRootJSONSchema(t *testing.T) {
 	schemas := parseJSONSchemas(t, output)
 	require.Greater(t, len(schemas), 1, "bare --jsonschema should return the full command tree")
 
-	rootSchema := schemaByTitle(t, schemas, "marketsurge-agent")
+	rootSchema := schemaJSONByTitle(t, schemas, "marketsurge-agent")
 	assert.Contains(t, rootSchema, `"x-structcli-env-prefix": "MARKETSURGE_AGENT"`)
 	assert.Contains(t, rootSchema, `"MARKETSURGE_AGENT_COOKIE_DB"`)
 	assert.Contains(t, rootSchema, `"MARKETSURGE_AGENT_VERBOSE"`)
 	assert.Contains(t, rootSchema, `"x-structcli-config-flag": "config"`)
 
-	schemaByTitle(t, schemas, "marketsurge-agent stock analyze")
-	schemaByTitle(t, schemas, "marketsurge-agent chart history")
-	schemaByTitle(t, schemas, "marketsurge-agent catalog run")
+	schemaMapByTitle(t, schemas, "marketsurge-agent stock analyze")
+	schemaMapByTitle(t, schemas, "marketsurge-agent chart history")
+	schemaMapByTitle(t, schemas, "marketsurge-agent catalog run")
 }
 
 func TestRootJSONSchemaTreeMatchesDefault(t *testing.T) {
@@ -78,13 +78,13 @@ func TestRootJSONSchemaIncludesAgentMetadata(t *testing.T) {
 	require.NoError(t, err, string(output))
 
 	schemas := parseJSONSchemas(t, output)
-	stockAnalyze := schemaByTitle(t, schemas, "marketsurge-agent stock analyze")
+	stockAnalyze := schemaJSONByTitle(t, schemas, "marketsurge-agent stock analyze")
 	assert.Contains(t, stockAnalyze, "one or more")
 	assert.Contains(t, stockAnalyze, `"x-structcli-group": "Input"`)
 	assert.Contains(t, stockAnalyze, `"x-structcli-group": "Output Format"`)
 	assert.Contains(t, stockAnalyze, "symbols to analyze")
 
-	catalogRun := schemaByTitle(t, schemas, "marketsurge-agent catalog run")
+	catalogRun := schemaJSONByTitle(t, schemas, "marketsurge-agent catalog run")
 	assert.Contains(t, catalogRun, `"x-structcli-group": "Catalog Selection"`)
 	assert.Contains(t, catalogRun, `"x-structcli-group": "Kind-Specific IDs"`)
 	assert.Contains(t, catalogRun, "required when kind=report")
@@ -92,7 +92,8 @@ func TestRootJSONSchemaIncludesAgentMetadata(t *testing.T) {
 	catalogRunSchema := schemaMapByTitle(t, schemas, "marketsurge-agent catalog run")
 	kind := schemaProperty(t, catalogRunSchema, "kind")
 	assert.Contains(t, kind["description"], "Required catalog kind to run")
-	assert.Contains(t, kind["description"], "watchlist, report, coach_screen")
+	assert.Contains(t, kind["description"], "watchlist uses --watchlist-id")
+	assert.Contains(t, kind["description"], "coach_screen uses --coach-screen-id")
 	assert.Contains(t, kind["description"], "screens are list-only")
 }
 
@@ -104,17 +105,17 @@ func TestRootJSONSchemaTreeIncludesComplexExamples(t *testing.T) {
 	var schemas []map[string]any
 	require.NoError(t, json.Unmarshal(output, &schemas))
 
-	chartHistory := schemaByTitle(t, schemas, "marketsurge-agent chart history")
+	chartHistory := schemaMapByTitle(t, schemas, "marketsurge-agent chart history")
 	assert.Contains(t, chartHistory["description"], "chart history AAPL --lookback 3M")
 	assert.Contains(t, schemaProperty(t, chartHistory, "start-date")["description"], "--start-date 2024-01-01 --end-date 2024-06-30")
 	assert.Contains(t, schemaProperty(t, chartHistory, "lookback")["description"], "--lookback 3M")
 
-	catalogRun := schemaByTitle(t, schemas, "marketsurge-agent catalog run")
+	catalogRun := schemaMapByTitle(t, schemas, "marketsurge-agent catalog run")
 	assert.Contains(t, catalogRun["description"], "catalog run --kind report --report-id")
 	assert.Contains(t, schemaProperty(t, catalogRun, "kind")["description"], "report uses --report-id")
 	assert.Contains(t, schemaProperty(t, catalogRun, "fields")["description"], "--fields symbol,price,composite_rating")
 
-	stockAnalyze := schemaByTitle(t, schemas, "marketsurge-agent stock analyze")
+	stockAnalyze := schemaMapByTitle(t, schemas, "marketsurge-agent stock analyze")
 	assert.Contains(t, stockAnalyze["description"], "stock analyze --summary")
 	assert.Contains(t, schemaProperty(t, stockAnalyze, "summary")["description"], "compatible with --compact and --flat")
 	assert.Contains(t, schemaProperty(t, stockAnalyze, "flat")["description"], "pricing_market_cap")
@@ -290,28 +291,6 @@ func rootExecCommand(t *testing.T, args ...string) *exec.Cmd {
 	return cmd
 }
 
-func schemaByTitle(t *testing.T, schemas []map[string]any, title string) map[string]any {
-	t.Helper()
-
-	for _, schema := range schemas {
-		if schema["title"] == title {
-			return schema
-		}
-	}
-	require.Failf(t, "schema not found", "title %q not found", title)
-	return nil
-}
-
-func schemaProperty(t *testing.T, schema map[string]any, name string) map[string]any {
-	t.Helper()
-
-	properties, ok := schema["properties"].(map[string]any)
-	require.True(t, ok, "schema should have properties")
-	property, ok := properties[name].(map[string]any)
-	require.True(t, ok, "schema should have property %q", name)
-	return property
-}
-
 func userHomeDir(t *testing.T) string {
 	t.Helper()
 
@@ -384,7 +363,7 @@ func parseJSONSchemas(t *testing.T, output []byte) []map[string]any {
 	return schemas
 }
 
-func schemaByTitle(t *testing.T, schemas []map[string]any, title string) string {
+func schemaJSONByTitle(t *testing.T, schemas []map[string]any, title string) string {
 	t.Helper()
 
 	schema := schemaMapByTitle(t, schemas, title)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -96,6 +96,30 @@ func TestRootJSONSchemaIncludesAgentMetadata(t *testing.T) {
 	assert.Contains(t, kind["description"], "screens are list-only")
 }
 
+func TestRootJSONSchemaTreeIncludesComplexExamples(t *testing.T) {
+	cmd := rootExecCommand(t, "--jsonschema=tree")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	var schemas []map[string]any
+	require.NoError(t, json.Unmarshal(output, &schemas))
+
+	chartHistory := schemaByTitle(t, schemas, "marketsurge-agent chart history")
+	assert.Contains(t, chartHistory["description"], "chart history AAPL --lookback 3M")
+	assert.Contains(t, schemaProperty(t, chartHistory, "start-date")["description"], "--start-date 2024-01-01 --end-date 2024-06-30")
+	assert.Contains(t, schemaProperty(t, chartHistory, "lookback")["description"], "--lookback 3M")
+
+	catalogRun := schemaByTitle(t, schemas, "marketsurge-agent catalog run")
+	assert.Contains(t, catalogRun["description"], "catalog run --kind report --report-id")
+	assert.Contains(t, schemaProperty(t, catalogRun, "kind")["description"], "report uses --report-id")
+	assert.Contains(t, schemaProperty(t, catalogRun, "fields")["description"], "--fields symbol,price,composite_rating")
+
+	stockAnalyze := schemaByTitle(t, schemas, "marketsurge-agent stock analyze")
+	assert.Contains(t, stockAnalyze["description"], "stock analyze --summary")
+	assert.Contains(t, schemaProperty(t, stockAnalyze, "summary")["description"], "compatible with --compact and --flat")
+	assert.Contains(t, schemaProperty(t, stockAnalyze, "flat")["description"], "pricing_market_cap")
+}
+
 func TestRootOptionsStructTags(t *testing.T) {
 	t.Parallel()
 
@@ -264,6 +288,28 @@ func rootExecCommand(t *testing.T, args ...string) *exec.Cmd {
 		"XDG_CONFIG_HOME="+tmpDir+"/xdg",
 	)
 	return cmd
+}
+
+func schemaByTitle(t *testing.T, schemas []map[string]any, title string) map[string]any {
+	t.Helper()
+
+	for _, schema := range schemas {
+		if schema["title"] == title {
+			return schema
+		}
+	}
+	require.Failf(t, "schema not found", "title %q not found", title)
+	return nil
+}
+
+func schemaProperty(t *testing.T, schema map[string]any, name string) map[string]any {
+	t.Helper()
+
+	properties, ok := schema["properties"].(map[string]any)
+	require.True(t, ok, "schema should have properties")
+	property, ok := properties[name].(map[string]any)
+	require.True(t, ok, "schema should have property %q", name)
+	return property
 }
 
 func userHomeDir(t *testing.T) string {

--- a/cmd/stock.go
+++ b/cmd/stock.go
@@ -63,9 +63,9 @@ type AnalysisResult struct {
 type StockAnalyzeOptions struct {
 	Symbols []string `flag:"symbols" flagshort:"s" flaggroup:"Input" flagdescr:"Stock symbols to analyze, for example AAPL,MSFT; accepts comma-separated or repeated values; positional symbols remain supported for shell use"`
 	Tickers []string `flag:"tickers" flagshort:"t" flaggroup:"Input" flagdescr:"Additional stock symbols to analyze; accepts comma-separated or repeated values"`
-	Compact bool     `flag:"compact" flaggroup:"Output Format" flagdescr:"Remove duplicate formatted string fields while keeping raw numeric values"`
-	Flat    bool     `flag:"flat" flaggroup:"Output Format" flagdescr:"Flatten nested analysis fields into single-level JSON keys"`
-	Summary bool     `flag:"summary" flaggroup:"Output Format" flagdescr:"Return compact screening objects for ranking many symbols"`
+	Compact bool     `flag:"compact" flaggroup:"Output Format" flagdescr:"Remove duplicate formatted string fields while keeping raw numeric values; compatible with --summary and --flat. Example: stock analyze AAPL --compact"`
+	Flat    bool     `flag:"flat" flaggroup:"Output Format" flagdescr:"Flatten nested analysis fields into single-level JSON keys, for example stock.pricing.market_cap becomes pricing_market_cap; compatible with --summary and --compact. Example: stock analyze AAPL --flat"`
+	Summary bool     `flag:"summary" flaggroup:"Output Format" flagdescr:"Return compact screening objects for ranking many symbols; compatible with --compact and --flat. Example: stock analyze --summary AAPL MSFT NVDA"`
 }
 
 // MergeSymbols merges positional arguments with --symbols and --tickers flag values, deduplicating and trimming whitespace.
@@ -78,6 +78,10 @@ func newStockAnalyzeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "analyze [symbol...]",
 		Short: "Analyze one or more stock symbols",
+		Example: `  marketsurge-agent stock analyze AAPL
+  marketsurge-agent stock analyze --tickers AAPL,MSFT,NVDA --compact
+  marketsurge-agent stock analyze --summary AAPL MSFT NVDA
+  marketsurge-agent stock analyze AAPL --flat --compact`,
 		Long: `Fetches stock, fundamentals, and ownership concurrently for one or more
 symbols. Accepts positional symbols, --symbols values, and backward-compatible
 --tickers values together. Multi-symbol requests are concurrent and can return partial

--- a/cmd/stock_test.go
+++ b/cmd/stock_test.go
@@ -316,9 +316,9 @@ func TestStockAnalyzeStructTags(t *testing.T) {
 	}{
 		{field: "Symbols", flag: "symbols", short: "s", group: "Input", descr: "Stock symbols to analyze, for example AAPL,MSFT; accepts comma-separated or repeated values; positional symbols remain supported for shell use", hasShort: true},
 		{field: "Tickers", flag: "tickers", short: "t", group: "Input", descr: "Additional stock symbols to analyze; accepts comma-separated or repeated values", hasShort: true},
-		{field: "Compact", flag: "compact", group: "Output Format", descr: "Remove duplicate formatted string fields while keeping raw numeric values"},
-		{field: "Flat", flag: "flat", group: "Output Format", descr: "Flatten nested analysis fields into single-level JSON keys"},
-		{field: "Summary", flag: "summary", group: "Output Format", descr: "Return compact screening objects for ranking many symbols"},
+		{field: "Compact", flag: "compact", group: "Output Format", descr: "Remove duplicate formatted string fields while keeping raw numeric values; compatible with --summary and --flat. Example: stock analyze AAPL --compact"},
+		{field: "Flat", flag: "flat", group: "Output Format", descr: "Flatten nested analysis fields into single-level JSON keys, for example stock.pricing.market_cap becomes pricing_market_cap; compatible with --summary and --compact. Example: stock analyze AAPL --flat"},
+		{field: "Summary", flag: "summary", group: "Output Format", descr: "Return compact screening objects for ranking many symbols; compatible with --compact and --flat. Example: stock analyze --summary AAPL MSFT NVDA"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.field, func(t *testing.T) {
@@ -402,6 +402,27 @@ func TestMultiSymbolOptionsResolveSymbols(t *testing.T) {
 	got := opts.ResolveSymbols([]string{"AAPL", "TSLA"}, []string{"NVDA,AMD"})
 
 	assert.Equal(t, []string{"AAPL", "TSLA", "MSFT", "NVDA", "AMD"}, got)
+}
+
+func TestStockAnalyzeExamples(t *testing.T) {
+	t.Parallel()
+
+	cmd := newStockAnalyzeCmd()
+	assert.Contains(t, cmd.Example, "marketsurge-agent stock analyze AAPL")
+	assert.Contains(t, cmd.Example, "--tickers AAPL,MSFT,NVDA --compact")
+	assert.Contains(t, cmd.Example, "--summary AAPL MSFT NVDA")
+	assert.Contains(t, cmd.Example, "--flat --compact")
+
+	typ := reflect.TypeFor[StockAnalyzeOptions]()
+	for _, fieldName := range []string{"Compact", "Flat", "Summary"} {
+		t.Run(fieldName, func(t *testing.T) {
+			field, ok := typ.FieldByName(fieldName)
+			require.True(t, ok)
+			descr := field.Tag.Get("flagdescr")
+			assert.Contains(t, descr, "compatible with")
+			assert.Contains(t, descr, "Example: stock analyze")
+		})
+	}
 }
 
 func TestStockAnalyzeMissingSymbol(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add copyable invocation examples to schema-visible command descriptions and flag descriptions for chart history, catalog run, and stock analyze.
- Document that complex examples belong in command Long text and flagdescr fields because structcli draft JSON Schema does not emit Cobra Example.
- Add tests proving the full-tree schema exposes the examples agents need for conditional modes and output formatting choices.

## Verification
- go test ./cmd
- make lint
- make test && make build
- live smoke: ./marketsurge-agent --jsonschema=tree
- live smoke: ./marketsurge-agent stock get AAPL
- live smoke: ./marketsurge-agent stock analyze --tickers AAPL,MSFT --compact --flat
- live smoke: ./marketsurge-agent chart history AAPL --lookback 3M
- live smoke: ./marketsurge-agent chart history AAPL --start-date 2024-01-01 --end-date 2024-06-30
- live smoke: ./marketsurge-agent catalog list --kind report