### PR TITLE
Add compact stock analyze output

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ marketsurge-agent stock get --symbol AAPL
 # Analyze multiple symbols concurrently
 marketsurge-agent stock analyze AAPL MSFT NVDA GOOG
 
-# Analyze a comma-separated batch and remove formatted duplicate fields
+# Analyze a comma-separated batch and remove low-value fields
 marketsurge-agent stock analyze --symbols AAPL,MSFT,NVDA --compact
 
 # Return screening fields for ranking many candidates
@@ -202,7 +202,7 @@ marketsurge-agent stock analyze --symbols AAPL,MSFT,NVDA --compact --flat
 
 - `--symbols AAPL,MSFT,NVDA` analyzes comma-separated symbols in one command. Positional symbols still work and can be combined with `--symbols`.
 - `--tickers AAPL,MSFT,NVDA` remains supported as a backward-compatible alias for `stock analyze`.
-- `--compact` removes duplicate formatted string fields such as `market_cap_formatted`, while keeping raw numeric values.
+- `--compact` removes low-value fields such as formatted duplicates, profile metadata, internal IDs, empty fields, and stale arrays, while keeping decision-relevant raw values.
 - `--summary` returns one small screening object per symbol with rankings, signal flags, ANTS dates and explanation, base details, liquidity, volatility, and ownership fields. Response metadata includes `mode: "summary"`.
 - `--flat` flattens each analysis result inside the standard JSON envelope, for example `stock.pricing.market_cap` becomes `pricing_market_cap`.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -91,8 +91,9 @@ Gotchas
     ticker when given multiple symbols.
   - Summary mode: stock analyze --summary returns compact screening
     objects for ranking many candidates. Metadata includes mode: "summary".
-  - Compact mode: stock analyze --compact strips duplicate formatted
-    string fields while keeping raw numeric values.
+  - Compact mode: stock analyze --compact removes formatted duplicates,
+    profile metadata, internal IDs, empty fields, and stale arrays while
+    keeping decision-relevant raw values.
   - Flat mode: stock analyze --flat flattens nested objects into
     single-level keys.
   - Batch tickers: stock analyze --tickers AAPL,NVDA,TSLA accepts
@@ -293,7 +294,8 @@ Flags:
   --setup     Setup-focused trade triage keys: all --summary keys plus
               base_length_weeks, volume_at_pivot_percent,
               ownership_funds_float_percent, quarterly_funds
-  --compact   Removes duplicate formatted string fields, keeps raw values
+  --compact   Removes formatted duplicates, profile metadata, internal IDs,
+              empty fields, and stale arrays while keeping raw decision fields
   --flat      Flattens nested analysis fields inside the JSON envelope
 
 Start with "stock analyze --summary" for candidate ranking, then rerun
@@ -303,7 +305,7 @@ interesting symbols without --summary for detail.
 
 | Flag | Type | Default | Required | Description |
 |------|------|---------|----------|-------------|
-| `--compact` | bool | false | no | Remove duplicate formatted string fields while keeping raw numeric values; compatible with --flat. Example: stock analyze AAPL --compact |
+| `--compact` | bool | false | no | Remove low-value fields such as formatted duplicates, profile metadata, internal IDs, empty fields, and stale arrays while keeping decision-relevant raw values; compatible with --flat. Example: stock analyze AAPL --compact |
 | `--flat` | bool | false | no | Flatten nested analysis fields into single-level JSON keys, for example stock.pricing.market_cap becomes pricing_market_cap; compatible with --compact. Example: stock analyze AAPL --flat |
 | `--setup` | bool | false | no | Return --setup trade triage fields: summary fields plus base_length_weeks, volume_at_pivot_percent, ownership_funds_float_percent, and quarterly_funds. Example: stock analyze AAPL --setup |
 | `--summary` | bool | false | no | Return compact screening objects for ranking many symbols. Example: stock analyze --summary AAPL MSFT NVDA |

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -90,8 +90,9 @@ Gotchas
     ticker when given multiple symbols.
   - Summary mode: stock analyze --summary returns compact screening
     objects for ranking many candidates. Metadata includes mode: "summary".
-  - Compact mode: stock analyze --compact strips duplicate formatted
-    string fields while keeping raw numeric values.
+  - Compact mode: stock analyze --compact removes formatted duplicates,
+    profile metadata, internal IDs, empty fields, and stale arrays while
+    keeping decision-relevant raw values.
   - Flat mode: stock analyze --flat flattens nested objects into
     single-level keys.
   - Batch tickers: stock analyze --tickers AAPL,NVDA,TSLA accepts

