### PR TITLE
fix: reject sparse stock analysis payloads

### DIFF
--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -211,6 +211,48 @@ func emptyMarketDataFixture() string {
 	return `{"data":{"marketData":[]}}`
 }
 
+// sparseMarketDataFixture returns a response with a marketData item but no useful data.
+func sparseMarketDataFixture() string {
+	return `{
+		"data": {
+			"marketData": [{
+				"originRequest": {"symbol": "CYBR"},
+				"ratings": {
+					"compRating": [],
+					"epsRating": [],
+					"rsRating": [],
+					"smrRating": [],
+					"adRating": []
+				},
+				"pricingStatistics": {
+					"endOfDayStatistics": {
+						"isDailyBlueDotEvent": false
+					},
+					"intradayStatistics": {
+						"isWeeklyBlueDotEvent": false
+					}
+				},
+				"financials": {
+					"consensusFinancials": {
+						"eps": {"reportedEarnings": [{}]},
+						"sales": {"reportedSales": [{}]}
+					},
+					"estimates": {
+						"epsEstimates": [{}],
+						"salesEstimates": [{}]
+					},
+					"profitMarginValues": [{}]
+				},
+				"industry": {},
+				"ownership": {"fundOwnershipSummary": []},
+				"fundamentals": {},
+				"patternInfo": {"patterns": [{}], "tightAreas": []},
+				"symbology": {"company": [], "instrument": []}
+			}]
+		}
+	}`
+}
+
 // chartResponseFixture returns a minimal chart API response.
 func chartResponseFixture() string {
 	return `{"data":{"marketData":[{"pricing":{"timeSeries":{"period":"P1D","dataPoints":[{"startDateTime":"2024-01-01","endDateTime":"2024-01-02","open":{"value":100},"high":{"value":102},"low":{"value":99},"last":{"value":101},"volume":{"value":50000}}]},"quote":{"tradeDateTime":"2024-01-02T16:00:00Z","timeliness":"REALTIME","quoteType":"LAST","last":{"value":101.5,"formattedValue":"101.5"},"volume":{"value":50000,"formattedValue":"50000"},"percentChange":{"value":1.5,"formattedValue":"1.5%"},"netChange":{"value":1.5,"formattedValue":"1.5"}},"currentMarketState":"REGULAR"}}],"exchangeData":[{"city":"New York","countryCode":"US","exchangeISO":"XNYS"}]}}`

--- a/cmd/stock_test.go
+++ b/cmd/stock_test.go
@@ -663,6 +663,21 @@ func TestStockAnalyzeTotalFailure(t *testing.T) {
 	assert.Empty(t, output)
 }
 
+func TestStockAnalyzeSparseMarketDataTotalFailure(t *testing.T) {
+	t.Parallel()
+	server := jsonServer(sparseMarketDataFixture())
+	defer server.Close()
+	c := testClient(t, server)
+
+	output, err := executeStockAnalyze(t, c, "analyze", "CYBR")
+	require.Error(t, err)
+	assert.Empty(t, output)
+
+	var apiErr *mserrors.APIError
+	assert.ErrorAs(t, err, &apiErr)
+	assert.Contains(t, err.Error(), "analysis failed for all symbols")
+}
+
 // executeStockAnalyze creates a stock command tree, injects the client into subcommand
 // contexts, and executes with the given args. structcli.Bind sets a scope context on the
 // analyze subcommand, which prevents cobra's parent-to-child context propagation. This

--- a/internal/client/fundamentals.go
+++ b/internal/client/fundamentals.go
@@ -2,8 +2,10 @@ package client
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/major/marketsurge-agent/internal/constants"
+	mserrors "github.com/major/marketsurge-agent/internal/errors"
 	"github.com/major/marketsurge-agent/internal/models"
 	"github.com/major/marketsurge-agent/queries"
 )
