### PR TITLE
Improve agent-focused stock and catalog output

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -286,8 +286,13 @@ Flags:
   --summary   Compact screening keys: symbol, composite, eps, rs, ad, smr,
               blue_dot, ant_signal, ant_dates, ant_explanation,
               base_type, base_stage, pivot,
-              base_depth_percent, industry_group_rs, up_down_volume,
-              atr_percent, avg_dollar_volume, funds_float_percent
+              pivot_price_date, pricing_start_date, pricing_end_date,
+              base_depth_percent,
+              industry_group_rs, up_down_volume, atr_percent,
+              avg_dollar_volume, funds_float_percent
+  --setup     Setup-focused trade triage keys: all --summary keys plus
+              base_length_weeks, volume_at_pivot_percent,
+              ownership_funds_float_percent, quarterly_funds
   --compact   Removes duplicate formatted string fields, keeps raw values
   --flat      Flattens nested analysis fields inside the JSON envelope
 
@@ -298,9 +303,10 @@ interesting symbols without --summary for detail.
 
 | Flag | Type | Default | Required | Description |
 |------|------|---------|----------|-------------|
-| `--compact` | bool | false | no | Remove duplicate formatted string fields while keeping raw numeric values; compatible with --summary and --flat. Example: stock analyze AAPL --compact |
-| `--flat` | bool | false | no | Flatten nested analysis fields into single-level JSON keys, for example stock.pricing.market_cap becomes pricing_market_cap; compatible with --summary and --compact. Example: stock analyze AAPL --flat |
-| `--summary` | bool | false | no | Return compact screening objects for ranking many symbols; compatible with --compact and --flat. Example: stock analyze --summary AAPL MSFT NVDA |
+| `--compact` | bool | false | no | Remove duplicate formatted string fields while keeping raw numeric values; compatible with --flat. Example: stock analyze AAPL --compact |
+| `--flat` | bool | false | no | Flatten nested analysis fields into single-level JSON keys, for example stock.pricing.market_cap becomes pricing_market_cap; compatible with --compact. Example: stock analyze AAPL --flat |
+| `--setup` | bool | false | no | Return --setup trade triage fields: summary fields plus base_length_weeks, volume_at_pivot_percent, ownership_funds_float_percent, and quarterly_funds. Example: stock analyze AAPL --setup |
+| `--summary` | bool | false | no | Return compact screening objects for ranking many symbols. Example: stock analyze --summary AAPL MSFT NVDA |
 | `--symbols` | stringSlice | [] | no | Stock symbols to analyze, for example AAPL,MSFT; accepts comma-separated or repeated values; positional symbols remain supported for shell use |
 | `--tickers` | stringSlice | [] | no | Additional stock symbols to analyze; accepts comma-separated or repeated values |
 
@@ -310,6 +316,7 @@ interesting symbols without --summary for detail.
 marketsurge-agent stock analyze AAPL
   marketsurge-agent stock analyze --tickers AAPL,MSFT,NVDA --compact
   marketsurge-agent stock analyze --summary AAPL MSFT NVDA
+  marketsurge-agent stock analyze AAPL --setup
   marketsurge-agent stock analyze AAPL --flat --compact
 ```
 
@@ -351,5 +358,6 @@ marketsurge-agent chart history AAPL --lookback 3M
 marketsurge-agent stock analyze AAPL
   marketsurge-agent stock analyze --tickers AAPL,MSFT,NVDA --compact
   marketsurge-agent stock analyze --summary AAPL MSFT NVDA
+  marketsurge-agent stock analyze AAPL --setup
   marketsurge-agent stock analyze AAPL --flat --compact
 ```

--- a/cmd/catalog_run.go
+++ b/cmd/catalog_run.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/leodido/structcli"
@@ -76,6 +77,8 @@ func (o *CatalogRunOptions) Validate(_ context.Context) []error {
 		return []error{mserrors.NewValidationError("invalid --kind screen for catalog run: screens are list-only; use catalog list --kind screen", nil)}
 	}
 
