### PR TITLE
Show commit sha in dev version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,14 @@
 .PHONY: build test smoke lint clean docs
 
+VERSION ?= dev
+COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null)
+LDFLAGS := -X github.com/major/marketsurge-agent/cmd.version=$(VERSION)
+ifneq ($(COMMIT),)
+LDFLAGS += -X github.com/major/marketsurge-agent/cmd.commit=$(COMMIT)
+endif
+
 build:
-	go build -o marketsurge-agent ./cmd/marketsurge-agent/
+	go build -ldflags "$(LDFLAGS)" -o marketsurge-agent ./cmd/marketsurge-agent/
 
 test:
 	go test -v -race -coverprofile=coverage.out ./...

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"strings"
 
+	builddebug "runtime/debug"
+
 	"github.com/leodido/structcli"
 	"github.com/leodido/structcli/config"
 	"github.com/leodido/structcli/debug"
@@ -24,8 +26,17 @@ import (
 	"github.com/major/marketsurge-agent/internal/output"
 )
 
+const (
+	devVersion          = "dev"
+	shortRevisionLength = 7
+	vcsRevisionKey      = "vcs.revision"
+)
+
 // version is set via ldflags at build time.
-var version = "dev"
+var version = devVersion
+
+// commit is set via ldflags at build time for local development builds.
+var commit string
 
 type clientKeyType struct{}
 
@@ -96,7 +107,7 @@ Gotchas
     single-level keys.
   - Batch tickers: stock analyze --tickers AAPL,NVDA,TSLA accepts
     comma-separated symbols. Positional and --tickers can be combined.`,
-	Version:            version,
+	Version:            displayVersion(),
 	SilenceUsage:       true,
 	SilenceErrors:      true,
 	TraverseChildren:   true,
@@ -122,7 +133,7 @@ func init() {
 		structcli.WithDebug(debug.Options{Exit: true}),
 		structcli.WithMCP(structclimcp.Options{
 			Name:      "marketsurge-agent",
-			Version:   version,
+			Version:   displayVersion(),
 			Separator: "_",
 			Exclude: []string{
 				"marketsurge-agent completion bash",
@@ -134,6 +145,43 @@ func init() {
 	); err != nil {
 		panic(err)
 	}
+}
+
+func displayVersion() string {
+	if commit != "" {
+		return displayVersionFromCommit(version, commit)
+	}
+
+	info, ok := builddebug.ReadBuildInfo()
+	if !ok {
+		return version
+	}
+	return displayVersionFromSettings(version, info.Settings)
+}
+
+func displayVersionFromCommit(rawVersion, revision string) string {
+	if rawVersion != devVersion || revision == "" {
+		return rawVersion
+	}
+	if len(revision) <= shortRevisionLength {
+		return devVersion + "-" + revision
+	}
+	return devVersion + "-" + revision[:shortRevisionLength]
+}
+
+func displayVersionFromSettings(rawVersion string, settings []builddebug.BuildSetting) string {
+	if rawVersion != devVersion {
+		return rawVersion
+	}
+
+	for _, setting := range settings {
+		if setting.Key != vcsRevisionKey || setting.Value == "" {
+			continue
+		}
+		return displayVersionFromCommit(rawVersion, setting.Value)
+	}
+
+	return rawVersion
 }
 
 // ClientFromContext returns the API client stored by PersistentPreRunE.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime/debug"
 	"strings"
 	"testing"
 
@@ -180,7 +181,7 @@ func TestRootMCPInitializeAndToolsList(t *testing.T) {
 	var initResult mcpInitializeResult
 	require.NoError(t, json.Unmarshal(responses[0].Result, &initResult))
 	assert.Equal(t, "marketsurge-agent", initResult.ServerInfo.Name)
-	assert.Equal(t, "dev", initResult.ServerInfo.Version)
+	assert.True(t, strings.HasPrefix(initResult.ServerInfo.Version, "dev"), "MCP version = %q, want dev build version", initResult.ServerInfo.Version)
 
 	var listResult mcpToolsListResult
 	require.NoError(t, json.Unmarshal(responses[1].Result, &listResult))
@@ -327,6 +328,104 @@ func TestRootRejectsJWTFlag(t *testing.T) {
 	require.Error(t, err, string(output))
 
 	assert.Contains(t, string(output), "unknown flag: --jwt")
+}
+
+func TestDisplayVersionFromSettings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		rawVersion string
+		settings   []debug.BuildSetting
+		want       string
+	}{
+		{
+			name:       "release version ignores vcs revision",
+			rawVersion: "1.2.3",
+			settings: []debug.BuildSetting{
+				{Key: vcsRevisionKey, Value: "09dd191abc123"},
+			},
+			want: "1.2.3",
+		},
+		{
+			name:       "dev version uses short vcs revision",
+			rawVersion: devVersion,
+			settings: []debug.BuildSetting{
+				{Key: vcsRevisionKey, Value: "09dd191abc123"},
+			},
+			want: "dev-09dd191",
+		},
+		{
+			name:       "dev version keeps short revision",
+			rawVersion: devVersion,
+			settings: []debug.BuildSetting{
+				{Key: vcsRevisionKey, Value: "abc123"},
+			},
+			want: "dev-abc123",
+		},
+		{
+			name:       "dev version without vcs revision stays dev",
+			rawVersion: devVersion,
+			settings: []debug.BuildSetting{
+				{Key: "vcs.modified", Value: "true"},
+			},
+			want: devVersion,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := displayVersionFromSettings(tt.rawVersion, tt.settings)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDisplayVersionFromCommit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		rawVersion string
+		revision   string
+		want       string
+	}{
+		{
+			name:       "release version ignores commit",
+			rawVersion: "1.2.3",
+			revision:   "09dd191abc123",
+			want:       "1.2.3",
+		},
+		{
+			name:       "dev version uses short commit",
+			rawVersion: devVersion,
+			revision:   "09dd191abc123",
+			want:       "dev-09dd191",
+		},
+		{
+			name:       "dev version keeps already short commit",
+			rawVersion: devVersion,
+			revision:   "abc123",
+			want:       "dev-abc123",
+		},
+		{
+			name:       "dev version without commit stays dev",
+			rawVersion: devVersion,
+			revision:   "",
+			want:       devVersion,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := displayVersionFromCommit(tt.rawVersion, tt.revision)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func rootExecCommand(t *testing.T, args ...string) *exec.Cmd {


### PR DESCRIPTION
## Summary
- Show `dev-<short-sha>` for dev builds while leaving release versions unchanged.
- Pass version and commit metadata through `make build` ldflags, with VCS build info as a fallback.
- Cover commit and VCS-derived version formatting in root tests.

## Verification
- `go test -run 'TestDisplayVersionFromSettings|TestDisplayVersionFromCommit|TestRootMCPInitializeAndToolsList|TestRootDebugOptions|TestRootHelpShowsConfigFlag' -v ./cmd`
- `make test`
- `make lint`
- `make build`
- `./marketsurge-agent --version` -> `marketsurge-agent version dev-a2b64c1`