### PR TITLE
feat: surface ANTS details in stock summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,10 +203,10 @@ marketsurge-agent stock analyze --symbols AAPL,MSFT,NVDA --compact --flat
 - `--symbols AAPL,MSFT,NVDA` analyzes comma-separated symbols in one command. Positional symbols still work and can be combined with `--symbols`.
 - `--tickers AAPL,MSFT,NVDA` remains supported as a backward-compatible alias for `stock analyze`.
 - `--compact` removes duplicate formatted string fields such as `market_cap_formatted`, while keeping raw numeric values.
-- `--summary` returns one small screening object per symbol with rankings, signal flags, base details, liquidity, volatility, and ownership fields. Response metadata includes `mode: "summary"`.
+- `--summary` returns one small screening object per symbol with rankings, signal flags, ANTS dates and explanation, base details, liquidity, volatility, and ownership fields. Response metadata includes `mode: "summary"`.
 - `--flat` flattens each analysis result inside the standard JSON envelope, for example `stock.pricing.market_cap` becomes `pricing_market_cap`.
 
-`stock analyze` also includes MarketSurge technical context for chart-driven screening: `stock.base_pattern` summarizes the current base with pattern type, base stage, pivot price, base length, depth, and volume at pivot; `stock.signals` reports blue dot and ant signal flags when the API provides them.
+`stock analyze` also includes MarketSurge technical context for chart-driven screening: `stock.base_pattern` summarizes the current base with pattern type, base stage, pivot price, base length, depth, and volume at pivot; `stock.signals` reports blue dot and ANTS signal flags when the API provides them. ANTS marks flag institutional accumulation: repeated upside price action with rising volume over a recent 15-day window. Full output exposes the mark dates at `stock.pricing.ant_dates`; summary output includes `ant_dates` and `ant_explanation` whenever `ant_signal` is true.
 
 `rs-history get` accepts multiple symbols in one request through positional arguments or `--symbols`. Multi-symbol output uses a `data` object keyed by ticker so agents can compare RS trends without shell loops.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -284,7 +284,8 @@ results when only some symbols or subresources fail.
 Flags:
 
   --summary   Compact screening keys: symbol, composite, eps, rs, ad, smr,
-              blue_dot, ant_signal, base_type, base_stage, pivot,
+              blue_dot, ant_signal, ant_dates, ant_explanation,
+              base_type, base_stage, pivot,
               base_depth_percent, industry_group_rs, up_down_volume,
               atr_percent, avg_dollar_volume, funds_float_percent
   --compact   Removes duplicate formatted string fields, keeps raw values

--- a/cmd/stock.go
+++ b/cmd/stock.go
@@ -17,6 +17,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const antSignalExplanation = "ANTS marks flag institutional accumulation: repeated upside price action with rising volume over a recent 15-day window."
+
 func init() { rootCmd.AddCommand(newStockCmd()) }
 
 func newStockCmd() *cobra.Command {
@@ -88,7 +90,8 @@ results when only some symbols or subresources fail.
 Flags:
 
   --summary   Compact screening keys: symbol, composite, eps, rs, ad, smr,
-              blue_dot, ant_signal, base_type, base_stage, pivot,
+              blue_dot, ant_signal, ant_dates, ant_explanation,
+              base_type, base_stage, pivot,
               base_depth_percent, industry_group_rs, up_down_volume,
               atr_percent, avg_dollar_volume, funds_float_percent
   --compact   Removes duplicate formatted string fields, keeps raw values
@@ -237,6 +240,7 @@ func analysisSummaryMap(result AnalysisResult) map[string]any {
 
 	addRatingSummary(data, result.Stock.Ratings)
 	addSignalSummary(data, result.Stock.Signals)
+	addAntSummary(data, result.Stock)
 	addBaseSummary(data, result.Stock.BasePattern)
 	addScreeningMetrics(data, result.Stock)
 	return data
@@ -259,6 +263,17 @@ func addSignalSummary(data map[string]any, signals *models.Signals) {
 	}
 	addPtrValue(data, "blue_dot", signals.BlueDot)
 	addPtrValue(data, "ant_signal", signals.AntSignal)
+}
+
+func addAntSummary(data map[string]any, stock *models.StockData) {
+	if stock.Signals == nil || stock.Signals.AntSignal == nil || !*stock.Signals.AntSignal {
+		return
+	}
+
+	if stock.Pricing != nil && len(stock.Pricing.AntDates) > 0 {
+		data["ant_dates"] = stock.Pricing.AntDates
+	}
+	data["ant_explanation"] = antSignalExplanation
 }
 
 func addBaseSummary(data map[string]any, base *models.BasePattern) {

--- a/cmd/stock_test.go
+++ b/cmd/stock_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/major/marketsurge-agent/internal/client"
 	mserrors "github.com/major/marketsurge-agent/internal/errors"
+	"github.com/major/marketsurge-agent/internal/models"
 )
 
 func TestStockGetSuccess(t *testing.T) {
@@ -351,6 +352,8 @@ func TestStockAnalyzeSummaryOutput(t *testing.T) {
 	assert.Equal(t, "A", first["smr"])
 	assert.Equal(t, true, first["blue_dot"])
 	assert.Equal(t, true, first["ant_signal"])
+	assert.Equal(t, []any{"2024-12-18"}, first["ant_dates"])
+	assert.Equal(t, antSignalExplanation, first["ant_explanation"])
 	assert.Equal(t, "Cup With Handle", first["base_type"])
 	assert.Equal(t, "STAGE_2", first["base_stage"])
 	assert.Equal(t, 199.99, first["pivot"])
@@ -366,6 +369,24 @@ func TestStockAnalyzeSummaryOutput(t *testing.T) {
 
 	meta, _ := result["metadata"].(map[string]any)
 	assert.Equal(t, "summary", meta["mode"])
+}
+
+func TestStockAnalyzeSummaryOmitsAntDetailsWhenSignalFalse(t *testing.T) {
+	t.Parallel()
+	antSignal := false
+	result := AnalysisResult{
+		Symbol: "AAPL",
+		Stock: &models.StockData{
+			Signals: &models.Signals{AntSignal: &antSignal},
+			Pricing: &models.Pricing{AntDates: []string{"2024-12-18"}},
+		},
+	}
+
+	summary := analysisSummaryMap(result)
+
+	assert.Equal(t, false, summary["ant_signal"])
+	assert.NotContains(t, summary, "ant_dates")
+	assert.NotContains(t, summary, "ant_explanation")
 }
 
 func TestStockAnalyzeStructTags(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `ant_dates` and `ant_explanation` to `stock analyze --summary` when `ant_signal` is true.
- Document ANTS summary fields and regenerate `SKILL.md`.
- Cover ANTS summary output and false-signal omission in tests.

## Verification
- LSP diagnostics for `cmd/stock.go` and `cmd/stock_test.go`
- `go test -v ./cmd -run 'TestStockAnalyze(TechnicalSignals|SummaryOutput|SummaryOmitsAntDetailsWhenSignalFalse)$'`
- `make test`
- `make build`