### PR TITLE
chore: tune automated review configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -30,7 +30,8 @@ reviews:
       mode: warning
 
   auto_review:
-    enabled: true
+    # Keep automatic reviews off so maintainers can request CodeRabbit manually when quota is available.
+    enabled: false
     drafts: false
     auto_pause_after_reviewed_commits: 0
     base_branches:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,21 @@
+# marketsurge-agent review instructions
+
+Review this repository as a Go CLI that gives agents structured access to MarketSurge stock research data. The CLI is JSON-first, self-documenting through structcli, and authenticated by exchanging browser cookies for a JWT.
+
+Focus on correctness, credential safety, broken command contracts, data loss, GraphQL/API behavior, and repository conventions. Do not nitpick formatting or style that gofmt or golangci-lint already handles.
+
+## Project invariants
+
+- Command output must use JSON envelopes through `internal/output` helpers.
+- Errors must use the `MarketSurgeError` hierarchy and constructor functions.
+- JWT and Cookie headers must be added per request in `client.Execute()`, not in base headers.
+- GraphQL queries are embedded files and loaded through `queries.Load("name")`, not hardcoded strings.
+- `--jsonschema`, `--jsonschema=tree`, `--mcp`, help topics, and generated `SKILL.md` should stay aligned with command behavior.
+- Keep README, `AGENTS.md`, `SKILL.md`, CodeRabbit, and Copilot review guidance updated when command behavior or review priorities change.
+
+## Security and API checks
+
+- Flag any leak of cookies, JWTs, browser profile paths that expose secrets, GraphQL auth headers, or account data.
+- Cookie database access should handle missing files and permission errors gracefully.
+- Verify GraphQL query variables match the Go code that calls them.
+- Concurrency should follow the existing `sync.WaitGroup` and `sync.Mutex` patterns for parallel stock analysis.

--- a/.github/instructions/auth.instructions.md
+++ b/.github/instructions/auth.instructions.md
@@ -1,0 +1,10 @@
+---
+applyTo: "internal/auth/**/*.go"
+---
+
+# Auth review instructions
+
+- Cookie database precedence is explicit `--cookie-db`, then Firefox auto-discovery.
+- The token exchange happens at investors.com and the JWT is used for GraphQL at dowjones.io.
+- Verify no cookies, JWTs, or credentials are logged or exposed in errors.
+- Cookie database access should handle missing files and permission errors gracefully.

--- a/.github/instructions/automation.instructions.md
+++ b/.github/instructions/automation.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: ".github/workflows/**"
+---
+
+# GitHub Actions review instructions
+
+- Validate workflow syntax, least-privilege permissions, and secret handling.
+- Actions should be pinned consistently with existing workflows.
+- Avoid workflow changes that spend extra CI minutes without a clear project benefit.

--- a/.github/instructions/client.instructions.md
+++ b/.github/instructions/client.instructions.md
@@ -1,0 +1,11 @@
+---
+applyTo: "internal/client/**/*.go"
+---
+
+# Client review instructions
+
+- JWT and Cookie headers must be set per request, not in default or base headers.
+- GraphQL queries must be loaded from embedded files through `queries.Load()`.
+- HTTP and GraphQL errors must be wrapped in typed project errors.
+- Preserve request context propagation for cancellation.
+- Avoid adding fields to GraphQL requests that increase payload size without command value.

--- a/.github/instructions/coderabbit.instructions.md
+++ b/.github/instructions/coderabbit.instructions.md
@@ -1,0 +1,8 @@
+---
+applyTo: ".coderabbit.yaml"
+---
+
+# CodeRabbit review instructions
+
+- CodeRabbit automatic reviews should stay disabled so reviews are requested manually when quota is available.
+- Preserve `chat.auto_reply: true` so maintainers can request manual reviews from GitHub comments.

--- a/.github/instructions/errors.instructions.md
+++ b/.github/instructions/errors.instructions.md
@@ -1,0 +1,10 @@
+---
+applyTo: "internal/errors/**/*.go"
+---
+
+# Error review instructions
+
+- All project errors should embed `MarketSurgeError`.
+- Use constructor functions, not raw struct literals.
+- Keep exit codes aligned with `AGENTS.md`.
+- Preserve import alias conventions where present: `mserrors` in commands and `mserr` in output.

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -1,0 +1,13 @@
+---
+applyTo: "internal/**/*.go"
+---
+
+# Go review instructions
+
+- Wrap errors with `fmt.Errorf("context: %w", err)` when preserving causes.
+- Use `errors.As()` for typed errors and constructor functions to create project errors.
+- Avoid `init()` functions except for the existing Cobra command wiring pattern.
+- Command factories should follow the existing command constructor style.
+- All user-facing output must go through JSON envelope helpers.
+- Use `sync.WaitGroup` and `sync.Mutex` for concurrent analysis patterns.
+- Do not suggest style-only changes handled by gofmt or golangci-lint.

--- a/.github/instructions/graphql.instructions.md
+++ b/.github/instructions/graphql.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: "queries/**/*.graphql"
+---
+
+# GraphQL review instructions
+
+- Verify query variables match the Go caller.
+- Check for unused fields that add unnecessary payload.
+- Queries are embedded at build time with go:embed and should not be duplicated as string literals.

--- a/.github/instructions/makefile.instructions.md
+++ b/.github/instructions/makefile.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: "Makefile"
+---
+
+# Makefile review instructions
+
+- Non-file targets should have `.PHONY` declarations.
+- Avoid flags that are already tool defaults.
+- Keep docs, smoke, build, test, and lint targets aligned with README and `AGENTS.md`.

--- a/.github/instructions/release.instructions.md
+++ b/.github/instructions/release.instructions.md
@@ -1,0 +1,8 @@
+---
+applyTo: ".goreleaser.yml"
+---
+
+# Release review instructions
+
+- Verify GoReleaser v2 config, CGO settings, and platform matrix.
+- Release workflow changes should preserve intended GitHub Releases behavior.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,0 +1,12 @@
+---
+applyTo: "**/*_test.go"
+---
+
+# Test review instructions
+
+- Use `testify/assert` and `testify/require`, not bare if checks.
+- Mock HTTP with `httptest.NewServer` and request capture.
+- Use shared helpers such as `testClient()`, `jsonServer()`, and fixture builders where they exist.
+- Prefer table-driven subtests with `t.Run()`.
+- Check typed errors with `assert.ErrorAs()` or `require.ErrorAs()`.
+- CLI tests should suppress exits via `ExitErrHandler` and capture output with `bytes.Buffer`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@ Go CLI tool that lets AI agents query the MarketSurge stock research API. Single
 
 This project is unofficial and is not affiliated with, approved by, or endorsed by MarketSurge or Investor's Business Daily.
 
+Keep `.coderabbit.yaml` and `.github/copilot-instructions.md` plus `.github/instructions/*.instructions.md` aligned with current repo conventions when review-relevant behavior changes.
+
 ## Architecture
 
 ```text


### PR DESCRIPTION
## Summary
- Disable automatic CodeRabbit reviews so maintainers can request them manually when quota is available.
- Add repository and path-specific GitHub Copilot review instructions based on the existing CodeRabbit guidance.
- Note that review guidance files should stay aligned when repo conventions change.

## Validation
- Parsed `.coderabbit.yaml` with PyYAML.
- Confirmed Copilot instruction files include frontmatter where needed and stay under 4,000 characters.
- Checked changed Markdown for em dashes and unlabeled fenced code blocks.
- Checked `.coderabbit.yaml` with LSP diagnostics.