--- a/cmd/stock.go
+++ b/cmd/stock.go
@@ -17,7 +17,36 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const antSignalExplanation = "ANTS marks flag institutional accumulation: repeated upside price action with rising volume over a recent 15-day window."
+const (
+	antSignalExplanation       = "ANTS marks flag institutional accumulation: repeated upside price action with rising volume over a recent 15-day window."
+	compactRecentSignalLimit   = 3
+	compactRecentQuarterLimit  = 4
+	compactRecentEstimateLimit = 2
+)
+
+var compactDroppedFields = map[string]bool{
+	"address":                     true,
+	"address2":                    true,
+	"city":                        true,
+	"code":                        true,
+	"corporate_actions":           true,
+	"country":                     true,
+	"description":                 true,
+	"estimate_type":               true,
+	"group_rank_history":          true,
+	"group_rs_history":            true,
+	"historical_price_statistics": true,
+	"id":                          true,
+	"instrument_sub_type":         true,
+	"pattern_id":                  true,
+	"patterns":                    true,
+	"period_offset":               true,
+	"phone":                       true,
+	"state_province":              true,
+	"tight_areas":                 true,
+	"volume_moving_averages":      true,
+	"website":                     true,
+}
 
 func init() { rootCmd.AddCommand(newStockCmd()) }
 
