### PR TITLE
feat(cmd): improve validation recovery errors

### DIFF
--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -4,6 +4,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -21,6 +22,7 @@ import (
 const (
 	defaultCatalogRunLimit       = 50
 	structcliFlagGroupAnnotation = "leodido/structcli/flag-groups"
+	validCatalogKindList         = "watchlist, screen, report, coach_screen"
 )
 
 var watchlistFieldAliases = map[string]string{
@@ -144,32 +146,34 @@ func (o *CatalogRunOptions) FromCommand(cmd *cobra.Command) {
 // Validate checks that the catalog run options are consistent and complete.
 func (o *CatalogRunOptions) Validate(_ context.Context) []error {
 	if o.Kind == "" {
-		return []error{mserrors.NewValidationError("kind is required", nil)}
+		return []error{mserrors.NewValidationError("missing --kind: use --kind watchlist --watchlist-id 12345, --kind report --report-id 67890, or --kind coach_screen --coach-screen-id ID", nil)}
 	}
 
 	kind, err := parseCatalogKind(string(o.Kind))
 	if err != nil {
-		return []error{err}
+		return []error{mserrors.NewValidationError(
+			fmt.Sprintf("invalid --kind %q for catalog run: use one of watchlist, report, coach_screen; screen is list-only", o.Kind), nil,
+		)}
 	}
 	if kind == nil {
-		return []error{mserrors.NewValidationError("kind is required", nil)}
+		return []error{mserrors.NewValidationError("missing --kind: use --kind watchlist --watchlist-id 12345, --kind report --report-id 67890, or --kind coach_screen --coach-screen-id ID", nil)}
 	}
 	if *kind == models.CatalogKindScreen {
-		return []error{mserrors.NewValidationError("screens cannot be run directly, use catalog list to view them", nil)}
+		return []error{mserrors.NewValidationError("invalid --kind screen for catalog run: screens are list-only; use catalog list --kind screen", nil)}
 	}
 
 	switch *kind {
 	case models.CatalogKindReport:
 		if o.ReportID == 0 {
-			return []error{mserrors.NewValidationError("report-id is required when kind=report", nil)}
+			return []error{mserrors.NewValidationError("missing --report-id: --kind report requires --report-id 67890", nil)}
 		}
 	case models.CatalogKindWatchlist:
 		if o.WatchlistID == 0 {
-			return []error{mserrors.NewValidationError("watchlist-id is required when kind=watchlist", nil)}
+			return []error{mserrors.NewValidationError("missing --watchlist-id: --kind watchlist requires --watchlist-id 12345", nil)}
 		}
 	case models.CatalogKindCoachScreen:
 		if o.CoachScreenID == "" {
-			return []error{mserrors.NewValidationError("coach-screen-id is required when kind=coach_screen", nil)}
+			return []error{mserrors.NewValidationError("missing --coach-screen-id: --kind coach_screen requires --coach-screen-id ID", nil)}
 		}
 	}
 
@@ -288,7 +292,7 @@ func runCatalogEntries(ctx context.Context, c *client.Client, opts *CatalogRunOp
 		rows := paginateSlice(result.Rows, opts.Limit, opts.Offset)
 		return rows, len(result.Rows), nil
 	default:
-		return nil, 0, mserrors.NewValidationError("kind must be one of: watchlist, screen, report, coach_screen", nil)
+		return nil, 0, mserrors.NewValidationError("invalid --kind: use one of watchlist, report, coach_screen for catalog run; screen is list-only", nil)
 	}
 }
 
@@ -470,7 +474,7 @@ func parseCatalogKind(value string) (*models.CatalogKind, error) {
 
 	kind, ok := validCatalogKinds[value]
 	if !ok {
-		return nil, mserrors.NewValidationError("kind must be one of: watchlist, screen, report, coach_screen", nil)
+		return nil, mserrors.NewValidationError(fmt.Sprintf("invalid --kind %q: use one of %s", value, validCatalogKindList), nil)
 	}
 
 	return &kind, nil

--- a/cmd/catalog_test.go
+++ b/cmd/catalog_test.go
@@ -139,7 +139,7 @@ func TestCatalogListInvalidKind(t *testing.T) {
 
 	var verr *mserrors.ValidationError
 	assert.ErrorAs(t, err, &verr)
-	assert.Contains(t, err.Error(), "kind must be one of")
+	assert.Equal(t, "invalid --kind \"invalid\": use one of watchlist, screen, report, coach_screen", err.Error())
 }
 
 func TestCatalogRunReportDispatch(t *testing.T) {
@@ -211,7 +211,7 @@ func TestCatalogRunMissingKind(t *testing.T) {
 
 	var verr *mserrors.ValidationError
 	assert.ErrorAs(t, err, &verr)
-	assert.Contains(t, err.Error(), "kind is required")
+	assert.Contains(t, err.Error(), "missing --kind: use --kind watchlist --watchlist-id 12345, --kind report --report-id 67890, or --kind coach_screen --coach-screen-id ID")
 }
 
 func TestCatalogRunScreenKindValidation(t *testing.T) {
@@ -224,7 +224,7 @@ func TestCatalogRunScreenKindValidation(t *testing.T) {
 
 	var verr *mserrors.ValidationError
 	assert.ErrorAs(t, err, &verr)
-	assert.Contains(t, err.Error(), "screens cannot be run directly")
+	assert.Contains(t, err.Error(), "invalid --kind screen for catalog run: screens are list-only; use catalog list --kind screen")
 }
 
 func TestCatalogRunMissingIDForKind(t *testing.T) {
@@ -237,9 +237,9 @@ func TestCatalogRunMissingIDForKind(t *testing.T) {
 		args    []string
 		message string
 	}{
-		{name: "report", args: []string{"run", "--kind", "report"}, message: "report-id is required when kind=report"},
-		{name: "watchlist", args: []string{"run", "--kind", "watchlist"}, message: "watchlist-id is required when kind=watchlist"},
-		{name: "coach_screen", args: []string{"run", "--kind", "coach_screen"}, message: "coach-screen-id is required when kind=coach_screen"},
+		{name: "report", args: []string{"run", "--kind", "report"}, message: "missing --report-id: --kind report requires --report-id 67890"},
+		{name: "watchlist", args: []string{"run", "--kind", "watchlist"}, message: "missing --watchlist-id: --kind watchlist requires --watchlist-id 12345"},
+		{name: "coach_screen", args: []string{"run", "--kind", "coach_screen"}, message: "missing --coach-screen-id: --kind coach_screen requires --coach-screen-id ID"},
 	}
 
 	for _, tt := range tests {
@@ -651,22 +651,22 @@ func TestCatalogRunOptionsValidate(t *testing.T) {
 		{
 			name:    "missing kind",
 			opts:    CatalogRunOptions{},
-			wantErr: "kind is required",
+			wantErr: "missing --kind: use --kind watchlist --watchlist-id 12345, --kind report --report-id 67890, or --kind coach_screen --coach-screen-id ID",
 		},
 		{
 			name:    "invalid kind",
 			opts:    CatalogRunOptions{Kind: "bogus"},
-			wantErr: "kind must be one of",
+			wantErr: "invalid --kind \"bogus\" for catalog run: use one of watchlist, report, coach_screen; screen is list-only",
 		},
 		{
 			name:    "screen kind rejected",
 			opts:    CatalogRunOptions{Kind: "screen"},
-			wantErr: "screens cannot be run directly",
+			wantErr: "invalid --kind screen for catalog run: screens are list-only; use catalog list --kind screen",
 		},
 		{
 			name:    "report without report-id",
 			opts:    CatalogRunOptions{Kind: "report"},
-			wantErr: "report-id is required when kind=report",
+			wantErr: "missing --report-id: --kind report requires --report-id 67890",
 		},
 		{
 			name: "report with report-id",
@@ -675,7 +675,7 @@ func TestCatalogRunOptionsValidate(t *testing.T) {
 		{
 			name:    "watchlist without watchlist-id",
 			opts:    CatalogRunOptions{Kind: "watchlist"},
-			wantErr: "watchlist-id is required when kind=watchlist",
+			wantErr: "missing --watchlist-id: --kind watchlist requires --watchlist-id 12345",
 		},
 		{
 			name: "watchlist with watchlist-id",
@@ -684,7 +684,7 @@ func TestCatalogRunOptionsValidate(t *testing.T) {
 		{
 			name:    "coach_screen without coach-screen-id",
 			opts:    CatalogRunOptions{Kind: "coach_screen"},
-			wantErr: "coach-screen-id is required when kind=coach_screen",
+			wantErr: "missing --coach-screen-id: --kind coach_screen requires --coach-screen-id ID",
 		},
 		{
 			name: "coach_screen with coach-screen-id",
@@ -704,7 +704,7 @@ func TestCatalogRunOptionsValidate(t *testing.T) {
 				require.Error(t, err)
 				var verr *mserrors.ValidationError
 				assert.ErrorAs(t, err, &verr)
-				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Equal(t, tt.wantErr, err.Error())
 			}
 		})
 	}

--- a/cmd/chart.go
+++ b/cmd/chart.go
@@ -81,7 +81,12 @@ var validLookbacks = map[string]bool{
 }
 
 // defaultExchangeName is used for daily chart queries.
-const defaultExchangeName = "NYSE"
+const (
+	defaultExchangeName       = "NYSE"
+	chartLookbackExample      = "--lookback 3M"
+	chartExplicitRangeExample = "--start-date 2024-01-01 --end-date 2024-04-21"
+	validLookbackValues       = "1W, 1M, 3M, 6M, 1Y, YTD"
+)
 
 // ChartHistoryOptions holds flags for the chart history command.
 // Lookback stays string (not models.Lookback) because it is optional with no default;
@@ -102,20 +107,25 @@ func (o *ChartHistoryOptions) Validate(_ context.Context) []error {
 
 	if hasExplicit && hasLookback {
 		return []error{mserrors.NewValidationError(
-			"cannot use both --start-date/--end-date and --lookback", nil,
+			"conflicting date flags: use either "+chartLookbackExample+" or "+chartExplicitRangeExample+", not both", nil,
 		)}
 	}
 
 	if !hasExplicit && !hasLookback {
 		return []error{mserrors.NewValidationError(
-			"either --start-date and --end-date or --lookback is required", nil,
+			"missing date range: provide either "+chartLookbackExample+" or both "+chartExplicitRangeExample, nil,
 		)}
 	}
 
 	if hasExplicit {
-		if o.StartDate == "" || o.EndDate == "" {
+		if o.StartDate == "" {
 			return []error{mserrors.NewValidationError(
-				"both --start-date and --end-date are required when using explicit dates", nil,
+				"missing --start-date: explicit date ranges require both "+chartExplicitRangeExample, nil,
+			)}
+		}
+		if o.EndDate == "" {
+			return []error{mserrors.NewValidationError(
+				"missing --end-date: explicit date ranges require both "+chartExplicitRangeExample, nil,
 			)}
 		}
 		return nil
@@ -123,7 +133,7 @@ func (o *ChartHistoryOptions) Validate(_ context.Context) []error {
 
 	if !validLookbacks[o.Lookback] {
 		return []error{mserrors.NewValidationError(
-			"invalid lookback value: must be one of 1W, 1M, 3M, 6M, 1Y, YTD", nil,
+			"invalid --lookback value \""+o.Lookback+"\": use one of "+validLookbackValues, nil,
 		)}
 	}
 

--- a/cmd/chart_test.go
+++ b/cmd/chart_test.go
@@ -134,7 +134,7 @@ func TestChartHistoryMutualExclusion(t *testing.T) {
 
 	var verr *mserrors.ValidationError
 	assert.ErrorAs(t, err, &verr)
-	assert.Contains(t, err.Error(), "cannot use both")
+	assert.Contains(t, err.Error(), "conflicting date flags: use either --lookback 3M or --start-date 2024-01-01 --end-date 2024-04-21, not both")
 }
 
 func TestChartHistoryNeitherDatesNorLookback(t *testing.T) {
@@ -148,7 +148,7 @@ func TestChartHistoryNeitherDatesNorLookback(t *testing.T) {
 
 	var verr *mserrors.ValidationError
 	assert.ErrorAs(t, err, &verr)
-	assert.Contains(t, err.Error(), "either")
+	assert.Contains(t, err.Error(), "missing date range: provide either --lookback 3M or both --start-date 2024-01-01 --end-date 2024-04-21")
 }
 
 func TestChartHistoryPartialExplicitDates(t *testing.T) {
@@ -163,7 +163,22 @@ func TestChartHistoryPartialExplicitDates(t *testing.T) {
 
 	var verr *mserrors.ValidationError
 	assert.ErrorAs(t, err, &verr)
-	assert.Contains(t, err.Error(), "both --start-date and --end-date")
+	assert.Contains(t, err.Error(), "missing --end-date: explicit date ranges require both --start-date 2024-01-01 --end-date 2024-04-21")
+}
+
+func TestChartHistoryEndDateWithoutStartDate(t *testing.T) {
+	t.Parallel()
+	server := jsonServer(`{}`)
+	defer server.Close()
+	c := testClient(t, server)
+
+	_, err := executeChartCmd(t, c,
+		"history", "--end-date", "2024-06-30", "AAPL")
+	require.Error(t, err)
+
+	var verr *mserrors.ValidationError
+	assert.ErrorAs(t, err, &verr)
+	assert.Contains(t, err.Error(), "missing --start-date: explicit date ranges require both --start-date 2024-01-01 --end-date 2024-04-21")
 }
 
 func TestChartHistoryInvalidLookback(t *testing.T) {
@@ -178,7 +193,7 @@ func TestChartHistoryInvalidLookback(t *testing.T) {
 
 	var verr *mserrors.ValidationError
 	assert.ErrorAs(t, err, &verr)
-	assert.Contains(t, err.Error(), "invalid lookback")
+	assert.Contains(t, err.Error(), "invalid --lookback value \"2W\": use one of 1W, 1M, 3M, 6M, 1Y, YTD")
 }
 
 func TestResolveLookback(t *testing.T) {
@@ -229,17 +244,22 @@ func TestChartHistoryOptionsValidate(t *testing.T) {
 		{
 			name:    "both explicit dates and lookback",
 			opts:    ChartHistoryOptions{StartDate: "2024-01-01", EndDate: "2024-06-30", Lookback: "3M"},
-			wantErr: "cannot use both",
+			wantErr: "conflicting date flags: use either --lookback 3M or --start-date 2024-01-01 --end-date 2024-04-21, not both",
 		},
 		{
 			name:    "neither dates nor lookback",
 			opts:    ChartHistoryOptions{},
-			wantErr: "either",
+			wantErr: "missing date range: provide either --lookback 3M or both --start-date 2024-01-01 --end-date 2024-04-21",
 		},
 		{
 			name:    "only start-date without end-date",
 			opts:    ChartHistoryOptions{StartDate: "2024-01-01"},
-			wantErr: "both --start-date and --end-date",
+			wantErr: "missing --end-date: explicit date ranges require both --start-date 2024-01-01 --end-date 2024-04-21",
+		},
+		{
+			name:    "only end-date without start-date",
+			opts:    ChartHistoryOptions{EndDate: "2024-04-21"},
+			wantErr: "missing --start-date: explicit date ranges require both --start-date 2024-01-01 --end-date 2024-04-21",
 		},
 		{
 			name: "valid explicit dates",
@@ -252,7 +272,7 @@ func TestChartHistoryOptionsValidate(t *testing.T) {
 		{
 			name:    "invalid lookback value",
 			opts:    ChartHistoryOptions{Lookback: "2W"},
-			wantErr: "invalid lookback",
+			wantErr: "invalid --lookback value \"2W\": use one of 1W, 1M, 3M, 6M, 1Y, YTD",
 		},
 	}
 
@@ -264,7 +284,7 @@ func TestChartHistoryOptionsValidate(t *testing.T) {
 				require.Len(t, errs, 1)
 				var verr *mserrors.ValidationError
 				assert.ErrorAs(t, errs[0], &verr)
-				assert.Contains(t, errs[0].Error(), tt.wantErr)
+				assert.Equal(t, tt.wantErr, errs[0].Error())
 			} else {
 				assert.Empty(t, errs)
 			}

--- a/cmd/marketsurge-agent/main_test.go
+++ b/cmd/marketsurge-agent/main_test.go
@@ -57,9 +57,37 @@ func TestHelpContainsAllCommands(t *testing.T) {
 // TestUnknownCommandReturnsError verifies that an unrecognized subcommand
 // produces a non-zero exit code and mentions "unknown command".
 func TestUnknownCommandReturnsError(t *testing.T) {
-	out, err := exec.Command(testBinary, "nonexistent").CombinedOutput()
+	cmd := exec.Command(testBinary, "nonexistent")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
 	require.Error(t, err, "unknown command should exit non-zero")
-	assert.Contains(t, strings.ToLower(string(out)), "unknown command")
+	assert.Contains(t, stdout.String(), "Usage:", "unknown commands still show root help on stdout")
+
+	envelope := parseErrorEnvelope(t, stderr.Bytes())
+	assert.Equal(t, "GENERAL_ERROR", envelope["code"])
+	assert.Contains(t, strings.ToLower(envelope["message"].(string)), "unknown command")
+}
+
+// TestUnknownFlagReturnsJSONError verifies cobra/structcli flag errors use the
+// same stderr JSON envelope as domain errors.
+func TestUnknownFlagReturnsJSONError(t *testing.T) {
+	cmd := exec.Command(testBinary, "--jwt", "not-supported")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	require.Error(t, err, "unknown flag should exit non-zero")
+	assert.Empty(t, stdout.String(), "errors should not be written to stdout")
+
+	envelope := parseErrorEnvelope(t, stderr.Bytes())
+	assert.Equal(t, "GENERAL_ERROR", envelope["code"])
+	assert.Contains(t, strings.ToLower(envelope["message"].(string)), "unknown flag")
 }
 
 // TestErrorOutputIsValidJSON runs a command with no valid Firefox profile
@@ -92,4 +120,13 @@ func TestErrorOutputIsValidJSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal(stderr.Bytes(), &envelope),
 		"stderr should be valid JSON: %s", stderr.String())
 	assert.Contains(t, envelope, "error")
+}
+
+func parseErrorEnvelope(t *testing.T, payload []byte) map[string]any {
+	t.Helper()
+	var envelope map[string]any
+	require.NoError(t, json.Unmarshal(payload, &envelope), "stderr should be valid JSON: %s", string(payload))
+	errorBody, ok := envelope["error"].(map[string]any)
+	require.True(t, ok, "stderr JSON should include an error object: %s", string(payload))
+	return errorBody
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -212,14 +212,15 @@ func Execute() {
 	filter := &configStatusFilter{w: originalOut}
 	rootCmd.SetOut(filter)
 	executed, err := structcli.ExecuteC(rootCmd)
-	if flushErr := filter.Flush(); err == nil && flushErr != nil {
-		err = flushErr
-	}
-	rootCmd.SetOut(nil)
-
 	if err == nil && executed == rootCmd && len(rootCmd.Flags().Args()) > 0 {
 		err = fmt.Errorf("unknown command %q", rootCmd.Flags().Arg(0))
 	}
+	if err == nil {
+		if flushErr := filter.Flush(); flushErr != nil {
+			err = flushErr
+		}
+	}
+	rootCmd.SetOut(nil)
 	if err != nil {
 		_ = output.WriteError(rootCmd.OutOrStderr(), err)
 		var mserr interface{ ExitCode() int }

--- a/cmd/rs_history_test.go
+++ b/cmd/rs_history_test.go
@@ -127,4 +127,8 @@ func TestRSHistoryGetMissingSymbol(t *testing.T) {
 
 	_, err := executeCommandWithClient(t, newRSHistoryCmd(), c, "get")
 	require.Error(t, err)
+
+	var verr *mserrors.ValidationError
+	assert.ErrorAs(t, err, &verr)
+	assert.Equal(t, "missing symbols: pass positional symbols like rs-history get AAPL MSFT", err.Error())
 }

--- a/cmd/rs_history_test.go
+++ b/cmd/rs_history_test.go
@@ -130,5 +130,5 @@ func TestRSHistoryGetMissingSymbol(t *testing.T) {
 
 	var verr *mserrors.ValidationError
 	assert.ErrorAs(t, err, &verr)
-	assert.Equal(t, "missing symbols: pass positional symbols like rs-history get AAPL MSFT", err.Error())
+	assert.Equal(t, "at least one symbol is required; pass --symbols AAPL,MSFT or positional symbols", err.Error())
 }

--- a/cmd/stock.go
+++ b/cmd/stock.go
@@ -101,7 +101,7 @@ interesting symbols without --summary for detail.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			symbols := opts.MergeSymbols(args)
 			if len(symbols) == 0 {
-				return mserrors.NewValidationError("at least one symbol required", nil)
+				return mserrors.NewValidationError("missing symbols: pass positional symbols like stock analyze AAPL MSFT or use --tickers AAPL,MSFT", nil)
 			}
 
 			ctx := cmd.Context()

--- a/cmd/stock_test.go
+++ b/cmd/stock_test.go
@@ -435,6 +435,7 @@ func TestStockAnalyzeMissingSymbol(t *testing.T) {
 	require.Error(t, err)
 	var verr *mserrors.ValidationError
 	assert.ErrorAs(t, err, &verr)
+	assert.Equal(t, "missing symbols: pass positional symbols like stock analyze AAPL MSFT or use --tickers AAPL,MSFT", err.Error())
 	assert.Empty(t, output)
 }
 


### PR DESCRIPTION
## Summary
- Make complex validation failures name the missing or conflicting flags and include valid retry shapes.
- Keep validation failures in the existing JSON error envelope with `VALIDATION_ERROR` exit codes where domain validation applies.
- Add binary-level coverage for JSON stderr envelopes on unknown command and unknown flag errors.

## Verification
- `go test ./cmd ./cmd/marketsurge-agent`
- `make lint`
- `make test && make build`
- Live smoke commands: `stock get AAPL`, `fundamental get MSFT`, `ownership get NVDA`, `stock analyze --tickers AAPL,MSFT --compact`, `rs-history get AAPL MSFT`, `chart history AAPL --lookback 3M`