### PR TITLE
feat(cmd): polish mcp tool exposure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,9 +97,15 @@ structcli.Setup(rootCmd,
     structcli.WithHelpTopics(helptopics.Options{ReferenceSection: true}),
     structcli.WithDebug(debug.Options{Exit: true}),
     structcli.WithMCP(mcp.Options{
-        Name:    "marketsurge-agent",
-        Version: version,
-        Exclude: []string{"completion-bash", "completion-fish", "completion-powershell", "completion-zsh"},
+        Name:      "marketsurge-agent",
+        Version:   version,
+        Separator: "_",
+        Exclude: []string{
+            "marketsurge-agent completion bash",
+            "marketsurge-agent completion fish",
+            "marketsurge-agent completion powershell",
+            "marketsurge-agent completion zsh",
+        },
     }),
 )
 ```
@@ -110,6 +116,8 @@ Key behaviors:
 - `--jsonschema` prints the full command tree JSON schema and exits without auth
 - `--jsonschema=tree` remains supported and returns the same full-tree schema for scripts that already request it
 - `--mcp` runs a stdio Model Context Protocol server; `initialize` and `tools/list` discovery do not require auth, while `tools/call` for API commands uses the normal Firefox cookie auth chain; shell completion subcommands are excluded from the MCP tool list
+- MCP tool names use `_` between command path segments, for example `stock_analyze`, `chart_history`, and `catalog_run`; command segments that already contain a dash keep it, for example `rs-history_get`
+- MCP exposes only runnable leaf API commands. Do not set `AllCommands: true` unless parent command tools become intentionally useful.
 - `--debug-options` prints resolved flag values and exits (requires `Exit: true` in debug options)
 - `env-vars` and `config-keys` are built-in help topics (e.g., `marketsurge-agent help env-vars`)
 - `structcli.ExecuteC(rootCmd)` replaces `rootCmd.Execute()` in `Execute()`

--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ marketsurge-agent --mcp
 
 MCP discovery does not require MarketSurge authentication. Tool calls that fetch MarketSurge data still use the same Firefox cookie authentication chain as normal CLI commands and return the same JSON envelopes.
 
+MCP tool names use underscores between command path segments, such as `stock_analyze`, `chart_history`, and `catalog_run`. Existing dashes inside a command segment remain, so `rs-history get` becomes `rs-history_get`. The tool list is limited to runnable MarketSurge data commands; shell completion and parent help commands are not exposed.
+
 ## Development
 
 Requires Go 1.26+.

--- a/cmd/AGENTS.md
+++ b/cmd/AGENTS.md
@@ -54,6 +54,8 @@ The root command enables structcli JSON schema output with `jsonschema.WithFullT
 
 Enum-backed flags should keep typed enum fields when a non-empty default exists. The schema exposes those values through machine-readable `enum` arrays and keeps the `{value1,value2}` text in descriptions for prompt readability. Optional enum-like fields with no default, such as `ChartHistoryOptions.Lookback`, must stay `string` and document valid values in `flagdescr` so command validation can return domain `ValidationError` envelopes.
 