@@ -63,7 +92,7 @@ type AnalysisResult struct {
 type StockAnalyzeOptions struct {
 	Symbols []string `flag:"symbols" flagshort:"s" flaggroup:"Input" flagdescr:"Stock symbols to analyze, for example AAPL,MSFT; accepts comma-separated or repeated values; positional symbols remain supported for shell use"`
 	Tickers []string `flag:"tickers" flagshort:"t" flaggroup:"Input" flagdescr:"Additional stock symbols to analyze; accepts comma-separated or repeated values"`
-	Compact bool     `flag:"compact" flaggroup:"Output Format" flagdescr:"Remove duplicate formatted string fields while keeping raw numeric values; compatible with --flat. Example: stock analyze AAPL --compact"`
+	Compact bool     `flag:"compact" flaggroup:"Output Format" flagdescr:"Remove low-value fields such as formatted duplicates, profile metadata, internal IDs, empty fields, and stale arrays while keeping decision-relevant raw values; compatible with --flat. Example: stock analyze AAPL --compact"`
 	Flat    bool     `flag:"flat" flaggroup:"Output Format" flagdescr:"Flatten nested analysis fields into single-level JSON keys, for example stock.pricing.market_cap becomes pricing_market_cap; compatible with --compact. Example: stock analyze AAPL --flat"`
 	Summary bool     `flag:"summary" flaggroup:"Output Format" flagdescr:"Return compact screening objects for ranking many symbols. Example: stock analyze --summary AAPL MSFT NVDA"`
 	Setup   bool     `flag:"setup" flaggroup:"Output Format" flagdescr:"Return --setup trade triage fields: summary fields plus base_length_weeks, volume_at_pivot_percent, ownership_funds_float_percent, and quarterly_funds. Example: stock analyze AAPL --setup"`
@@ -101,7 +130,8 @@ Flags:
   --setup     Setup-focused trade triage keys: all --summary keys plus
               base_length_weeks, volume_at_pivot_percent,
               ownership_funds_float_percent, quarterly_funds
-  --compact   Removes duplicate formatted string fields, keeps raw values
+  --compact   Removes formatted duplicates, profile metadata, internal IDs,
+              empty fields, and stale arrays while keeping raw decision fields
   --flat      Flattens nested analysis fields inside the JSON envelope
 
 Start with "stock analyze --summary" for candidate ranking, then rerun
@@ -231,7 +261,7 @@ func transformAnalysisOutput(results []AnalysisResult, compact, flat, summary, s
 			return nil, err
 		}
 		if compact {
-			data = removeFormattedFields(data).(map[string]any)
+			data = compactAnalysisMap(data)
 		}
 		if flat {
 			data = flattenAnalysisMap(data)
@@ -370,30 +400,81 @@ func analysisResultMap(result AnalysisResult) (map[string]any, error) {
 	return resultMap, nil
 }
 
-func removeFormattedFields(value any) any {
+func compactAnalysisMap(data map[string]any) map[string]any {
+	cleaned, keep := compactAnalysisValue(data, 0, "")
+	if !keep {
+		return map[string]any{}
+	}
+	return cleaned.(map[string]any)
+}
+
+func compactAnalysisValue(value any, depth int, key string) (any, bool) {
 	switch typed := value.(type) {
 	case map[string]any:
 		cleaned := make(map[string]any, len(typed))
 		for key, nested := range typed {
-			if isFormattedField(key) {
+			if isCompactDroppedField(key, depth) {
 				continue
 			}
-			cleaned[key] = removeFormattedFields(nested)
+			cleanedValue, keep := compactAnalysisValue(nested, depth+1, key)
+			if keep {
+				cleaned[key] = cleanedValue
+			}
 		}
-		return cleaned
+		if len(cleaned) == 0 {
+			return nil, false
+		}
+		return cleaned, true
 	case []any:
-		cleaned := make([]any, 0, len(typed))
-		for _, nested := range typed {
-			cleaned = append(cleaned, removeFormattedFields(nested))
+		limit := compactArrayLimit(key, len(typed))
+		cleaned := make([]any, 0, limit)
+		for _, nested := range typed[:limit] {
+			cleanedValue, keep := compactAnalysisValue(nested, depth+1, key)
+			if keep {
+				cleaned = append(cleaned, cleanedValue)
+			}
 		}
-		return cleaned
+		if len(cleaned) == 0 {
+			return nil, false
+		}
+		return cleaned, true
+	case string:
+		if typed == "" || typed == "N/A" {
+			return nil, false
+		}
+		return typed, true
+	case nil:
+		return nil, false
 	default:
-		return value
+		return value, true
 	}
+}
+
+func isCompactDroppedField(key string, parentDepth int) bool {
+	if isFormattedField(key) {
+		return true
+	}
+	if key == "symbol" && parentDepth > 0 {
+		return true
+	}
+	return compactDroppedFields[key]
 }
 
 func isFormattedField(key string) bool {
 	return strings.HasSuffix(key, "_formatted") || strings.HasPrefix(key, "formatted_")
+}
+
+func compactArrayLimit(key string, length int) int {
+	limit := length
+	switch key {
+	case "ant_dates", "blue_dot_daily_dates", "blue_dot_weekly_dates":
+		limit = min(length, compactRecentSignalLimit)
+	case "eps_estimates", "sales_estimates":
+		limit = min(length, compactRecentEstimateLimit)
+	case "profit_margins", "quarterly_funds", "reported_earnings", "reported_sales":
+		limit = min(length, compactRecentQuarterLimit)
+	}
+	return limit
 }
 
 func flattenAnalysisMap(data map[string]any) map[string]any {

--- a/cmd/stock_test.go
+++ b/cmd/stock_test.go
@@ -290,6 +290,87 @@ func TestStockAnalyzeCompactOutput(t *testing.T) {
 	assert.Contains(t, pricing, "market_cap")
 	assert.NotContains(t, pricing, "market_cap_formatted")
 	assert.NotContains(t, pricing, "forward_price_to_earnings_ratio_formatted")
+	assert.NotContains(t, pricing, "volume_moving_averages")
+	assert.NotContains(t, pricing, "historical_price_statistics")
+
+	company, _ := stock["company"].(map[string]any)
+	assert.Contains(t, company, "name")
+	assert.NotContains(t, company, "website")
+	assert.NotContains(t, company, "address")
+	assert.NotContains(t, company, "city")
+	assert.NotContains(t, company, "state_province")
+	assert.NotContains(t, company, "instrument_sub_type")
+
+	industry, _ := stock["industry"].(map[string]any)
+	assert.Contains(t, industry, "name")
+	assert.NotContains(t, industry, "code")
+	assert.NotContains(t, stock, "corporate_actions")
+	assert.NotContains(t, stock, "patterns")
+	assert.NotContains(t, stock, "tight_areas")
+
+	fundamentals, _ := data["fundamentals"].(map[string]any)
+	assert.NotContains(t, fundamentals, "symbol")
+	reportedEarnings, _ := fundamentals["reported_earnings"].([]any)
+	firstEarnings, _ := reportedEarnings[0].(map[string]any)
+	assert.NotContains(t, firstEarnings, "formatted_value")
+	assert.NotContains(t, firstEarnings, "formatted_pct_change")
+	assert.NotContains(t, firstEarnings, "period_offset")
+}
+
+func TestCompactAnalysisMapPrunesLowValueFields(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]any{
+		"symbol": "AAPL",
+		"stock": map[string]any{
+			"symbol": "AAPL",
+			"pricing": map[string]any{
+				"market_cap":                         3000000000000.0,
+				"market_cap_formatted":               "$3T",
+				"blue_dot_daily_dates":               []any{"2024-12-20", "2024-12-19", "2024-12-18", "2024-12-17"},
+				"historical_price_statistics":        []any{map[string]any{"period_offset": "0"}},
+				"price_to_cash_flow_ratio_formatted": "N/A",
+			},
+			"corporate_actions": map[string]any{},
+			"patterns": []any{
+				map[string]any{"id": "pattern-1", "pattern_type": "Cup With Handle"},
+			},
+		},
+		"fundamentals": map[string]any{
+			"symbol": "AAPL",
+			"reported_earnings": []any{
+				map[string]any{"period_offset": "0", "value": 1.5, "formatted_value": "1.5"},
+				map[string]any{"period_offset": "-1", "value": 1.4},
+				map[string]any{"period_offset": "-2", "value": 1.3},
+				map[string]any{"period_offset": "-3", "value": 1.2},
+				map[string]any{"period_offset": "-4", "value": 1.1},
+			},
+		},
+	}
+
+	compact := compactAnalysisMap(data)
+
+	assert.Equal(t, "AAPL", compact["symbol"])
+	stock, _ := compact["stock"].(map[string]any)
+	assert.NotContains(t, stock, "symbol")
+	assert.NotContains(t, stock, "corporate_actions")
+	assert.NotContains(t, stock, "patterns")
+
+	pricing, _ := stock["pricing"].(map[string]any)
+	assert.Equal(t, 3000000000000.0, pricing["market_cap"])
+	assert.NotContains(t, pricing, "market_cap_formatted")
+	assert.NotContains(t, pricing, "price_to_cash_flow_ratio_formatted")
+	assert.NotContains(t, pricing, "historical_price_statistics")
+	assert.Equal(t, []any{"2024-12-20", "2024-12-19", "2024-12-18"}, pricing["blue_dot_daily_dates"])
+
+	fundamentals, _ := compact["fundamentals"].(map[string]any)
+	assert.NotContains(t, fundamentals, "symbol")
+	reportedEarnings, _ := fundamentals["reported_earnings"].([]any)
+	require.Len(t, reportedEarnings, 4)
+	firstEarnings, _ := reportedEarnings[0].(map[string]any)
+	assert.Equal(t, 1.5, firstEarnings["value"])
+	assert.NotContains(t, firstEarnings, "period_offset")
+	assert.NotContains(t, firstEarnings, "formatted_value")
 }
 
 func TestStockAnalyzeFlatOutput(t *testing.T) {
@@ -433,7 +514,7 @@ func TestStockAnalyzeStructTags(t *testing.T) {
 	}{
 		{field: "Symbols", flag: "symbols", short: "s", group: "Input", descr: "Stock symbols to analyze, for example AAPL,MSFT; accepts comma-separated or repeated values; positional symbols remain supported for shell use", hasShort: true},
 		{field: "Tickers", flag: "tickers", short: "t", group: "Input", descr: "Additional stock symbols to analyze; accepts comma-separated or repeated values", hasShort: true},
-		{field: "Compact", flag: "compact", group: "Output Format", descr: "Remove duplicate formatted string fields while keeping raw numeric values; compatible with --flat. Example: stock analyze AAPL --compact"},
+		{field: "Compact", flag: "compact", group: "Output Format", descr: "Remove low-value fields such as formatted duplicates, profile metadata, internal IDs, empty fields, and stale arrays while keeping decision-relevant raw values; compatible with --flat. Example: stock analyze AAPL --compact"},
 		{field: "Flat", flag: "flat", group: "Output Format", descr: "Flatten nested analysis fields into single-level JSON keys, for example stock.pricing.market_cap becomes pricing_market_cap; compatible with --compact. Example: stock analyze AAPL --flat"},
 		{field: "Summary", flag: "summary", group: "Output Format", descr: "Return compact screening objects for ranking many symbols. Example: stock analyze --summary AAPL MSFT NVDA"},
 		{field: "Setup", flag: "setup", group: "Output Format", descr: "Return --setup trade triage fields: summary fields plus base_length_weeks, volume_at_pivot_percent, ownership_funds_float_percent, and quarterly_funds. Example: stock analyze AAPL --setup"},


### PR DESCRIPTION
## Summary
- Expand `stock analyze --compact` to remove formatted duplicates, profile metadata, internal IDs, empty fields, and stale arrays while preserving decision-relevant raw values.
- Keep compact output compatible with `--flat` and refresh generated docs/help text.
- Add regression coverage for compact pruning, nested symbol removal, and array limiting.

Closes #56.

## Verification
- `go test -run 'TestStockAnalyzeCompact|TestCompactAnalysisMap|TestStockAnalyzeStructTags|TestStockAnalyzeExamples|TestRoot|TestHelp|TestJSONSchema' -v ./cmd`
- `make test`
- `make lint`
- `make build`