@@ -42,14 +44,46 @@ func (c *Client) GetFundamentals(ctx context.Context, symbol string) (*models.Fu
 	symbology := getNestedMap(item, "symbology")
 	companyName := stringPtr(firstMap(getNestedSlice(symbology, "company"))["companyName"])
 
-	return &models.FundamentalData{
+	fundamentals := &models.FundamentalData{
 		Symbol:           symbol,
 		CompanyName:      companyName,
 		ReportedEarnings: buildReportedPeriods(getNestedSlice(consensus, "eps", "reportedEarnings")),
 		ReportedSales:    buildReportedPeriods(getNestedSlice(consensus, "sales", "reportedSales")),
 		EPSEstimates:     buildEstimatePeriods(getNestedSlice(estimates, "epsEstimates")),
 		SalesEstimates:   buildEstimatePeriods(getNestedSlice(estimates, "salesEstimates")),
-	}, nil
+	}
+	if !hasFundamentalData(fundamentals) {
+		return nil, mserrors.NewSymbolNotFoundError(fmt.Sprintf("symbol not found: %q", symbol), nil, symbol)
+	}
+	return fundamentals, nil
+}
+
+func hasFundamentalData(data *models.FundamentalData) bool {
+	if data == nil {
+		return false
+	}
+	if data.CompanyName != nil {
+		return true
+	}
+	return hasReportedPeriodData(data.ReportedEarnings) || hasReportedPeriodData(data.ReportedSales) || hasEstimatePeriodData(data.EPSEstimates) || hasEstimatePeriodData(data.SalesEstimates)
+}
+
+func hasReportedPeriodData(periods []models.ReportedPeriod) bool {
+	for _, period := range periods {
+		if period.Value != nil || period.FormattedValue != nil || period.PctChangeYoY != nil || period.FormattedPctChange != nil || period.PeriodEndDate != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func hasEstimatePeriodData(periods []models.EstimatePeriod) bool {
+	for _, period := range periods {
+		if period.Value != nil || period.FormattedValue != nil || period.PctChangeYoY != nil || period.FormattedPctChange != nil || period.Period != nil || period.RevisionDirection != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func buildReportedPeriods(items []any) []models.ReportedPeriod {

--- a/internal/client/ownership.go
+++ b/internal/client/ownership.go
@@ -2,8 +2,10 @@ package client
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/major/marketsurge-agent/internal/constants"
+	mserrors "github.com/major/marketsurge-agent/internal/errors"
 	"github.com/major/marketsurge-agent/internal/models"
 	"github.com/major/marketsurge-agent/queries"
 )
@@ -34,7 +36,7 @@ func (c *Client) GetOwnership(ctx context.Context, symbol string) (*models.Owner
 
 	ownership := getNestedMap(item, "ownership")
 	quarterly := getNestedSlice(ownership, "fundOwnershipSummary")
-	return &models.OwnershipData{
+	data := &models.OwnershipData{
 		Symbol:        symbol,
 		FundsFloatPct: formattedValue(ownership["fundsFloatPercentHeld"]),
 		QuarterlyFunds: buildSlice(quarterly, func(item map[string]any) models.QuarterlyFundOwnership {
@@ -43,5 +45,24 @@ func (c *Client) GetOwnership(ctx context.Context, symbol string) (*models.Owner
 				Count: formattedValue(item["numberOfFundsHeld"]),
 			}
 		}),
-	}, nil
+	}
+	if !hasOwnershipData(data) {
+		return nil, mserrors.NewSymbolNotFoundError(fmt.Sprintf("symbol not found: %q", symbol), nil, symbol)
+	}
+	return data, nil
+}
+
+func hasOwnershipData(data *models.OwnershipData) bool {
+	if data == nil {
+		return false
+	}
+	if data.FundsFloatPct != nil {
+		return true
+	}
+	for _, fund := range data.QuarterlyFunds {
+		if fund.Date != nil || fund.Count != nil {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/client/stock.go
+++ b/internal/client/stock.go
@@ -2,10 +2,12 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/major/marketsurge-agent/internal/constants"
+	mserrors "github.com/major/marketsurge-agent/internal/errors"
 	"github.com/major/marketsurge-agent/internal/models"
 	"github.com/major/marketsurge-agent/queries"
 )
@@ -153,7 +155,7 @@ func (c *Client) GetStock(ctx context.Context, symbol string) (*models.StockData
 		PricingEndDate:                       stringPtr(pricingEOD["pricingEndDate"]),
 	}
 
-	return &models.StockData{
+	stock := &models.StockData{
 		Symbol: symbol,
 		Ratings: &models.Ratings{
 			Composite: intPtr(compRating["value"]),
@@ -287,7 +289,80 @@ func (c *Client) GetStock(ctx context.Context, symbol string) (*models.StockData
 				Length:    intPtr(item["length"]),
 			}
 		}),
-	}, nil
+	}
+	if !hasStockData(stock) {
+		return nil, mserrors.NewSymbolNotFoundError(fmt.Sprintf("symbol not found: %q", symbol), nil, symbol)
+	}
+	return stock, nil
+}
+
+func hasStockData(stock *models.StockData) bool {
+	if stock == nil {
+		return false
+	}
+	if stock.Ratings != nil && (stock.Ratings.Composite != nil || stock.Ratings.EPS != nil || stock.Ratings.RS != nil || stock.Ratings.SMR != nil || stock.Ratings.AD != nil) {
+		return true
+	}
+	if stock.Company != nil && (stock.Company.Name != nil || stock.Company.Industry != nil || stock.Company.Sector != nil || stock.Company.IndustryGroupRank != nil || stock.Company.IndustryGroupRS != nil) {
+		return true
+	}
+	if stock.Pricing != nil && (stock.Pricing.MarketCap != nil || stock.Pricing.AvgDollarVolume50D != nil || stock.Pricing.UpDownVolumeRatio != nil || stock.Pricing.ATRPercent21D != nil || stock.Pricing.PricingStartDate != nil || stock.Pricing.PricingEndDate != nil) {
+		return true
+	}
+	if hasBasePatternData(stock.BasePattern) {
+		return true
+	}
+	if stock.Financials != nil && (stock.Financials.EPSDueDate != nil || stock.Financials.EPSLastReportedDate != nil || stock.Financials.EPSGrowthRate != nil || stock.Financials.SalesGrowthRate3Y != nil || stock.Financials.CashFlowPerShare != nil) {
+		return true
+	}
+	if stock.Ownership != nil && stock.Ownership.FundsFloatPct != nil {
+		return true
+	}
+	if stock.Fundamentals != nil && (stock.Fundamentals.RAndDPercentLastQtr != nil || stock.Fundamentals.DebtPercentFormatted != nil || stock.Fundamentals.NewCEODate != nil) {
+		return true
+	}
+	return hasQuarterlyFinancialData(stock.QuarterlyFinancials)
+}
+
+func hasBasePatternData(pattern *models.BasePattern) bool {
+	if pattern == nil {
+		return false
+	}
+	return pattern.PatternType != nil || pattern.BaseStage != nil || pattern.PivotPrice != nil || pattern.PivotPriceDate != nil || pattern.BaseLengthWeeks != nil || pattern.BaseDepthPercent != nil || pattern.VolumeAtPivotPct != nil
+}
+
+func hasQuarterlyFinancialData(financials *models.QuarterlyFinancials) bool {
+	if financials == nil {
+		return false
+	}
+	return hasQuarterlyReportedPeriodData(financials.ReportedEarnings) || hasQuarterlyReportedPeriodData(financials.ReportedSales) || hasQuarterlyEstimateData(financials.EPSEstimates) || hasQuarterlyEstimateData(financials.SalesEstimates) || hasQuarterlyProfitMarginData(financials.ProfitMargins)
+}
+
+func hasQuarterlyReportedPeriodData(periods []models.QuarterlyReportedPeriod) bool {
+	for _, period := range periods {
+		if period.Value != nil || period.PctChangeYoY != nil || period.PeriodEndDate != nil || period.EffectiveDate != nil || period.PercentSurprise != nil || period.SurpriseAmount != nil || period.QuarterNumber != nil || period.FiscalYear != nil || period.Period != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func hasQuarterlyEstimateData(estimates []models.QuarterlyEstimate) bool {
+	for _, estimate := range estimates {
+		if estimate.Value != nil || estimate.PctChangeYoY != nil || estimate.PeriodEndDate != nil || estimate.EffectiveDate != nil || estimate.RevisionDirection != nil || estimate.EstimateType != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func hasQuarterlyProfitMarginData(margins []models.QuarterlyProfitMargin) bool {
+	for _, margin := range margins {
+		if margin.PeriodEndDate != nil || margin.PreTaxMargin != nil || margin.AfterTaxMargin != nil || margin.GrossMargin != nil || margin.ReturnOnEquity != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func buildSignals(pricing *models.Pricing) *models.Signals {

--- a/internal/client/stock_test.go
+++ b/internal/client/stock_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	mserrors "github.com/major/marketsurge-agent/internal/errors"
 )
 
 func TestGetStockSuccess(t *testing.T) {
@@ -43,6 +45,19 @@ func TestGetStockReturnsSymbolNotFoundForEmptyMarketData(t *testing.T) {
 	assert.Contains(t, err.Error(), "symbol not found")
 }
 
+func TestGetStockReturnsSymbolNotFoundForSparseMarketData(t *testing.T) {
+	t.Parallel()
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(sparseMarketDataJSON()))
+	})
+
+	_, err := client.GetStock(t.Context(), "CYBR")
+	require.Error(t, err)
+	var snf *mserrors.SymbolNotFoundError
+	assert.ErrorAs(t, err, &snf)
+}
+
 func TestGetFundamentalsSuccess(t *testing.T) {
 	t.Parallel()
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
@@ -58,6 +73,19 @@ func TestGetFundamentalsSuccess(t *testing.T) {
 	assert.Len(t, data.EPSEstimates, 1)
 }
 
+func TestGetFundamentalsReturnsSymbolNotFoundForSparseMarketData(t *testing.T) {
+	t.Parallel()
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(sparseMarketDataJSON()))
+	})
+
+	_, err := client.GetFundamentals(t.Context(), "CYBR")
+	require.Error(t, err)
+	var snf *mserrors.SymbolNotFoundError
+	assert.ErrorAs(t, err, &snf)
+}
+
 func TestGetOwnershipSuccess(t *testing.T) {
 	t.Parallel()
 	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
@@ -70,6 +98,19 @@ func TestGetOwnershipSuccess(t *testing.T) {
 	assert.Equal(t, "65%", *data.FundsFloatPct)
 	assert.Len(t, data.QuarterlyFunds, 1)
 	assert.Equal(t, "100", *data.QuarterlyFunds[0].Count)
+}
+
+func TestGetOwnershipReturnsSymbolNotFoundForSparseMarketData(t *testing.T) {
+	t.Parallel()
+	client := testServerAndClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(sparseMarketDataJSON()))
+	})
+
+	_, err := client.GetOwnership(t.Context(), "CYBR")
+	require.Error(t, err)
+	var snf *mserrors.SymbolNotFoundError
+	assert.ErrorAs(t, err, &snf)
 }
 
 func TestGetRSRatingHistorySuccess(t *testing.T) {
@@ -170,6 +211,47 @@ func stockResponseJSON() string {
 					"company": [{"companyName": "Apple Inc.", "businessDescription": "Desc", "url": "https://apple.example", "address": "One Apple Park", "address2": "Suite 1", "phone": "123", "city": "Cupertino", "country": "USA", "stateProvince": "CA"}],
 					"instrument": [{"ipoDate": {"value": "1980-12-12"}, "ipoPrice": {"value": 22, "formattedValue": "$22"}, "subType": "COMMON"}]
 				}
+			}]
+		}
+	}`
+}
+
+func sparseMarketDataJSON() string {
+	return `{
+		"data": {
+			"marketData": [{
+				"originRequest": {"symbol": "CYBR"},
+				"ratings": {
+					"compRating": [],
+					"epsRating": [],
+					"rsRating": [],
+					"smrRating": [],
+					"adRating": []
+				},
+				"pricingStatistics": {
+					"endOfDayStatistics": {
+						"isDailyBlueDotEvent": false
+					},
+					"intradayStatistics": {
+						"isWeeklyBlueDotEvent": false
+					}
+				},
+				"financials": {
+					"consensusFinancials": {
+						"eps": {"reportedEarnings": [{}]},
+						"sales": {"reportedSales": [{}]}
+					},
+					"estimates": {
+						"epsEstimates": [{}],
+						"salesEstimates": [{}]
+					},
+					"profitMarginValues": [{}]
+				},
+				"industry": {},
+				"ownership": {"fundOwnershipSummary": []},
+				"fundamentals": {},
+				"patternInfo": {"patterns": [{}], "tightAreas": []},
+				"symbology": {"company": [], "instrument": []}
 			}]
 		}
 	}`


### PR DESCRIPTION
## Summary
- Treat sparse MarketSurge `marketData[0]` payloads as `SymbolNotFoundError` instead of successful null-heavy stock analysis output.
- Add regression coverage for empty placeholder pattern and quarterly rows plus false blue-dot flags.

Fixes #58

## Verification
- `go test -v ./internal/client ./cmd -run 'TestGetStockReturnsSymbolNotFoundForSparseMarketData|TestStockAnalyzeSparseMarketDataTotalFailure'`
- `make test`
- `make lint`
- `make build`
- LSP diagnostics on modified Go files
- Oracle review completed, must-fix feedback addressed
- CodeRabbit requested, but local CLI hit usage rate limit before producing findings