+MCP tool names use `_` as the structcli command-path separator, for example `stock_analyze`, `chart_history`, and `catalog_run`. Existing command segments keep their own spelling, so `rs-history get` becomes `rs-history_get`. Use full command paths in the MCP `Exclude` list, not generated tool names, so excludes keep working if the separator changes later. Keep `AllCommands` unset/false so only runnable leaf API commands are exposed.
+
 ### Test pattern
 
 Tests call constructors directly (not package-level vars) and inject client via context:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -121,13 +121,14 @@ func init() {
 		structcli.WithHelpTopics(helptopics.Options{ReferenceSection: true}),
 		structcli.WithDebug(debug.Options{Exit: true}),
 		structcli.WithMCP(structclimcp.Options{
-			Name:    "marketsurge-agent",
-			Version: version,
+			Name:      "marketsurge-agent",
+			Version:   version,
+			Separator: "_",
 			Exclude: []string{
-				"completion-bash",
-				"completion-fish",
-				"completion-powershell",
-				"completion-zsh",
+				"marketsurge-agent completion bash",
+				"marketsurge-agent completion fish",
+				"marketsurge-agent completion powershell",
+				"marketsurge-agent completion zsh",
 			},
 		}),
 	); err != nil {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -183,32 +183,83 @@ func TestRootMCPInitializeAndToolsList(t *testing.T) {
 
 	var listResult mcpToolsListResult
 	require.NoError(t, json.Unmarshal(responses[1].Result, &listResult))
-	toolNames := make([]string, 0, len(listResult.Tools))
-	for _, tool := range listResult.Tools {
-		toolNames = append(toolNames, tool.Name)
-	}
+	toolNames := mcpToolNames(listResult)
 	assert.ElementsMatch(t, []string{
-		"catalog-list",
-		"catalog-run",
-		"chart-history",
-		"chart-markups",
-		"fundamental-get",
-		"ownership-get",
-		"rs-history-get",
-		"stock-analyze",
-		"stock-get",
+		"catalog_list",
+		"catalog_run",
+		"chart_history",
+		"chart_markups",
+		"fundamental_get",
+		"ownership_get",
+		"rs-history_get",
+		"stock_analyze",
+		"stock_get",
 	}, toolNames)
-	assert.NotContains(t, toolNames, "completion-bash")
-	assert.NotContains(t, toolNames, "completion-fish")
-	assert.NotContains(t, toolNames, "completion-powershell")
-	assert.NotContains(t, toolNames, "completion-zsh")
+	assert.NotContains(t, toolNames, "completion_bash")
+	assert.NotContains(t, toolNames, "completion_fish")
+	assert.NotContains(t, toolNames, "completion_powershell")
+	assert.NotContains(t, toolNames, "completion_zsh")
+	assert.NotContains(t, toolNames, "stock")
+	assert.NotContains(t, toolNames, "chart")
+	assert.NotContains(t, toolNames, "catalog")
+	for _, tool := range listResult.Tools {
+		assert.NotEmpty(t, tool.Description, "tool %s should have a description", tool.Name)
+		require.NotEmpty(t, tool.InputSchema, "tool %s should expose an input schema", tool.Name)
+		var schema map[string]any
+		require.NoError(t, json.Unmarshal(tool.InputSchema, &schema), "tool %s input schema should be JSON", tool.Name)
+		assert.Equal(t, "object", schema["type"], "tool %s schema should be an object", tool.Name)
+		assert.Equal(t, "MARKETSURGE_AGENT", schema["x-structcli-env-prefix"], "tool %s schema should expose env metadata", tool.Name)
+		assert.Equal(t, "config", schema["x-structcli-config-flag"], "tool %s schema should expose config metadata", tool.Name)
+	}
 	assert.NotContains(t, string(output), "Firefox")
 	assert.NotContains(t, string(output), "cookie")
 }
 
+func TestRootMCPToolSchemasExposeFlagMetadata(t *testing.T) {
+	cmd := rootExecCommand(t, "--mcp")
+	cmd.Stdin = strings.NewReader(
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"test"}}}` + "\n" +
+			`{"jsonrpc":"2.0","id":2,"method":"tools/list"}`,
+	)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	responses := decodeMCPResponses(t, output)
+	require.Len(t, responses, 2)
+
+	var listResult mcpToolsListResult
+	require.NoError(t, json.Unmarshal(responses[1].Result, &listResult))
+
+	stockAnalyze := mcpToolByName(t, listResult, "stock_analyze")
+	stockAnalyzeSchema := mcpInputSchema(t, stockAnalyze)
+	stockAnalyzeProps := schemaProperties(t, stockAnalyzeSchema)
+	assert.Contains(t, stockAnalyze.Description, "Fetches stock")
+	assert.Contains(t, stockAnalyzeProps, "tickers")
+	assert.Contains(t, stockAnalyzeProps, "compact")
+	assert.Equal(t, "Input", stockAnalyzeProps["tickers"].(map[string]any)["x-structcli-group"])
+
+	chartHistory := mcpToolByName(t, listResult, "chart_history")
+	chartHistorySchema := mcpInputSchema(t, chartHistory)
+	chartHistoryProps := schemaProperties(t, chartHistorySchema)
+	assert.Contains(t, chartHistory.Description, "Fetches price history")
+	assert.Contains(t, chartHistoryProps, "lookback")
+	assert.Contains(t, chartHistoryProps, "start-date")
+	assert.Contains(t, chartHistoryProps, "end-date")
+	assert.Equal(t, "Date Range", chartHistoryProps["lookback"].(map[string]any)["x-structcli-group"])
+
+	catalogRun := mcpToolByName(t, listResult, "catalog_run")
+	catalogRunSchema := mcpInputSchema(t, catalogRun)
+	catalogRunProps := schemaProperties(t, catalogRunSchema)
+	assert.Contains(t, catalogRun.Description, "Runs a catalog entry")
+	assert.Contains(t, catalogRunProps, "kind")
+	assert.Contains(t, catalogRunProps, "report-id")
+	assert.Contains(t, catalogRunProps, "watchlist-id")
+	assert.Equal(t, "Catalog Selection", catalogRunProps["kind"].(map[string]any)["x-structcli-group"])
+}
+
 func TestRootMCPToolsCallUsesAPIAuth(t *testing.T) {
 	cmd := rootExecCommand(t, "--mcp")
-	cmd.Stdin = strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"stock-analyze","arguments":{"tickers":"AAPL"}}}` + "\n")
+	cmd.Stdin = strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"stock_analyze","arguments":{"tickers":"AAPL"}}}` + "\n")
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(output))
 
@@ -326,8 +377,55 @@ type mcpInitializeResult struct {
 
 type mcpToolsListResult struct {
 	Tools []struct {
-		Name string `json:"name"`
+		Name        string          `json:"name"`
+		Description string          `json:"description"`
+		InputSchema json.RawMessage `json:"inputSchema"`
 	} `json:"tools"`
+}
+
+func mcpToolNames(result mcpToolsListResult) []string {
+	toolNames := make([]string, 0, len(result.Tools))
+	for _, tool := range result.Tools {
+		toolNames = append(toolNames, tool.Name)
+	}
+	return toolNames
+}
+
+func mcpToolByName(t *testing.T, result mcpToolsListResult, name string) struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"inputSchema"`
+} {
+	t.Helper()
+	for _, tool := range result.Tools {
+		if tool.Name == name {
+			return tool
+		}
+	}
+	require.Failf(t, "MCP tool not found", "tool %q not found in %v", name, mcpToolNames(result))
+	return struct {
+		Name        string          `json:"name"`
+		Description string          `json:"description"`
+		InputSchema json.RawMessage `json:"inputSchema"`
+	}{}
+}
+
+func mcpInputSchema(t *testing.T, tool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"inputSchema"`
+}) map[string]any {
+	t.Helper()
+	var schema map[string]any
+	require.NoError(t, json.Unmarshal(tool.InputSchema, &schema), "tool %s input schema should be JSON", tool.Name)
+	return schema
+}
+
+func schemaProperties(t *testing.T, schema map[string]any) map[string]any {
+	t.Helper()
+	props, ok := schema["properties"].(map[string]any)
+	require.True(t, ok, "schema should include object properties")
+	return props
 }
 
 type mcpToolCallResult struct {


### PR DESCRIPTION
## Summary
- Switch MCP tool names to underscore-separated command paths like `stock_analyze`, `chart_history`, and `catalog_run`.
- Keep MCP discovery limited to runnable MarketSurge data commands by leaving parent commands out and excluding shell completions with full command paths.
- Strengthen MCP tests around tool names, schema metadata, descriptions, and authenticated `tools/call` dispatch.

## Stack note
Merge after #43 so symbol-based MCP tools have schema-visible `--symbol` and `--symbols` inputs before agents rely on the polished tool names.

## Verification
- `go test ./cmd -run MCP`
- `go test ./cmd ./cmd/marketsurge-agent`
- `make lint`
- `make test && make build`
- MCP smoke: `tools/list` returned exactly 9 underscore tools with descriptions and object input schemas
- Live smoke commands: `stock get AAPL`, `fundamental get MSFT`, `ownership get NVDA`, `stock analyze --tickers AAPL,MSFT --compact`, `chart history AAPL --lookback 3M`