+	o.Fields = normalizeWatchlistFields(o.Fields)
+
 	switch *kind {
 	case models.CatalogKindReport:
 		if o.ReportID == 0 {
@@ -89,6 +92,16 @@ func (o *CatalogRunOptions) Validate(_ context.Context) []error {
 		if o.CoachScreenID == "" {
 			return []error{mserrors.NewValidationError("missing --coach-screen-id: --kind coach_screen requires --coach-screen-id ID", nil)}
 		}
+		if hasWatchlistFields(o.Fields) {
+			return []error{mserrors.NewValidationError("unsupported --fields with --kind coach_screen: field projection is only supported for report and watchlist rows", nil)}
+		}
+	}
+
+	if unknown := unknownWatchlistFields(o.Fields); len(unknown) > 0 {
+		return []error{mserrors.NewValidationError(
+			fmt.Sprintf("unknown --fields values %q: use one or more of %s", strings.Join(unknown, ", "), strings.Join(validWatchlistFields(), ", ")),
+			nil,
+		)}
 	}
 
 	return nil
@@ -314,4 +327,60 @@ func normalizeWatchlistField(field string) (string, bool) {
 	}
 
 	return "", false
+}
+
+func unknownWatchlistFields(fields []string) []string {
+	unknown := make([]string, 0)
+	seen := map[string]bool{}
+	for _, field := range fields {
+		trimmed := strings.TrimSpace(field)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := normalizeWatchlistField(trimmed); ok {
+			continue
+		}
+		if seen[trimmed] {
+			continue
+		}
+		seen[trimmed] = true
+		unknown = append(unknown, trimmed)
+	}
+	sort.Strings(unknown)
+	return unknown
+}
+
+func normalizeWatchlistFields(fields []string) []string {
+	normalized := make([]string, 0, len(fields))
+	for _, field := range fields {
+		trimmed := strings.TrimSpace(field)
+		if trimmed == "" {
+			continue
+		}
+		normalized = append(normalized, trimmed)
+	}
+	return normalized
+}
+
+func hasWatchlistFields(fields []string) bool {
+	for _, field := range fields {
+		if strings.TrimSpace(field) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func validWatchlistFields() []string {
+	seen := map[string]bool{}
+	fields := make([]string, 0, len(watchlistFieldAliases))
+	for _, field := range watchlistFieldAliases {
+		if seen[field] {
+			continue
+		}
+		seen[field] = true
+		fields = append(fields, field)
+	}
+	sort.Strings(fields)
+	return fields
 }

--- a/cmd/catalog_test.go
+++ b/cmd/catalog_test.go
@@ -350,6 +350,73 @@ func TestCatalogRunWatchlistID64Bit(t *testing.T) {
 	assert.Len(t, envelope.Data.Entries, 2)
 }
 
+func TestCatalogRunFieldProjection(t *testing.T) {
+	t.Parallel()
+	server, _ := newCatalogRunServer(t)
+	defer server.Close()
+
+	envelope := runCatalogRunCommand(
+		t,
+		testClient(t, server),
+		"--kind", "report",
+		"--report-id", "124",
+		"--fields", "symbol,composite-rating",
+	)
+
+	require.Len(t, envelope.Data.Entries, 2)
+	assert.Equal(t, map[string]any{"symbol": "AAPL", "composite_rating": float64(99)}, envelope.Data.Entries[0])
+	assert.Equal(t, map[string]any{"symbol": "MSFT", "composite_rating": float64(97)}, envelope.Data.Entries[1])
+}
+
+func TestCatalogRunBlankFieldsBehaveLikeUnset(t *testing.T) {
+	t.Parallel()
+	server, _ := newCatalogRunServer(t)
+	defer server.Close()
+
+	envelope := runCatalogRunCommand(
+		t,
+		testClient(t, server),
+		"--kind", "report",
+		"--report-id", "124",
+		"--fields", "   ",
+	)
+
+	require.Len(t, envelope.Data.Entries, 2)
+	assert.Contains(t, envelope.Data.Entries[0], "symbol")
+	assert.Contains(t, envelope.Data.Entries[0], "composite_rating")
+	assert.Contains(t, envelope.Data.Entries[0], "rs_rating")
+}
+
+func TestCatalogRunUnknownFieldsValidation(t *testing.T) {
+	t.Parallel()
+	server := jsonServer(`{}`)
+	defer server.Close()
+
+	_, err := executeCatalogRun(
+		t,
+		testClient(t, server),
+		"run",
+		"--kind", "report",
+		"--report-id", "124",
+		"--fields", "symbol,not_real",
+	)
+	require.Error(t, err)
+
+	var verr *mserrors.ValidationError
+	assert.ErrorAs(t, err, &verr)
+	assert.Contains(t, err.Error(), `unknown --fields values "not_real"`)
+	assert.Contains(t, err.Error(), "composite_rating")
+}
+
+func TestCatalogRunOptionsValidateNormalizesFields(t *testing.T) {
+	t.Parallel()
+
+	opts := CatalogRunOptions{Kind: "report", ReportID: 42, Fields: []string{" ", " symbol ", "\t"}}
+
+	assert.Nil(t, opts.Validate(context.Background()))
+	assert.Equal(t, []string{"symbol"}, opts.Fields)
+}
+
 func TestCatalogListStructTags(t *testing.T) {
 	t.Parallel()
 
@@ -689,6 +756,16 @@ func TestCatalogRunOptionsValidate(t *testing.T) {
 		{
 			name: "coach_screen with coach-screen-id",
 			opts: CatalogRunOptions{Kind: "coach_screen", CoachScreenID: "s-1"},
+		},
+		{
+			name:    "report with unknown fields",
+			opts:    CatalogRunOptions{Kind: "report", ReportID: 42, Fields: []string{"symbol", "not_real"}},
+			wantErr: `unknown --fields values "not_real": use one or more of acc_dis_rating, charting_symbol, company_name, composite_rating, dow_jones_key, eps_rating, industry_group_rank, industry_name, instrument_sub_type, instrument_type, ipo_date, list_rank, market_cap, price, price_net_change, price_pct_change, price_pct_off_52w_high, rs_rating, smr_rating, symbol, volume, volume_change, volume_dollar_avg_50d, volume_pct_change`,
+		},
+		{
+			name:    "coach_screen with fields",
+			opts:    CatalogRunOptions{Kind: "coach_screen", CoachScreenID: "s-1", Fields: []string{"symbol"}},
+			wantErr: "unsupported --fields with --kind coach_screen: field projection is only supported for report and watchlist rows",
 		},
 	}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -117,7 +117,8 @@ func TestRootJSONSchemaTreeIncludesComplexExamples(t *testing.T) {
 
 	stockAnalyze := schemaMapByTitle(t, schemas, "marketsurge-agent stock analyze")
 	assert.Contains(t, stockAnalyze["description"], "stock analyze --summary")
-	assert.Contains(t, schemaProperty(t, stockAnalyze, "summary")["description"], "compatible with --compact and --flat")
+	assert.Contains(t, schemaProperty(t, stockAnalyze, "setup")["description"], "base_length_weeks")
+	assert.Contains(t, schemaProperty(t, stockAnalyze, "setup")["description"], "quarterly_funds")
 	assert.Contains(t, schemaProperty(t, stockAnalyze, "flat")["description"], "pricing_market_cap")
 }
 

--- a/cmd/stock.go
+++ b/cmd/stock.go
@@ -63,9 +63,10 @@ type AnalysisResult struct {
 type StockAnalyzeOptions struct {
 	Symbols []string `flag:"symbols" flagshort:"s" flaggroup:"Input" flagdescr:"Stock symbols to analyze, for example AAPL,MSFT; accepts comma-separated or repeated values; positional symbols remain supported for shell use"`
 	Tickers []string `flag:"tickers" flagshort:"t" flaggroup:"Input" flagdescr:"Additional stock symbols to analyze; accepts comma-separated or repeated values"`
-	Compact bool     `flag:"compact" flaggroup:"Output Format" flagdescr:"Remove duplicate formatted string fields while keeping raw numeric values; compatible with --summary and --flat. Example: stock analyze AAPL --compact"`
-	Flat    bool     `flag:"flat" flaggroup:"Output Format" flagdescr:"Flatten nested analysis fields into single-level JSON keys, for example stock.pricing.market_cap becomes pricing_market_cap; compatible with --summary and --compact. Example: stock analyze AAPL --flat"`
-	Summary bool     `flag:"summary" flaggroup:"Output Format" flagdescr:"Return compact screening objects for ranking many symbols; compatible with --compact and --flat. Example: stock analyze --summary AAPL MSFT NVDA"`
+	Compact bool     `flag:"compact" flaggroup:"Output Format" flagdescr:"Remove duplicate formatted string fields while keeping raw numeric values; compatible with --flat. Example: stock analyze AAPL --compact"`
+	Flat    bool     `flag:"flat" flaggroup:"Output Format" flagdescr:"Flatten nested analysis fields into single-level JSON keys, for example stock.pricing.market_cap becomes pricing_market_cap; compatible with --compact. Example: stock analyze AAPL --flat"`
+	Summary bool     `flag:"summary" flaggroup:"Output Format" flagdescr:"Return compact screening objects for ranking many symbols. Example: stock analyze --summary AAPL MSFT NVDA"`
+	Setup   bool     `flag:"setup" flaggroup:"Output Format" flagdescr:"Return --setup trade triage fields: summary fields plus base_length_weeks, volume_at_pivot_percent, ownership_funds_float_percent, and quarterly_funds. Example: stock analyze AAPL --setup"`
 }
 
 // MergeSymbols merges positional arguments with --symbols and --tickers flag values, deduplicating and trimming whitespace.
@@ -81,6 +82,7 @@ func newStockAnalyzeCmd() *cobra.Command {
 		Example: `  marketsurge-agent stock analyze AAPL
   marketsurge-agent stock analyze --tickers AAPL,MSFT,NVDA --compact
   marketsurge-agent stock analyze --summary AAPL MSFT NVDA
+  marketsurge-agent stock analyze AAPL --setup
   marketsurge-agent stock analyze AAPL --flat --compact`,
 		Long: `Fetches stock, fundamentals, and ownership concurrently for one or more
 symbols. Accepts positional symbols, --symbols values, and backward-compatible
@@ -92,8 +94,13 @@ Flags:
   --summary   Compact screening keys: symbol, composite, eps, rs, ad, smr,
               blue_dot, ant_signal, ant_dates, ant_explanation,
               base_type, base_stage, pivot,
-              base_depth_percent, industry_group_rs, up_down_volume,
-              atr_percent, avg_dollar_volume, funds_float_percent
+              pivot_price_date, pricing_start_date, pricing_end_date,
+              base_depth_percent,
+              industry_group_rs, up_down_volume, atr_percent,
+              avg_dollar_volume, funds_float_percent
+  --setup     Setup-focused trade triage keys: all --summary keys plus
+              base_length_weeks, volume_at_pivot_percent,
+              ownership_funds_float_percent, quarterly_funds
   --compact   Removes duplicate formatted string fields, keeps raw values
   --flat      Flattens nested analysis fields inside the JSON envelope
 
@@ -129,13 +136,15 @@ interesting symbols without --summary for detail.`,
 				return mserrors.NewAPIError(fmt.Sprintf("analysis failed for all symbols: %v", allErrors), nil)
 			}
 
-			data, err := transformAnalysisOutput(results, opts.Compact, opts.Flat, opts.Summary)
+			data, err := transformAnalysisOutput(results, opts.Compact, opts.Flat, opts.Summary, opts.Setup)
 			if err != nil {
 				return fmt.Errorf("transform analysis output: %w", err)
 			}
 
 			metadata := analyzeMetadata(symbols)
-			if opts.Summary {
+			if opts.Setup {
+				metadata["mode"] = "setup"
+			} else if opts.Summary {
 				metadata["mode"] = "summary"
 			}
 			if len(allErrors) > 0 {
@@ -205,9 +214,13 @@ func analyzeMetadata(symbols []string) map[string]any {
 	}
 }
 
-func transformAnalysisOutput(results []AnalysisResult, compact, flat, summary bool) (any, error) {
+func transformAnalysisOutput(results []AnalysisResult, compact, flat, summary, setup bool) (any, error) {
 	transformed := make([]any, 0, len(results))
 	for _, result := range results {
+		if setup {
+			transformed = append(transformed, analysisSetupMap(result))
+			continue
+		}
 		if summary {
 			transformed = append(transformed, analysisSummaryMap(result))
 			continue
@@ -243,6 +256,17 @@ func analysisSummaryMap(result AnalysisResult) map[string]any {
 	addAntSummary(data, result.Stock)
 	addBaseSummary(data, result.Stock.BasePattern)
 	addScreeningMetrics(data, result.Stock)
+	addPricingFreshness(data, result.Stock.Pricing)
+	return data
+}
+
+func analysisSetupMap(result AnalysisResult) map[string]any {
+	data := analysisSummaryMap(result)
+	if result.Stock != nil {
+		addSetupBaseContext(data, result.Stock.BasePattern)
+	}
+
+	addSetupOwnershipContext(data, result.Ownership)
 	return data
 }
 
@@ -283,6 +307,7 @@ func addBaseSummary(data map[string]any, base *models.BasePattern) {
 	addPtrValue(data, "base_type", base.PatternType)
 	addPtrValue(data, "base_stage", base.BaseStage)
 	addPtrValue(data, "pivot", base.PivotPrice)
+	addPtrValue(data, "pivot_price_date", base.PivotPriceDate)
 	addPtrValue(data, "base_depth_percent", base.BaseDepthPercent)
 }
 
@@ -297,6 +322,32 @@ func addScreeningMetrics(data map[string]any, stock *models.StockData) {
 	}
 	if stock.Ownership != nil {
 		addPtrValue(data, "funds_float_percent", stock.Ownership.FundsFloatPct)
+	}
+}
+
+func addPricingFreshness(data map[string]any, pricing *models.Pricing) {
+	if pricing == nil {
+		return
+	}
+	addPtrValue(data, "pricing_start_date", pricing.PricingStartDate)
+	addPtrValue(data, "pricing_end_date", pricing.PricingEndDate)
+}
+
+func addSetupBaseContext(data map[string]any, base *models.BasePattern) {
+	if base == nil {
+		return
+	}
+	addPtrValue(data, "base_length_weeks", base.BaseLengthWeeks)
+	addPtrValue(data, "volume_at_pivot_percent", base.VolumeAtPivotPct)
+}
+
+func addSetupOwnershipContext(data map[string]any, ownership *models.OwnershipData) {
+	if ownership == nil {
+		return
+	}
+	addPtrValue(data, "ownership_funds_float_percent", ownership.FundsFloatPct)
+	if len(ownership.QuarterlyFunds) > 0 {
+		data["quarterly_funds"] = ownership.QuarterlyFunds
 	}
 }
 

--- a/cmd/stock_test.go
+++ b/cmd/stock_test.go
@@ -357,7 +357,10 @@ func TestStockAnalyzeSummaryOutput(t *testing.T) {
 	assert.Equal(t, "Cup With Handle", first["base_type"])
 	assert.Equal(t, "STAGE_2", first["base_stage"])
 	assert.Equal(t, 199.99, first["pivot"])
+	assert.Equal(t, "2024-12-16", first["pivot_price_date"])
 	assert.Equal(t, 18.5, first["base_depth_percent"])
+	assert.Equal(t, "2024-01-01", first["pricing_start_date"])
+	assert.Equal(t, "2024-12-31", first["pricing_end_date"])
 	assert.Equal(t, float64(95), first["industry_group_rs"])
 	assert.Equal(t, 1.2, first["up_down_volume"])
 	assert.Equal(t, float64(60), first["funds_float_percent"])
@@ -369,6 +372,33 @@ func TestStockAnalyzeSummaryOutput(t *testing.T) {
 
 	meta, _ := result["metadata"].(map[string]any)
 	assert.Equal(t, "summary", meta["mode"])
+}
+
+func TestStockAnalyzeSetupOutput(t *testing.T) {
+	t.Parallel()
+	server := jsonServer(stockResponseFixture())
+	defer server.Close()
+	c := testClient(t, server)
+
+	output, err := executeStockAnalyze(t, c, "analyze", "--setup", "AAPL")
+	require.NoError(t, err)
+
+	result := parseJSONEnvelope(t, output)
+	data, ok := result["data"].(map[string]any)
+	require.True(t, ok, "setup single-symbol data should be an object")
+	assert.Equal(t, "AAPL", data["symbol"])
+	assert.Equal(t, float64(99), data["composite"])
+	assert.Equal(t, "2024-12-31", data["pricing_end_date"])
+	assert.Equal(t, float64(7), data["base_length_weeks"])
+	assert.Equal(t, 42.3, data["volume_at_pivot_percent"])
+	assert.Equal(t, "60%", data["ownership_funds_float_percent"])
+	require.Contains(t, data, "quarterly_funds")
+	assert.NotContains(t, data, "stock")
+	assert.NotContains(t, data, "fundamentals")
+	assert.NotContains(t, data, "ownership")
+
+	meta, _ := result["metadata"].(map[string]any)
+	assert.Equal(t, "setup", meta["mode"])
 }
 
 func TestStockAnalyzeSummaryOmitsAntDetailsWhenSignalFalse(t *testing.T) {
@@ -403,9 +433,10 @@ func TestStockAnalyzeStructTags(t *testing.T) {
 	}{
 		{field: "Symbols", flag: "symbols", short: "s", group: "Input", descr: "Stock symbols to analyze, for example AAPL,MSFT; accepts comma-separated or repeated values; positional symbols remain supported for shell use", hasShort: true},
 		{field: "Tickers", flag: "tickers", short: "t", group: "Input", descr: "Additional stock symbols to analyze; accepts comma-separated or repeated values", hasShort: true},
-		{field: "Compact", flag: "compact", group: "Output Format", descr: "Remove duplicate formatted string fields while keeping raw numeric values; compatible with --summary and --flat. Example: stock analyze AAPL --compact"},
-		{field: "Flat", flag: "flat", group: "Output Format", descr: "Flatten nested analysis fields into single-level JSON keys, for example stock.pricing.market_cap becomes pricing_market_cap; compatible with --summary and --compact. Example: stock analyze AAPL --flat"},
-		{field: "Summary", flag: "summary", group: "Output Format", descr: "Return compact screening objects for ranking many symbols; compatible with --compact and --flat. Example: stock analyze --summary AAPL MSFT NVDA"},
+		{field: "Compact", flag: "compact", group: "Output Format", descr: "Remove duplicate formatted string fields while keeping raw numeric values; compatible with --flat. Example: stock analyze AAPL --compact"},
+		{field: "Flat", flag: "flat", group: "Output Format", descr: "Flatten nested analysis fields into single-level JSON keys, for example stock.pricing.market_cap becomes pricing_market_cap; compatible with --compact. Example: stock analyze AAPL --flat"},
+		{field: "Summary", flag: "summary", group: "Output Format", descr: "Return compact screening objects for ranking many symbols. Example: stock analyze --summary AAPL MSFT NVDA"},
+		{field: "Setup", flag: "setup", group: "Output Format", descr: "Return --setup trade triage fields: summary fields plus base_length_weeks, volume_at_pivot_percent, ownership_funds_float_percent, and quarterly_funds. Example: stock analyze AAPL --setup"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.field, func(t *testing.T) {
@@ -498,10 +529,11 @@ func TestStockAnalyzeExamples(t *testing.T) {
 	assert.Contains(t, cmd.Example, "marketsurge-agent stock analyze AAPL")
 	assert.Contains(t, cmd.Example, "--tickers AAPL,MSFT,NVDA --compact")
 	assert.Contains(t, cmd.Example, "--summary AAPL MSFT NVDA")
+	assert.Contains(t, cmd.Example, "stock analyze AAPL --setup")
 	assert.Contains(t, cmd.Example, "--flat --compact")
 
 	typ := reflect.TypeFor[StockAnalyzeOptions]()
-	for _, fieldName := range []string{"Compact", "Flat", "Summary"} {
+	for _, fieldName := range []string{"Compact", "Flat"} {
 		t.Run(fieldName, func(t *testing.T) {
 			field, ok := typ.FieldByName(fieldName)
 			require.True(t, ok)
@@ -510,6 +542,19 @@ func TestStockAnalyzeExamples(t *testing.T) {
 			assert.Contains(t, descr, "Example: stock analyze")
 		})
 	}
+
+	field, ok := typ.FieldByName("Summary")
+	require.True(t, ok)
+	assert.Contains(t, field.Tag.Get("flagdescr"), "compact screening objects")
+	assert.Contains(t, field.Tag.Get("flagdescr"), "Example: stock analyze")
+
+	field, ok = typ.FieldByName("Setup")
+	require.True(t, ok)
+	descr := field.Tag.Get("flagdescr")
+	assert.Contains(t, descr, "Return --setup trade triage fields")
+	assert.Contains(t, descr, "base_length_weeks")
+	assert.Contains(t, descr, "quarterly_funds")
+	assert.Contains(t, descr, "Example: stock analyze")
 }
 
 func TestStockAnalyzeMissingSymbol(t *testing.T) {

--- a/internal/client/stock.go
+++ b/internal/client/stock.go
@@ -331,6 +331,7 @@ func buildBasePattern(patterns []models.Pattern) *models.BasePattern {
 		PatternType:      pattern.PatternType,
 		BaseStage:        pattern.BaseStage,
 		PivotPrice:       pattern.PivotPrice,
+		PivotPriceDate:   pattern.PivotPriceDate,
 		BaseLengthWeeks:  pattern.BaseLength,
 		BaseDepthPercent: pattern.BaseDepth,
 		VolumeAtPivotPct: pattern.AvgVolumeRatePctOnPivot,

--- a/internal/models/stock.go
+++ b/internal/models/stock.go
@@ -164,6 +164,7 @@ type BasePattern struct {
 	PatternType      *string  `json:"pattern_type,omitempty"`
 	BaseStage        *string  `json:"base_stage,omitempty"`
 	PivotPrice       *float64 `json:"pivot_price,omitempty"`
+	PivotPriceDate   *string  `json:"pivot_price_date,omitempty"`
 	BaseLengthWeeks  *int     `json:"base_length_weeks,omitempty"`
 	BaseDepthPercent *float64 `json:"base_depth_percent,omitempty"`
 	VolumeAtPivotPct *float64 `json:"volume_at_pivot_pct,omitempty"`


### PR DESCRIPTION
## Summary
- Add `stock analyze --setup` for trade setup triage and include pricing freshness plus pivot date in summary output.
- Validate `catalog run --fields` instead of silently ignoring unknown or unsupported projections.
- Regenerate `SKILL.md` so agent-facing docs match the updated schema and output modes.

## Verification
- `go test -v -race -coverprofile=coverage.out ./...`
- `make lint`
- `make build`
- `coderabbit review --agent --base main -c .coderabbit.yaml` (single local review, findings addressed)

Fixes #52
Fixes #53
Fixes #54